### PR TITLE
Fix gradient problem in spectral magnitude

### DIFF
--- a/speechbrain/processing/features.py
+++ b/speechbrain/processing/features.py
@@ -419,9 +419,17 @@ def spectral_magnitude(stft, power=1, log=False, eps=1e-14):
 
     Example
     -------
-
+    >>> a = torch.Tensor([[3, 4]])
+    >>> spectral_magnitude(a, power=0.5)
+    tensor([5.])
     """
-    spectr = stft.pow(2).sum(-1).pow(power)
+    spectr = stft.pow(2).sum(-1)
+
+    # Add eps avoids NaN when spectr is zero
+    if power < 1:
+        spectr = spectr + eps
+    spectr = spectr.pow(power)
+
     if log:
         return torch.log(spectr + eps)
     return spectr


### PR DESCRIPTION
I got NaN in spectral magnitude when power was 0.5, but didn't have the problem when power was 1. Turns out that the gradient of square root can be NaN if the input is 0.