### PR TITLE
Improve CRDNN by using layernorm for CNNs

### DIFF
--- a/speechbrain/lobes/models/CRDNN.py
+++ b/speechbrain/lobes/models/CRDNN.py
@@ -10,7 +10,7 @@ from speechbrain.nnet.linear import Linear
 from speechbrain.nnet.pooling import Pooling1d
 from speechbrain.nnet.dropout import Dropout2d
 from speechbrain.nnet.containers import Sequential
-from speechbrain.nnet.normalization import BatchNorm1d, BatchNorm2d
+from speechbrain.nnet.normalization import BatchNorm1d, LayerNorm
 
 
 class CRDNN(Sequential):
@@ -81,13 +81,13 @@ class CRDNN(Sequential):
                         out_channels=cnn_channels[block_index],
                         kernel_size=cnn_kernelsize,
                     ),
-                    BatchNorm2d(),
+                    LayerNorm(),
                     activation(),
                     Conv2d(
                         out_channels=cnn_channels[block_index],
                         kernel_size=cnn_kernelsize,
                     ),
-                    BatchNorm2d(),
+                    LayerNorm(),
                     activation(),
                     # Frequency Pooling
                     Pooling1d(


### PR DESCRIPTION
I got the following performance on our TIMIT CTC example:
- CNN with batchnorm 2D (current master): PER=15.1% (average over 5 runs)
- CNN with layernorm (this pull request): PER=14.7% (average over 7 runs)
This is not totally surprising to me. For instance, I noticed that CNNs work better with layernorm during my research on SincNet.

