### PR TITLE
Allow builtins and other kinds of functions for "name" tag

### DIFF
--- a/speechbrain/yaml.py
+++ b/speechbrain/yaml.py
@@ -308,7 +308,7 @@ def _construct_name(loader, callable_string, node):
     if callable_ is None:
         raise ImportError("There is no such callable as %s" % callable_string)
 
-    if not (inspect.isclass(callable_) or inspect.isfunction(callable_)):
+    if not (inspect.isclass(callable_) or inspect.isroutine(callable_)):
         raise ValueError(
             f"!name:{callable_string} should be class or function, "
             f"but is {callable_}"


### PR DESCRIPTION
Functions coded in C are apparently "not functions" according to python, go figure. This allows all "function-like" objects to be passed via yaml's "name" tag.