### PR TITLE
Reducelrfixes

### DIFF
--- a/speechbrain/nnet/lr_schedulers.py
+++ b/speechbrain/nnet/lr_schedulers.py
@@ -509,6 +509,7 @@ class CustomLRScheduler:
         data = torch.load(path)
         self.losses = data["losses"]
 
+
 @checkpoints.register_checkpoint_hooks
 class ReduceLROnPlateau:
     """Learning rate scheduler which decreases the learning rate if the loss
@@ -617,6 +618,7 @@ class ReduceLROnPlateau:
         del end_of_epoch  # Unused in this class
         data = torch.load(path)
         self.losses = data["losses"]
+
 
 @checkpoints.register_checkpoint_hooks
 class CyclicLRScheduler:


### PR DESCRIPTION
-I have fixed the bug in NewBobLRScheduler: we need an absolute value in the denominator. Now it seems to behave correctly. 

However, I am still suggesting to keep the other implementation, as it's slightly different. As opposed to comparing with the most recent improvement, this one compares with an anchor value which is defined as the first loss value at which we do not observe an improvement. I am seeing better results with this one. 