### PR TITLE
A more stable setting for seq2seq on TIMIT

### DIFF
--- a/recipes/TIMIT/ASR/seq2seq/hyperparams.yaml
+++ b/recipes/TIMIT/ASR/seq2seq/hyperparams.yaml
@@ -14,7 +14,7 @@ csv_test: !ref <data_folder>/test.csv
 
 # Training parameters
 number_of_epochs: 50
-batch_size: 4
+batch_size: 8
 lr: 0.0001
 ctc_weight: 0.2
 


### PR DESCRIPTION
Hi @TParcollet, this is the pr that gives more stable (no NaN observed) and better results on TIMIT using seq2seq recipe.
I repeated the experiments twice and got 13.6 and 14.17 respectively.
```
Epoch loaded: 49 - test loss: 1.04, test PER: 13.60
Epoch loaded: 48 - test loss: 9.48e-01, test PER: 14.17
```
Note that in general, if using other seeds, the PER is around 14.6.
