### PR TITLE
External LM as Transducer predictor

### DIFF
--- a/recipes/LibriSpeech/ASR/transducer/hyperparams.yaml
+++ b/recipes/LibriSpeech/ASR/transducer/hyperparams.yaml
@@ -15,7 +15,6 @@ output_folder: !ref results/CRDNN_BPE_RNNT_LM_100H/<seed>
 wer_file: !ref <output_folder>/wer.txt
 save_folder: !ref <output_folder>/save
 train_log: !ref <output_folder>/train_log.txt
-lm_ckpt_file: https://www.dropbox.com/s/wop14orl69gakhl/model.ckpt?dl=1
 
 # Tokenizer model
 tok_mdl_file: https://www.dropbox.com/s/o7gnouwdoqchotj/1000_unigram.model?dl=1
@@ -91,13 +90,13 @@ expand_beam: 2.3
 lm_weight: 0.50
 
 # LM Model parameters
-lm_emb_size: 128
-lm_activation: !name:torch.nn.LeakyReLU
-lm_dropout: 0.0
-lm_rnn_layers: 2
-lm_rnn_neurons: 2048
-lm_dnn_blocks: 1
-lm_dnn_neurons: 512
+#lm_emb_size: 128
+#lm_activation: !name:torch.nn.LeakyReLU
+#lm_dropout: 0.0
+#lm_rnn_layers: 2
+#lm_rnn_neurons: 2048
+#lm_dnn_blocks: 1
+#lm_dnn_neurons: 512
 
 epoch_counter: !new:speechbrain.utils.epoch_loop.EpochCounter
     limit: !ref <number_of_epochs>
@@ -178,10 +177,10 @@ enc: !new:speechbrain.lobes.models.CRDNN.CRDNN
 # ctc_cost: !name:speechbrain.nnet.ctc_loss
 #    blank_index: !ref <blank_index>
 
-emb: !new:speechbrain.nnet.embedding.Embedding
-    num_embeddings: !ref <output_neurons>
-    consider_as_one_hot: True
-    blank_id: !ref <blank_index>
+#emb: !new:speechbrain.nnet.embedding.Embedding
+#    num_embeddings: !ref <output_neurons>
+#    consider_as_one_hot: True
+#    blank_id: !ref <blank_index>
 
 #dec: !new:speechbrain.nnet.RNN.GRU
 #    input_shape: [null, null, !ref <output_neurons> - 1]
@@ -189,11 +188,16 @@ emb: !new:speechbrain.nnet.embedding.Embedding
 #    num_layers: 1
 #    re_init: True
 
-external_lm:
+external_lm: !new:recipes.LibriSpeech.LM.pretrained.LM
+    hparams_file: ../../LM/hyperparams/pretrained.yaml
+
+external_lm_dim: 512
 
 dec: !new:experiment.PredictionNetwork
     lm: !ref <external_lm>
-    ff:
+    ff: !new:speechbrain.nnet.linear.Linear
+        input_size: !ref <external_lm_dim>
+        n_neurons: !ref <joint_dim>
 
 # For MTL with LM over the decoder
 # dec_lin: !new:speechbrain.nnet.linear.Linear
@@ -236,7 +240,7 @@ transducer_cost: !name:speechbrain.nnet.losses.transducer_loss
 modules:
     enc: !ref <enc>
     #emb: !ref <emb>
-    #dec: !ref <dec>
+    dec: !ref <dec>
     Tjoint: !ref <Tjoint>
     transducer_lin: !ref <transducer_lin>
     normalize: !ref <normalize>
@@ -247,11 +251,12 @@ modules:
 # for MTL
 # update model if any HEAD module is added
 model: !new:torch.nn.ModuleList
-    - [!ref <enc>, !ref <emb>, !ref <dec>, !ref <transducer_lin>]
+    - [!ref <enc>, !ref <dec>, !ref <transducer_lin>]
+    #- [!ref <enc>, !ref <emb>, !ref <dec>, !ref <transducer_lin>]
 
 Greedysearcher: !new:speechbrain.decoders.transducer.TransducerBeamSearcher
     #decode_network_lst: [!ref <emb>, !ref <dec>]
-    decode_network_lst: [!ref <dec.emb>, !ref <dec>]
+    decode_network_lst: [!ref <dec>]
     tjoint: !ref <Tjoint>
     classifier_network: [!ref <transducer_lin>]
     blank_id: !ref <blank_index>
@@ -259,8 +264,8 @@ Greedysearcher: !new:speechbrain.decoders.transducer.TransducerBeamSearcher
     nbest: 1
 
 Beamsearcher: !new:speechbrain.decoders.transducer.TransducerBeamSearcher
-    #decode_network_lst: [!ref <emb>, !ref <dec>]
-    decode_network_lst: [!ref <dec.emb>, !ref <dec>]
+    #decode_network_lst: [!ref <emb>, !ref <dec>] # dec.embedding?
+    decode_network_lst: [!ref <dec>]
     tjoint: !ref <Tjoint>
     classifier_network: [!ref <transducer_lin>]
     blank_id: !ref <blank_index>

--- a/recipes/LibriSpeech/LM/hyperparams/pretrained.yaml
+++ b/recipes/LibriSpeech/LM/hyperparams/pretrained.yaml
@@ -1,0 +1,28 @@
+# ############################################################################
+# Model: LM for LibriSpeech
+# Tokens: Pre-trained LibriSpeech tokens
+# losses: NLL
+# Training: Timers and Such
+# Authors:  Loren Lugosch 2020
+# ############################################################################
+
+save_folder: pretrained_models
+lm_ckpt_file:
+    https://www.dropbox.com/s/wop14orl69gakhl/model.ckpt?dl=1
+
+device: 'cuda:0'
+
+# Model params
+emb_size: 128
+num_asr_tokens: 1000
+
+net: !new:speechbrain.lobes.models.RNNLM.RNNLM
+    output_neurons: !ref <num_asr_tokens>
+    embedding_dim: !ref <emb_size>
+    activation: !name:torch.nn.LeakyReLU
+    dropout: 0.0
+    rnn_layers: 2
+    rnn_neurons: 2048
+    dnn_blocks: 1
+    dnn_neurons: 512
+    return_hidden: True  # For inference

--- a/recipes/LibriSpeech/LM/pretrained.py
+++ b/recipes/LibriSpeech/LM/pretrained.py
@@ -1,0 +1,71 @@
+"""
+LM trained on LibriSpeech
+
+Example
+-------
+>>> import torchaudio
+>>> lm = LM()
+
+TODO forward()?
+
+Authors
+ * Loren Lugosch 2020
+"""
+
+import os
+import torch
+import speechbrain as sb
+from speechbrain.utils.data_utils import download_file
+
+
+class LM(torch.nn.Module):
+    def __init__(
+        self,
+        hparams_file="hparams/pretrained.yaml",
+        overrides={},
+        freeze_params=True,
+    ):
+        """Downloads the pretrained modules specified in the yaml"""
+        super().__init__()
+
+        # Loading modules defined in the yaml file
+        with open(hparams_file) as fin:
+            self.hparams = sb.load_extended_yaml(fin, overrides)
+
+        self.device = self.hparams["device"]
+
+        # Creating directory where pre-trained models are stored
+        if not os.path.isabs(self.hparams["save_folder"]):
+            dirname = os.path.dirname(__file__)
+            self.hparams["save_folder"] = os.path.join(
+                dirname, self.hparams["save_folder"]
+            )
+        if not os.path.isdir(self.hparams["save_folder"]):
+            os.makedirs(self.hparams["save_folder"])
+
+        # putting modules on the right device
+        self.net = self.hparams["net"].to(self.device)
+
+        # Load pretrained modules
+        self.load_lm()
+
+        # If we don't want to backprop, freeze the pretrained parameters
+        if freeze_params:
+            self.net.eval()
+            for p in self.net.parameters():
+                p.requires_grad = False
+
+    def forward(self, x, hx=None):
+        return self.net.forward(x, hx)
+
+    def extract_features(self, x):
+        return self.net.extract_features(x)
+
+    def load_lm(self):
+        """Loads the LM specified in the yaml file"""
+        save_model_path = os.path.join(self.hparams["save_folder"], "lm.ckpt")
+        download_file(self.hparams["lm_ckpt_file"], save_model_path)
+
+        # Load downloaded model, removing prefix
+        state_dict = torch.load(save_model_path, map_location=self.device)
+        self.net.load_state_dict(state_dict, strict=True)

--- a/speechbrain/lobes/models/RNNLM.py
+++ b/speechbrain/lobes/models/RNNLM.py
@@ -5,7 +5,8 @@ Authors
  * Peter Plantinga 2020
  * Ju-Chieh Chou 2020
  * Titouan Parcollet 2020
- * Abdel 2020
+ * Abdel Heba 2020
+ * Loren Lugosch 2020
 """
 import torch
 from torch import nn
@@ -122,3 +123,13 @@ class RNNLM(nn.Module):
             return out, hidden
         else:
             return out
+
+    def extract_features(self, x):
+        """
+        Similar to forward(), but just extracts features from the input sequence (e.g. for using a pre-trained LM as the predictor in a Transducer model).
+        """
+        out = self.embedding(x)
+        out = self.dropout(out)
+        out, _ = self.rnn(out, None)
+        out = self.dnn(out)
+        return out


### PR DESCRIPTION
This is a PR for using a pre-trained LM as the Transducer predictor.

@aheba I'm getting this error:
```
  from speechbrain.nnet.loss.transducer_loss import Transducer
  ...
  File "/home/mila/l/lugoschl/speechbrain/lib/python3.7/site-packages/numba/cuda/cudadrv/nvvm.py", line 345, in get_arch_option
    return 'compute_%d%d' % arch
TypeError: not enough arguments for format string
```
Any idea what the problem is?