### PR TITLE
Remove integration tests from pre-push

### DIFF
--- a/.pre-push-config.yaml
+++ b/.pre-push-config.yaml
@@ -47,13 +47,3 @@ repos:
             pass_filenames: False
             always_run: True
             require_serial: False
-
-    - repo: local
-      hooks:
-          - id: integration
-            name: integration
-            entry: pytest tests/integration
-            language: python
-            pass_filenames: False
-            always_run: True
-            require_serial: False


### PR DESCRIPTION
The integration tests take around 6.5 minutes to run (at least on my comp). This is too long for pushes, so I propose to remove integration tests from our default pre-push test suite. Of course, the whole pre-push test suite is opt-in anyway. And we can keep running the integration tests on the pull request CI still.