### PR TITLE
Update TIMIT_seq2seq

### DIFF
--- a/recipes/TIMIT/ASR/seq2seq/train/hparams/train.yaml
+++ b/recipes/TIMIT/ASR/seq2seq/train/hparams/train.yaml
@@ -87,7 +87,6 @@ compute_features: !new:speechbrain.lobes.features.Fbank
     n_mels: !ref <n_mels>
 
 enc: !new:speechbrain.lobes.models.CRDNN.CRDNN
-    rnn_class: !name:speechbrain.nnet.RNN.LSTM
     input_shape: [null, null, !ref <n_mels>]
     activation: !ref <activation>
     dropout: !ref <dropout>
@@ -178,7 +177,7 @@ modules:
     normalize: !ref <normalize>
     #env_corrupt: !ref <env_corrupt>
 
-    #jit_module_keys: [enc]
+jit_module_keys: [enc]
 
 checkpointer: !new:speechbrain.utils.checkpoints.Checkpointer
     checkpoints_dir: !ref <save_folder>

--- a/speechbrain/dataio/encoder.py
+++ b/speechbrain/dataio/encoder.py
@@ -786,7 +786,10 @@ class TextEncoder(CategoricalEncoder):
         # Same thing with unk, see base class.
         if "bos_label" in special_labels and "eos_label" in special_labels:
             self.insert_bos_eos(
-                special_labels["bos_label"], special_labels["eos_label"]
+                bos_label="<bos>",
+                eos_label="<eos>",
+                bos_index=special_labels["bos_label"],
+                eos_index=special_labels["eos_label"],
             )
         elif "bos_label" in special_labels or "eos_label" in special_labels:
             raise TypeError("Only BOS or EOS specified. Need both for init.")
@@ -967,14 +970,16 @@ class CTCTextEncoder(TextEncoder):
     """
 
     def handle_special_labels(self, special_labels):
-        super().handle_special_labels(special_labels)
+        # super().handle_special_labels(special_labels)
         # NOTE: blank_label is not necessarily set at all!
         # This is because None is a suitable value.
         # So the test is: hasattr(self, "blank_label")
         # rather than self.blank_label is not None
         # Same thing with unk, see base class.
         if "blank_label" in special_labels:
-            self.insert_blank(special_labels["blank_label"])
+            self.insert_blank(index=special_labels["blank_label"])
+
+        super().handle_special_labels(special_labels)
 
     def add_blank(self, blank_label=DEFAULT_BLANK):
         """Add blank symbol to labelset."""

--- a/tests/unittests/test_categorical_encoder.py
+++ b/tests/unittests/test_categorical_encoder.py
@@ -178,8 +178,11 @@ def test_text_encoder(tmpdir):
 def test_ctc_encoder(tmpdir):
     from speechbrain.dataio.encoder import CTCTextEncoder
 
-    encoder = CTCTextEncoder(bos_label="<s>", eos_label="</s>")
-    encoder.add_blank(blank_label="_")
+    encoder = CTCTextEncoder()
+    encoder.insert_bos_eos(
+        bos_label="<s>", bos_index=0, eos_label="</s>", eos_index=1
+    )
+    encoder.insert_blank(blank_label="_", index=2)
     encoding_file = tmpdir / "ctc_encoding.txt"
     encoder.update_from_iterable(["abcd", "bcdef"], sequence_input=True)
     encoded = encoder.encode_sequence(encoder.prepend_bos_label(["a", "b"]))


### PR DESCRIPTION
With this PR, I fix some small issues that were added after Feb, 5.
1. I fixed a bug in the categorical encoder that wasn't able to managed correctly bos, eos, blank indexes (when all are specified and assigned to different indexes)
2. I restored the LiGRU in the CRDNN model (much better than LSTM).

After testing, I achieve the expected PER for this tasks: PER=13.8% 