### PR TITLE
Cudnn benchmark mode

### DIFF
--- a/recipes/VoxCeleb/SpeakerRec/hyperparams/train_xvector_voxceleb1.yaml
+++ b/recipes/VoxCeleb/SpeakerRec/hyperparams/train_xvector_voxceleb1.yaml
@@ -7,8 +7,8 @@ seed: 222
 __set_seed: !!python/object/apply:torch.manual_seed [!ref <seed>]
 
 # Folders and train_log file
-data_folder: /local_disk/nyx/tparcollet/datasets/voxceleb1/
-output_folder: /local_disk/arges/jduret/exp_sb/voxceleb1/xvector
+data_folder: !PLACEHOLDER # e.g, /localscratch/voxceleb1
+output_folder: results/voxceleb1/xvector
 save_folder: !ref <output_folder>/save/
 train_log: !ref <output_folder>/train_log.txt
 
@@ -59,7 +59,7 @@ epoch_counter: !new:speechbrain.utils.epoch_loop.EpochCounter
     limit: !ref <number_of_epochs>
 
 env_corrupt: !new:speechbrain.lobes.augment.env_corrupt.EnvCorrupt
-    openrir_folder: /local_disk/arges/jduret/corpus/voxceleb1/dev
+    openrir_folder: !ref <data_folder>
     openrir_max_noise_len: 3.0  # seconds
     reverb_prob: 1.0
     noise_prob: 1.0


### PR DESCRIPTION
This PR add the `torch.backends.cudnn.benchmark` flag. It allows to find the best algorithm to use for your hardware, this usually leads to faster runtime.

With torch.backends.cudnn.benchmark = True on V100 with local data and batch_size = 200 : 12min for 1 epoch
With torch.backends.cudnn.benchmark = False on V100 with local data and batch_size = 200 : 17min for 1 epoch

With torch.backends.cudnn.benchmark = True on 1080ti with local data and batch_size = 200 : 25min for 1 epoch
With torch.backends.cudnn.benchmark = False on 1080ti with local data and batch_size = 200 : 60min for 1 epoch