### PR TITLE
Simplify checkpointing with max/min keys

### DIFF
--- a/recipes/DNS/enhance_spectral_map/experiment.py
+++ b/recipes/DNS/enhance_spectral_map/experiment.py
@@ -7,7 +7,6 @@ import multiprocessing
 import torchaudio
 from speechbrain.utils.train_logger import summarize_average
 from speechbrain.processing.features import spectral_magnitude
-from speechbrain.utils.checkpoints import ckpt_recency
 
 try:
     from pesq import pesq
@@ -168,8 +167,7 @@ class SEBrain(sb.core.Brain):
         )
 
         params.checkpointer.save_and_keep_only(
-            meta={"PESQ": epoch_pesq},
-            importance_keys=[ckpt_recency, lambda c: c.meta["PESQ"]],
+            meta={"PESQ": epoch_pesq}, max_keys=["PESQ"],
         )
 
     def resynthesize(self, predictions, noisys):
@@ -222,7 +220,7 @@ params.checkpointer.recover_if_possible()
 se_brain.fit(params.epoch_counter, train_set, valid_set)
 
 # Load best checkpoint for evaluation
-params.checkpointer.recover_if_possible(lambda c: c.meta["PESQ"])
+params.checkpointer.recover_if_possible(max_key="PESQ")
 
 test_stats = se_brain.evaluate(params.test_loader())
 params.train_logger.log_stats(

--- a/recipes/LibriSpeech/ASR_seq2seq/experiment.py
+++ b/recipes/LibriSpeech/ASR_seq2seq/experiment.py
@@ -14,7 +14,6 @@ from speechbrain.data_io.data_io import merge_char
 from speechbrain.decoders.seq2seq import S2SRNNGreedySearcher
 from speechbrain.decoders.seq2seq import S2SRNNBeamSearcher
 from speechbrain.decoders.decoders import undo_padding
-from speechbrain.utils.checkpoints import ckpt_recency
 from speechbrain.utils.train_logger import summarize_error_rate
 
 # This hack needed to import data preparation script from ..
@@ -189,10 +188,7 @@ class ASR(sb.core.Brain):
         epoch_stats = {"epoch": epoch, "lr": old_lr}
         params.train_logger.log_stats(epoch_stats, train_stats, valid_stats)
 
-        checkpointer.save_and_keep_only(
-            meta={"WER": wer},
-            importance_keys=[ckpt_recency, lambda c: -c.meta["WER"]],
-        )
+        checkpointer.save_and_keep_only(meta={"WER": wer}, min_keys=["WER"])
 
 
 # Prepare data
@@ -228,7 +224,7 @@ checkpointer.recover_if_possible()
 asr_brain.fit(params.epoch_counter, train_set, valid_set)
 
 # Load best checkpoint for evaluation
-checkpointer.recover_if_possible(lambda c: -c.meta["WER"])
+checkpointer.recover_if_possible(min_key="WER")
 test_stats = asr_brain.evaluate(params.test_loader())
 params.train_logger.log_stats(
     stats_meta={"Epoch loaded": params.epoch_counter.current},

--- a/recipes/TIMIT/ASR_CTC/experiment.py
+++ b/recipes/TIMIT/ASR_CTC/experiment.py
@@ -8,7 +8,6 @@ import speechbrain.utils.edit_distance as edit_distance
 from speechbrain.data_io.data_io import convert_index_to_lab
 from speechbrain.decoders.ctc import ctc_greedy_decode
 from speechbrain.decoders.decoders import undo_padding
-from speechbrain.utils.checkpoints import ckpt_recency
 from speechbrain.utils.train_logger import summarize_error_rate
 
 # This hack needed to import data preparation script from ..
@@ -78,8 +77,7 @@ class ASR(sb.core.Brain):
         params.train_logger.log_stats(epoch_stats, train_stats, valid_stats)
 
         params.checkpointer.save_and_keep_only(
-            meta={"PER": per},
-            importance_keys=[ckpt_recency, lambda c: -c.meta["PER"]],
+            meta={"PER": per}, min_keys=["PER"],
         )
 
 
@@ -108,7 +106,7 @@ params.checkpointer.recover_if_possible()
 asr_brain.fit(params.epoch_counter, train_set, valid_set)
 
 # Load best checkpoint for evaluation
-params.checkpointer.recover_if_possible(lambda c: -c.meta["PER"])
+params.checkpointer.recover_if_possible(min_key="PER")
 test_stats = asr_brain.evaluate(params.test_loader())
 params.train_logger.log_stats(
     stats_meta={"Epoch loaded": params.epoch_counter.current},

--- a/recipes/Voicebank/ASR_CTC/experiment.py
+++ b/recipes/Voicebank/ASR_CTC/experiment.py
@@ -8,7 +8,6 @@ import speechbrain.utils.edit_distance as edit_distance
 from speechbrain.data_io.data_io import convert_index_to_lab
 from speechbrain.decoders.ctc import ctc_greedy_decode
 from speechbrain.decoders.decoders import undo_padding
-from speechbrain.utils.checkpoints import ckpt_recency
 from speechbrain.utils.train_logger import summarize_error_rate
 
 # This hack needed to import data preparation script from ..
@@ -87,8 +86,7 @@ class ASR(sb.core.Brain):
         params.train_logger.log_stats(epoch_stats, train_stats, valid_stats)
 
         params.checkpointer.save_and_keep_only(
-            meta={"CER": cer},
-            importance_keys=[ckpt_recency, lambda c: -c.meta["CER"]],
+            meta={"CER": cer}, min_keys=["CER"],
         )
 
 
@@ -122,7 +120,7 @@ params.checkpointer.recover_if_possible()
 asr_brain.fit(params.epoch_counter, train_set, valid_set)
 
 # Load best checkpoint for evaluation
-params.checkpointer.recover_if_possible(lambda c: -c.meta["CER"])
+params.checkpointer.recover_if_possible(min_key="CER")
 test_stats = asr_brain.evaluate(params.test_loader())
 params.train_logger.log_stats(
     stats_meta={"Epoch loaded": params.epoch_counter.current},

--- a/recipes/Voicebank/enhance_waveform_map/experiment.py
+++ b/recipes/Voicebank/enhance_waveform_map/experiment.py
@@ -5,7 +5,6 @@ import torch
 import torchaudio
 import multiprocessing
 import speechbrain as sb
-from speechbrain.utils.checkpoints import ckpt_recency
 from speechbrain.utils.train_logger import summarize_average
 from pystoi.stoi import stoi
 from pesq import pesq
@@ -132,8 +131,7 @@ class SEBrain(sb.core.Brain):
 
         pesq_score = summarize_average(valid_stats["pesq"])
         params.checkpointer.save_and_keep_only(
-            meta={"pesq_score": pesq_score},
-            importance_keys=[ckpt_recency, lambda c: c.meta["pesq_score"]],
+            meta={"pesq_score": pesq_score}, max_keys="pesq_score",
         )
 
 
@@ -155,7 +153,7 @@ params.checkpointer.recover_if_possible()
 se_brain.fit(params.epoch_counter, train_set, valid_set)
 
 # Load best checkpoint for evaluation
-params.checkpointer.recover_if_possible(lambda c: c.meta["pesq_score"])
+params.checkpointer.recover_if_possible(max_key="pesq_score")
 test_stats = se_brain.evaluate(test_set)
 params.train_logger.log_stats(
     stats_meta={"Epoch loaded": params.epoch_counter.current},

--- a/speechbrain/utils/checkpoints.py
+++ b/speechbrain/utils/checkpoints.py
@@ -466,7 +466,10 @@ class Checkpointer:
         end_of_epoch=True,
         name=None,
         num_to_keep=1,
-        importance_keys=[ckpt_recency],
+        keep_recent=True,
+        importance_keys=[],
+        max_keys=[],
+        min_keys=[],
         ckpt_predicate=None,
     ):
         """Saves a checkpoint, then deletes the least important checkpoints
@@ -487,17 +490,19 @@ class Checkpointer:
             The name will still have a prefix added. If no name is given,
             a name is created from a timestamp and a random unique id.
         num_to_keep : int, optional
-            Number of checkpoints to keep.
-            Defaults to 10. You choose to keep 0. This deletes all
+            Number of checkpoints to keep. Defaults to 1. This deletes all
             checkpoints remaining after filtering. Must be >=0
+        keep_recent : bool, optional
+            Whether to keep the most recent ``num_to_keep`` checkpoints.
         importance_keys : list, optional
             A list of key functions used in sorting (see the sorted built-in).
             Each callable defines a sort order and num_to_keep checkpoints are
-            kept for  callable. To be clear, those with the highest key are
-            kept.
-            The functions are called with Checkpoint namedtuples
-            (see above). See also the default (ckpt_recency,
-            above). The default deletes all but the latest checkpoint.
+            kept for callable. The checkpoint with the highest keys are kept.
+            The functions are passed Checkpoint namedtuples (see above).
+        max_keys : list, optional
+            A list of keys for which the *highest* value will be kept.
+        min_keys : list, optional
+            A list of keys for which the *lowest* value will be kept.
         ckpt_predicate : callable, optional
             Use this to exclude some checkpoints from deletion. Before any
             sorting, the list of checkpoints is filtered with this predicate.
@@ -513,6 +518,13 @@ class Checkpointer:
             deletion.
         """
         self.save_checkpoint(meta=meta, end_of_epoch=end_of_epoch, name=name)
+
+        if keep_recent:
+            importance_keys.append(ckpt_recency)
+        for key in max_keys:
+            importance_keys.append(lambda ckpt, key=key: ckpt.meta[key])
+        for key in min_keys:
+            importance_keys.append(lambda ckpt, key=key: -ckpt.meta[key])
         self.delete_checkpoints(
             num_to_keep=num_to_keep,
             importance_keys=importance_keys,
@@ -520,19 +532,30 @@ class Checkpointer:
         )
 
     def find_checkpoint(
-        self, importance_key=ckpt_recency, ckpt_predicate=None,
+        self,
+        importance_key=None,
+        max_key=None,
+        min_key=None,
+        ckpt_predicate=None,
     ):
         """Picks a particular checkpoint from all available checkpoints.
+
+        If none of ``importance_key``, ``max_key``, and ``min_key`` is
+        used, then most recent checkpoint will be returned. No more than
+        one of them may be used.
 
         Arguments
         ---------
         importance_key : callable, optional
-            The key function used in sorting (see the max built-in).
-            The checkpoint with the highest key value is picked. By default,
-            the key value is unixtime. The higher the unixtime,
-            the newer -> the latest checkpoint is picked.
-            The function is called with Checkpoint namedtuples (see above).
-            See also the default (ckpt_recency, above).
+            The key function used in sorting.
+            The checkpoint with the highest returned value is picked.
+            The function is called with Checkpoint namedtuples.
+        max_key : str, optional
+            The checkpoint with the highest value for this key will
+            be returned.
+        min_key : str, optional
+            The checkpoint with the lowest value for this key will
+            be returned.
         ckpt_predicate : callable, optional
             Before sorting, the list of
             checkpoints is filtered with this predicate.
@@ -547,6 +570,25 @@ class Checkpointer:
         None
             if no Checkpoints exist/remain after filtering
         """
+        if importance_key is None and min_key is None and max_key is None:
+            importance_key = ckpt_recency
+
+        if max_key and not importance_key:
+
+            def importance_key(ckpt):
+                return ckpt.meta[max_key]
+
+        elif min_key and not importance_key:
+
+            def importance_key(ckpt):
+                return -ckpt.meta[min_key]
+
+        elif min_key or max_key:
+            raise ValueError(
+                "Must specify only one of 'importance_key', 'max_key', "
+                "and 'min_key'."
+            )
+
         ckpts = self.list_checkpoints()
         ckpts = list(filter(ckpt_predicate, ckpts))
         if ckpts:
@@ -556,21 +598,30 @@ class Checkpointer:
             return None  # Be explicit :)
 
     def recover_if_possible(
-        self, importance_key=ckpt_recency, ckpt_predicate=None,
+        self,
+        importance_key=None,
+        max_key=None,
+        min_key=None,
+        ckpt_predicate=None,
     ):
         """Picks a checkpoint and recovers from that, if one is found.
 
         If a checkpoint is not found, no recovery is run.
 
+        If none of ``importance_key``, ``max_key``, and ``min_key`` is
+        used, then most recent checkpoint will be returned. No more than
+        one of them may be used.
+
         Arguments
         ---------
         importance_key : callable, optional
-            The key function used in sorting (see the max built-in).
-            The checkpoint with the highest key value is picked. By default,
-            the key value is unixtime. The higher the unixtime,
-            the newer -> the latest checkpoint is picked.
-            The function is called with Checkpoint namedtuples (see above).
-            See also the default (ckpt_recency, above).
+            The key function used in sorting.
+            The checkpoint with the highest returned value is loaded.
+            The function is called with Checkpoint namedtuples.
+        max_key : str, optional
+            The checkpoint with the highest value for this key will be loaded.
+        min_key : str, optional
+            The checkpoint with the lowest value for this key will be loaded.
         ckpt_predicate : callable, optional
             Before sorting, the list of
             checkpoints is filtered with this predicate.
@@ -586,7 +637,9 @@ class Checkpointer:
         None
             if no Checkpoints exist/remain after filtering
         """
-        chosen_ckpt = self.find_checkpoint(importance_key, ckpt_predicate)
+        chosen_ckpt = self.find_checkpoint(
+            importance_key, max_key, min_key, ckpt_predicate
+        )
         if chosen_ckpt is not None:
             self.load_checkpoint(chosen_ckpt)
         else:


### PR DESCRIPTION
Checkpointing's "importance_keys" are a bit more complex than necessary. This adds an interface (max_keys/min_keys) that is a bit easier to use.

closes #231 