### PR TITLE
removing initial random sorting

### DIFF
--- a/speechbrain/data_io/data_io.py
+++ b/speechbrain/data_io/data_io.py
@@ -665,13 +665,8 @@ class DataLoaderFactory(torch.nn.Module):
                 key=lambda k: -float(data_dict[k]["duration"]),
             )
 
-        # Random sorting
-        if sorting == "random":
-            sorted_ids = list(data_dict.keys())
-            random.shuffle(sorted_ids)
-
         # Original order
-        if sorting == "original":
+        if sorting == "original" or sorting == "random":
             sorted_ids = list(data_dict.keys())
 
         # Filling the dictionary


### PR DESCRIPTION
This solves non-replicability issue observed when using sort=random. The problem was due to "random.shuffle(sorted_ids)". We indeed set torch.seed but not random.random seed. Just removing the initial random sorting (not really needed) solves the issue.