### PR TITLE
Launch CI on any push

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -5,7 +5,6 @@ name: SpeechBrain toolkit CI
 # Runs on pushes to master and all pull requests
 on:
   push:
-    branches: [ master ]
   pull_request:
 
 jobs:


### PR DESCRIPTION
This solves the temporary problem that PRs from private forks to private repos cannot launch CI.