### PR TITLE
New data loading: Pass all non-dataloader things to make_dataloader()

### DIFF
--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -403,7 +403,6 @@ class Brain:
     Example
     -------
     >>> from torch.optim import SGD
-    >>> from torch.utils.data import TensorDataset
     >>> class SimpleBrain(Brain):
     ...     def compute_forward(self, batch, stage):
     ...         return self.modules.model(batch[0])
@@ -411,7 +410,7 @@ class Brain:
     ...         return torch.nn.functional.l1_loss(predictions, batch[0])
     >>> model = torch.nn.Linear(in_features=10, out_features=10)
     >>> brain = SimpleBrain({"model": model}, opt_class=lambda x: SGD(x, 0.1))
-    >>> brain.fit(range(1), TensorDataset(torch.rand(10, 10), torch.rand(10, 10)))
+    >>> brain.fit(range(1), ([torch.rand(10, 10), torch.rand(10, 10)],))
     """
 
     def __init__(  # noqa: C901


### PR DESCRIPTION
We can also, by default, pass anything to make_dataloader. 
Pros: allows overriding make_dataloader().

Possible trouble: I think the Torch DataLoader actually deals just fine with lists or tensors or such as datasources, but officially it wants a Dataset.