### PR TITLE
Bug occurring with f_min = 0; Now fixed.

### DIFF
--- a/speechbrain/lobes/features.py
+++ b/speechbrain/lobes/features.py
@@ -37,7 +37,7 @@ class Fbank(torch.nn.Module):
     n_fft : int (default: 400)
         Number of samples to use in each stft.
     n_mels : int (default: 40)
-        Lowest frequency for the Mel filters.
+        Number of Mel filters.
     filter_shape : str (default: triangular)
         Shape of the filters ('triangular', 'rectangular', 'gaussian').
     param_change_factor : float (default: 1.0)


### PR DESCRIPTION
Hi @mravanelli,

As found by @mdhaffar and @gruly, some low pass filters might make our FBANK instable with f_min = 0 as the Mel filter output will be constant. Here is a quick fix to allow users to modify the f_min 