### PR TITLE
Add option to remove progressbar

### DIFF
--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -382,7 +382,7 @@ class Brain:
             else:
                 dataset_stats[key].append(batch_stats[key])
 
-    def fit(self, epoch_counter, train_set, valid_set=None):
+    def fit(self, epoch_counter, train_set, valid_set=None, progressbar=True):
         """Iterate epochs and datasets to improve objective.
 
         Relies on the existence of mulitple functions that can (or should) be
@@ -401,11 +401,14 @@ class Brain:
             a list of datasets to use for training, zipped before iterating.
         valid_set : list of Data Loaders
             a list of datasets to use for validation, zipped before iterating.
+        progressbar : bool
+            Whether to display the progress of each epoch in a progressbar.
         """
         for epoch in epoch_counter:
             self.modules.train()
             train_stats = {}
-            with tqdm(train_set, dynamic_ncols=True) as t:
+            disable = not progressbar
+            with tqdm(train_set, dynamic_ncols=True, disable=disable) as t:
                 for i, batch in enumerate(t):
                     stats = self.fit_batch(batch)
                     self.add_stats(train_stats, stats)
@@ -416,7 +419,9 @@ class Brain:
             if valid_set is not None:
                 self.modules.eval()
                 with torch.no_grad():
-                    for batch in tqdm(valid_set, dynamic_ncols=True):
+                    for batch in tqdm(
+                        valid_set, dynamic_ncols=True, disable=disable
+                    ):
                         stats = self.evaluate_batch(batch, stage="valid")
                         self.add_stats(valid_stats, stats)
 


### PR DESCRIPTION
TQDM tends to clog captured output (e.g. sbatch). This option allows users to disable the progressbar.