### PR TITLE
Add average loss to progress bar, check that its finite

### DIFF
--- a/recipes/minimal_examples/neural_networks/ASR_CTC/example_asr_ctc_experiment.py
+++ b/recipes/minimal_examples/neural_networks/ASR_CTC/example_asr_ctc_experiment.py
@@ -60,4 +60,4 @@ print("Test PER: %.2f" % summarize_error_rate(test_stats["PER"]))
 
 # Integration test: check that the model overfits the training data
 def test_error():
-    assert ctc_brain.avg_loss < 3.0
+    assert ctc_brain.avg_train_loss < 3.0

--- a/recipes/minimal_examples/neural_networks/ASR_DNN_HMM/example_asr_dnn_hmm_experiment.py
+++ b/recipes/minimal_examples/neural_networks/ASR_DNN_HMM/example_asr_dnn_hmm_experiment.py
@@ -57,4 +57,4 @@ print("Test error: %.2f" % summarize_average(test_stats["error"]))
 
 # Define an integration test of overfitting on the train data
 def test_error():
-    assert asr_brain.avg_loss < 0.2
+    assert asr_brain.avg_train_loss < 0.2

--- a/recipes/minimal_examples/neural_networks/autoencoder/example_auto_experiment.py
+++ b/recipes/minimal_examples/neural_networks/autoencoder/example_auto_experiment.py
@@ -70,4 +70,4 @@ print("Test loss: %.3f" % summarize_average(test_stats["loss"]))
 
 # Integration test: make sure we are overfitting training data
 def test_loss():
-    assert auto_brain.avg_loss < 0.08
+    assert auto_brain.avg_train_loss < 0.08

--- a/recipes/minimal_examples/neural_networks/speaker_identification/example_spkid_experiment.py
+++ b/recipes/minimal_examples/neural_networks/speaker_identification/example_spkid_experiment.py
@@ -58,4 +58,4 @@ print("Test error: %.2f" % summarize_average(test_stats["error"]))
 
 # Integration test: ensure we overfit the training data
 def test_error():
-    assert spk_id_brain.avg_loss < 0.2
+    assert spk_id_brain.avg_train_loss < 0.2

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -219,7 +219,7 @@ class Brain:
     def __init__(self, modules=None, optimizer=None, first_inputs=None):
         self.modules = torch.nn.ModuleList(modules)
         self.optimizer = optimizer
-        self.avg_loss = 0.0
+        self.avg_train_loss = 0.0
 
         # Initialize parameters
         if first_inputs is not None:
@@ -396,7 +396,7 @@ class Brain:
                     stats = self.fit_batch(batch)
                     self.add_stats(train_stats, stats)
                     average = self.update_average(stats, iteration=i + 1)
-                    t.set_postfix(loss=average)
+                    t.set_postfix(train_loss=average)
 
             valid_stats = {}
             if valid_set is not None:
@@ -452,6 +452,6 @@ class Brain:
             )
 
         # Compute moving average
-        self.avg_loss -= self.avg_loss / iteration
-        self.avg_loss += float(stats["loss"]) / iteration
-        return self.avg_loss
+        self.avg_train_loss -= self.avg_train_loss / iteration
+        self.avg_train_loss += float(stats["loss"]) / iteration
+        return self.avg_train_loss


### PR DESCRIPTION
Updated progress bar looks like:
  3%|█▋                                               | 16/462 [00:08<03:44,  1.99it/s, loss=4.93]

And only applies to training, not to validation or test. Also, while computing average loss, checks to make sure it is finite and throws a helpful error if it is not.

Closes #123 and closes #133 