### PR TITLE
Remove load_lm()

### DIFF
--- a/recipes/LibriSpeech/ASR/seq2seq/train/train.py
+++ b/recipes/LibriSpeech/ASR/seq2seq/train/train.py
@@ -346,10 +346,6 @@ if __name__ == "__main__":
     # adding objects to trainer:
     asr_brain.tokenizer = tokenizer
 
-    # if a language model is specified it is loaded
-    if hasattr(asr_brain.hparams, "language_model_file"):
-        asr_brain.load_lm()
-
     # Training
     asr_brain.fit(
         asr_brain.hparams.epoch_counter,


### PR DESCRIPTION
The `load_lm()` in `seq2seq/train/train.py` is outdated. While we define `load_lm()` in `../../LM/pretrained/pretrained.py`,   transformer recipe defines it in `train.py`. I think we should make it consistent to the seq2seq one.

Also, @aheba, I found that `train.py` in transducer recipe has:
```
    # if a language model is specified it is loaded
    if hasattr(asr_brain.hparams, "language_model_file"):
        asr_brain.load_lm()
```
is this outdated as well?
