### PR TITLE
Remove the call to git as it is done twice and causes a bug

### DIFF
--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -17,7 +17,6 @@ import inspect
 import pathlib
 import argparse
 import tempfile
-import subprocess
 import speechbrain as sb
 from datetime import date
 from enum import Enum, auto
@@ -104,12 +103,6 @@ def create_experiment_directory(
             # Log beginning of experiment!
             logger.info("Beginning experiment!")
             logger.info(f"Experiment folder: {experiment_directory}")
-            commit_hash = subprocess.check_output(
-                ["git", "describe", "--always"]
-            )
-            logger.debug(
-                "Commit hash: '%s'" % commit_hash.decode("utf-8").strip()
-            )
 
             # Save system description:
             if save_env_desc:


### PR DESCRIPTION
The git logging is already done (and properly managed with a try catch) in the same function (save_env_desc). With the current double git hash it was causing a bug as reported by @gruly. 