### PR TITLE
Remove extra output size

### DIFF
--- a/recipes/TIMIT/ASR_CTC/hyperparams/augment_vgg_ligru.yaml
+++ b/recipes/TIMIT/ASR_CTC/hyperparams/augment_vgg_ligru.yaml
@@ -30,7 +30,6 @@ device: 'cuda:0'
 
 # Functions
 model: !speechbrain.lobes.models.CRDNN.CRDNN
-    output_size: 40  # 39 phonemes + 1 blank symbol
     cnn_blocks: 2
     dnn_blocks: 2
     rnn_overrides: {rnn: {rnn_type: ligru}}

--- a/recipes/TIMIT/ASR_CTC/hyperparams/vgg_blstm.yaml
+++ b/recipes/TIMIT/ASR_CTC/hyperparams/vgg_blstm.yaml
@@ -29,7 +29,6 @@ device: 'cuda:0'
 
 # Functions
 model: !speechbrain.lobes.models.CRDNN.CRDNN
-    output_size: 40  # 39 phonemes + 1 blank symbol
     cnn_blocks: 2
     dnn_blocks: 2
 

--- a/recipes/TIMIT/ASR_CTC/hyperparams/vgg_ligru.yaml
+++ b/recipes/TIMIT/ASR_CTC/hyperparams/vgg_ligru.yaml
@@ -29,7 +29,6 @@ device: 'cuda:0'
 
 # Functions
 model: !speechbrain.lobes.models.CRDNN.CRDNN
-    output_size: 40  # 39 phonemes + 1 blank symbol
     cnn_blocks: 2
     dnn_blocks: 2
     rnn_overrides: {rnn: {rnn_type: ligru}}


### PR DESCRIPTION
The timit recipe crashes after #84 due to forgetting to remove the output size from the yaml files. This fixes that bug.