### PR TITLE
Conv1D and SincNet were not Jittable

### DIFF
--- a/speechbrain/nnet/CNN.py
+++ b/speechbrain/nnet/CNN.py
@@ -397,8 +397,8 @@ class Conv1d(nn.Module):
 
         else:
             raise ValueError(
-                "Padding must be 'same', 'valid' or 'causal'. Got %s."
-                % (self.padding)
+                "Padding must be 'same', 'valid' or 'causal'. Got "
+                + self.padding
             )
 
         wx = self.conv(x)


### PR DESCRIPTION
Hey, Conv1D and SincNet were not Jittable due to some padding issues (TorchScript doesn't like tuple()) 