### PR TITLE
fix timit vgg_blstm recipe (outdated)

### DIFF
--- a/recipes/TIMIT/ASR_CTC/hyperparams/vgg_blstm.yaml
+++ b/recipes/TIMIT/ASR_CTC/hyperparams/vgg_blstm.yaml
@@ -1,5 +1,5 @@
 # ################################
-# Model: Model: VGG2 + BLSTM + MLP
+# Model: VGG2 + BLSTM + MLP
 # Authors: Mirco Ravanelli
 # ################################
 


### PR DESCRIPTION
That recipe was outdated (it was not using the feature lobe). Now it is fixed!