### PR TITLE
Make parent directory for download_file if it doesn't exist

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: black
         types: [python]
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://gitlab.com/pycqa/flake8.git
     rev: 3.7.9
     hooks:
       - id: flake8

--- a/speechbrain/utils/data_utils.py
+++ b/speechbrain/utils/data_utils.py
@@ -12,6 +12,7 @@ import urllib.request
 import collections.abc
 import torch
 import tqdm
+import pathlib
 
 
 def undo_padding(batch, lengths):
@@ -261,6 +262,9 @@ def download_file(
                 self.total = tsize
             self.update(b * bsize - self.n)
 
+    # Create the destination directory if it doesn't exist
+    dest_dir = pathlib.Path(dest).resolve().parent
+    dest_dir.mkdir(parents=True, exist_ok=True)
     if "http" not in source:
         shutil.copyfile(source, dest)
 


### PR DESCRIPTION
When using download_file function, if the destination directory did not exist the execution would raise an error. The fix tries to create the parent directory before downloading the required file. 

A minor change in the `.pre-commit-config.yaml` file was to include the ".git" at the end of the URL. In older git environments the previous URL would fail.