### PR TITLE
adding new fbank options

### DIFF
--- a/speechbrain/lobes/features/fbank.py
+++ b/speechbrain/lobes/features/fbank.py
@@ -41,7 +41,7 @@ class Fbank(torch.nn.Module):
         If freeze=False, this parameter affects the speed at which the filter
         parameters (i.e., central_freqs and bands) can be changed.  When high
         (e.g., param_change_factor=1) the filters change a lot during training.
-        When low (e.g. param_change_factor=1) the filter parameters are more
+        When low (e.g. param_change_factor=0.1) the filter parameters are more
         stable during training
     param_rand_factor: float
         This parameter can be used to randomly change the filter parameters

--- a/speechbrain/lobes/features/mfcc.py
+++ b/speechbrain/lobes/features/mfcc.py
@@ -44,7 +44,7 @@ class MFCC(torch.nn.Module):
         If freeze=False, this parameter affects the speed at which the filter
         parameters (i.e., central_freqs and bands) can be changed.  When high
         (e.g., param_change_factor=1) the filters change a lot during training.
-        When low (e.g. param_change_factor=1) the filter parameters are more
+        When low (e.g. param_change_factor=0.1) the filter parameters are more
         stable during training
     param_rand_factor: float
         This parameter can be used to randomly change the filter parameters

--- a/speechbrain/processing/features.py
+++ b/speechbrain/processing/features.py
@@ -471,7 +471,7 @@ class Filterbank(torch.nn.Module):
         If freeze=False, this parameter affects the speed at which the filter
         parameters (i.e., central_freqs and bands) can be changed.  When high
         (e.g., param_change_factor=1) the filters change a lot during training.
-        When low (e.g. param_change_factor=1) the filter parameters are more
+        When low (e.g. param_change_factor=0.1) the filter parameters are more
         stable during training
      param_rand_factor: float
         This parameter can be used to randomly change the filter parameters
@@ -596,11 +596,12 @@ class Filterbank(torch.nn.Module):
             0, 1
         )
 
-        # Print filter parameters
+        # Uncomment to print filter parameters
         # print(self.f_central*self.sample_rate * self.param_change_factor)
         # print(self.band*self.sample_rate* self.param_change_factor)
 
-        # Creation of the multiplication matrix
+        # Creation of the multiplication matrix. It is used to create
+        # the filters that average the computed spectrogram.
         if not self.freeze:
             f_central_mat = f_central_mat * (
                 self.sample_rate


### PR DESCRIPTION
With this pull request I add the following (optional) functionalities to the fbank computation:

     param_change_factor: bool
        If freeze=False, this parameter affects the speed at which the filter
        parameters (i.e., central_freqs and bands) can be changed.  When high
        (e.g., param_change_factor=1) the filters change a lot during training.
        When low (e.g. param_change_factor=1) the filter parameters are more
        stable during training.

     param_rand_factor: float
        This parameter can be used to randomly change the filter parameters
        (i.e, central frequencies and bands) during training.  It is thus a
        sort of regularization. param_rand_factor=0 does not affect, while
        param_rand_factor=0.15 allows random variations within +-15% of the
        standard values of the filter parameters (e.g., if the central freq
        is 100 Hz, we can randomly change it from 85 Hz to 115 Hz).

- [x] Implementing new functionalities
- [x]  tests