### PR TITLE
Fix MTL for Transducer on Libri

### DIFF
--- a/recipes/LibriSpeech/ASR/transducer/train/hparams/train.yaml
+++ b/recipes/LibriSpeech/ASR/transducer/train/hparams/train.yaml
@@ -148,7 +148,7 @@ enc: !new:speechbrain.lobes.models.CRDNN.CRDNN
 #     input_size: !ref <dnn_neurons>
 #     n_neurons: !ref <joint_dim>
 #
-# ctc_cost: !name:speechbrain.nnet.ctc_loss
+# ctc_cost: !name:speechbrain.nnet.losses.ctc_loss
 #    blank_index: !ref <blank_index>
 
 emb: !new:speechbrain.nnet.embedding.Embedding
@@ -168,7 +168,7 @@ dec: !new:speechbrain.nnet.RNN.GRU
 #     n_neurons: !ref <joint_dim>
 #     bias: False
 #
-# ce_cost: !name:speechbrain.nnet.nll_loss
+# ce_cost: !name:speechbrain.nnet.losses.nll_loss
 #    label_smoothing: 0.1
 
 Tjoint: !new:speechbrain.nnet.transducer.transducer_joint.Transducer_joint


### PR DESCRIPTION
The call for the losses (CTC + NLL) was wrong. Now it's fixed, 