### PR TITLE
Use torch.istft introduced in 1.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ scipy>=1.4.1
 SoundFile>=0.10.0
 sphinx-rtd-theme==0.4.3
 Sphinx>=3.0.4
-torch>=1.3.0
+torch>=1.6.0
 torchaudio>=0.4
 tqdm>=4.42.0


### PR DESCRIPTION
In pytorch 1.6, torch introduced an implementation of istft and deprecated torchaudio's. This PR updates the requirements so that 1.6 is now the minimum supported version.