### PR TITLE
Prevent division by zero in improvement calculation 

### DIFF
--- a/recipes/timers-and-such/prepare.py
+++ b/recipes/timers-and-such/prepare.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 import logging
-from speechbrain.data_io.data_io import read_audio, merge_csvs
+from speechbrain.dataio.dataio import read_audio, merge_csvs
 from speechbrain.utils.data_utils import download_file
 
 try:

--- a/speechbrain/nnet/schedulers.py
+++ b/speechbrain/nnet/schedulers.py
@@ -4,6 +4,7 @@ Schedulers for updating hyperparameters (such as learning rate).
 Authors
  * Mirco Ravanelli 2020
  * Peter Plantinga 2020
+ * Loren Lugosch 2020
 """
 
 import math
@@ -107,9 +108,11 @@ class NewBobScheduler:
         old_value = new_value = self.hyperparam_value
         if len(self.metric_values) > 0:
             prev_metric = self.metric_values[-1]
-
             # Update value if improvement too small and patience is 0
-            improvement = (prev_metric - metric_value) / prev_metric
+            if prev_metric == 0:  # Prevent division by zero
+                improvement = 0
+            else:
+                improvement = (prev_metric - metric_value) / prev_metric
             if improvement < self.improvement_threshold:
                 if self.current_patient == 0:
                     new_value *= self.annealing_factor


### PR DESCRIPTION
Fixed a corner case where WER = 0 that causes a division by zero (e.g. this can happen in the decoupled SLU recipe where it is very easy to perfectly fit the training text)

Also I snuck in a fix to the TAS preparation script, which I guess I didn't commit before.