### PR TITLE
Return empty list rather than None in find_checkpoints

### DIFF
--- a/speechbrain/utils/checkpoints.py
+++ b/speechbrain/utils/checkpoints.py
@@ -595,10 +595,10 @@ class Checkpointer:
             ckpt_predicate=ckpt_predicate,
             max_num_checkpoints=None,
         )
-        if ckpts_found is None:
-            return None
-        else:
+        if ckpts_found:
             return ckpts_found[0]
+        else:
+            return None
 
     def find_checkpoints(
         self,


### PR DESCRIPTION
Fixes small bug where if you try to delete checkpoints but no checkpoints match the predicates, it raises TypeError. (Due to trying to iterate None, but it makes sense for find_checkpoints to return empty list if none are found.)