### PR TITLE
Add debug flag to iterate only a few batches

### DIFF
--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -169,6 +169,13 @@ def parse_arguments(arg_list):
         help="Number of batches to run in debug mode.",
     )
     parser.add_argument(
+        "--debug_epochs",
+        type=int,
+        default=2,
+        help="Number of epochs to run in debug mode. "
+        "If a non-positive number is passed, all epochs are run.",
+    )
+    parser.add_argument(
         "--log_config",
         type=str,
         help="A file storing the configuration options for logging",
@@ -452,6 +459,9 @@ class Brain:
                 datasets, to ensure code runs without crashing.
             debug_batches : int
                 Number of batches to run in debug mode, Default 2.
+            debug_epochs : int
+                Number of epochs to run in debug mode, Default 2.
+                If a non-positive number is passed, all epochs are run.
             jit_module_keys : list of str
                 List of keys in modules that should be jit compiled.
             distributed_count : int
@@ -503,6 +513,7 @@ class Brain:
         run_opt_defaults = {
             "debug": False,
             "debug_batches": 2,
+            "debug_epochs": 2,
             "device": "cpu",
             "data_parallel_count": -1,
             "data_parallel_backend": False,
@@ -951,6 +962,10 @@ class Brain:
                             )
                     finally:
                         sb.ddp_barrier()
+
+            # Debug mode only runs a few epochs
+            if self.debug and epoch == self.debug_epochs:
+                break
 
     def _compile_jit(self):
         """This should be run *after* mp.spawn, since jit modules


### PR DESCRIPTION
So far this only implements shortening each dataset iteration to a few batches.

One feature discussed was not writing anything to the `results` directory. I think this mode should execute every line of code as normal, but perhaps we could think about making a temporary directory to write some outputs to. For example, the checkpointer could be changed to point to a temporary directory. What do others think?