### PR TITLE
Use white noise instead of 0s by default for drop_chunk

### DIFF
--- a/speechbrain/processing/speech_augmentation.py
+++ b/speechbrain/processing/speech_augmentation.py
@@ -1015,7 +1015,7 @@ class DropChunk(torch.nn.Module):
         drop_start=0,
         drop_end=None,
         drop_prob=1,
-        noise_factor=0,
+        noise_factor=0.0,
     ):
         super().__init__()
         self.drop_length_low = drop_length_low

--- a/tests/unittests/test_augment.py
+++ b/tests/unittests/test_augment.py
@@ -179,7 +179,7 @@ def test_drop_chunk():
     assert dropper(test_waveform, lengths).allclose(expected_waveform)
 
     # Make sure amplitude is similar before and after
-    dropper = DropChunk()
+    dropper = DropChunk(noise_factor=1.0)
     drop_amplitude = dropper(test_waveform, lengths).abs().mean()
     orig_amplitude = test_waveform.abs().mean()
     assert drop_amplitude.allclose(orig_amplitude, atol=1e-2)


### PR DESCRIPTION
Maybe we still want to check some recipes perform the same, and update recipes to use drop value of 0.