### PR TITLE
Added adaptive score normalization

### DIFF
--- a/recipes/VoxCeleb/SpeakerRec/train/hparams/verification_ecapa.yaml
+++ b/recipes/VoxCeleb/SpeakerRec/train/hparams/verification_ecapa.yaml
@@ -23,7 +23,8 @@ enrol_data: !ref <save_folder>/enrol.csv
 test_data: !ref <save_folder>/test.csv
 
 batch_size: 32
-score_norm: 't-norm' # z-norm t-norm s-norm none
+score_norm: 's-norm' # z-norm t-norm s-norm none
+cohort_size: 20000 # amount of imposter utterances in normalization cohort
 n_train_snts: 300000 # used for normalization stats
 
 # Feature parameters

--- a/recipes/VoxCeleb/SpeakerRec/train/speaker_verification_cosine.py
+++ b/recipes/VoxCeleb/SpeakerRec/train/speaker_verification_cosine.py
@@ -85,12 +85,20 @@ def get_verification_scores(veri_test):
             # Getting norm stats for enrol impostors
             enrol_rep = enrol.repeat(train_cohort.shape[0], 1, 1)
             score_e_c = similarity(enrol_rep, train_cohort)
+
+            if "cohort_size" in params:
+                score_e_c = torch.topk(score_e_c, k=params["cohort_size"], dim=0)[0]
+
             mean_e_c = torch.mean(score_e_c, dim=0)
             std_e_c = torch.std(score_e_c, dim=0)
 
             # Getting norm stats for test impostors
             test_rep = test.repeat(train_cohort.shape[0], 1, 1)
             score_t_c = similarity(test_rep, train_cohort)
+
+            if "cohort_size" in params:
+                score_t_c = torch.topk(score_t_c, k=params["cohort_size"], dim=0)[0]
+
             mean_t_c = torch.mean(score_t_c, dim=0)
             std_t_c = torch.std(score_t_c, dim=0)
 


### PR DESCRIPTION
Added an option for speaker verification to only use the top-n imposter utterances when calculating the score normalization statistics. I also changed the default settings for verification_ecapa.yaml to use adaptive s-norm with a 20k cohort size. This results in a performance of 0.79% EER and 0.087 minDCF on the VoxCeleb1 test set with the pre-trained model.