### PR TITLE
Librispeech preparation

### DIFF
--- a/speechbrain/data_io/data_preparation.py
+++ b/speechbrain/data_io/data_preparation.py
@@ -102,8 +102,8 @@ class LibriSpeechPreparer:
 
             self.create_csv(wav_lst, text_dict, split, select_n_sentences)
 
-            # saving options
-            save_pkl(self.conf, self.save_opt)
+        # saving options
+        save_pkl(self.conf, self.save_opt)
 
     def read_lexicon(self, lexicon_path):
         """


### PR DESCRIPTION
Change the original librispeech preparing class to the new format csv. 
Now there is no `self.conf`, I use a tuple to represent conf (to be easily compared in `skip()`)