### PR TITLE
Specify exact linter/pytest versions in lint-requirements.txt

### DIFF
--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,5 +1,5 @@
-black>=19.10b0
-flake8
-pycodestyle>=2.5.0
-pytest>=5.4.1
-yamllint>=1.23.0
+black==19.10b0
+flake8==3.7.9
+pycodestyle==2.5.0
+pytest==5.4.1
+yamllint==1.23.0


### PR DESCRIPTION
@pplantinga reported that some CI tests have been failing due to new black version.

This PR removes the separate (third-party) linter tests, which used to produce separate checkmarks in the report. This still runs the lint tests, they are just bundled into one lint test. This way, the lint tests definitely use the same linter versions as we define in lint-requirements.txt