### PR TITLE
Remove AccuracyStats shortcut

### DIFF
--- a/recipes/LibriSpeech/ASR/transformer/train/hparams/conformer.yaml
+++ b/recipes/LibriSpeech/ASR/transformer/train/hparams/conformer.yaml
@@ -254,4 +254,4 @@ train_logger: !new:speechbrain.utils.train_logger.FileTrainLogger
     save_file: !ref <train_log>
 
 error_rate_computer: !name:speechbrain.utils.metric_stats.ErrorRateStats
-acc_computer: !name:speechbrain.AccuracyStats
+acc_computer: !name:speechbrain.utils.Accuracy.AccuracyStats

--- a/recipes/LibriSpeech/ASR/transformer/train/hparams/transformer.yaml
+++ b/recipes/LibriSpeech/ASR/transformer/train/hparams/transformer.yaml
@@ -239,4 +239,4 @@ train_logger: !new:speechbrain.utils.train_logger.FileTrainLogger
     save_file: !ref <train_log>
 
 error_rate_computer: !name:speechbrain.utils.metric_stats.ErrorRateStats
-acc_computer: !name:speechbrain.AccuracyStats
+acc_computer: !name:speechbrain.utils.Accuracy.AccuracyStats

--- a/speechbrain/__init__.py
+++ b/speechbrain/__init__.py
@@ -11,12 +11,9 @@ import speechbrain.processing
 import speechbrain.tokenizers
 import speechbrain.utils  # noqa
 
-from speechbrain.utils.Accuracy import AccuracyStats
-
 __all__ = [
     "Stage",
     "Brain",
     "create_experiment_directory",
     "parse_arguments",
-    "AccuracyStats",
 ]


### PR DESCRIPTION
There is exactly one shortcut (that's not in core.py) in the main `__init__.py`, and it seems out of place. I removed the shortcut.

Additionally, I'm curious why this extra class is needed over the `BinaryMetricStats` that should take care of this use case from what I can tell. If indeed that class does cover this use case, then we should do the conversion, either here or in another PR.