### PR TITLE
Adding wav2vec2 support from pretrained fairseq models !

### DIFF
--- a/speechbrain/lobes/models/fairseq_wav2vec.py
+++ b/speechbrain/lobes/models/fairseq_wav2vec.py
@@ -1,6 +1,7 @@
-"""This lobes enables the integration of fairseq pretrained wav2vec2.0 models.
+"""This lobes enables the integration of fairseq pretrained wav2vec models.
 
 Reference: https://arxiv.org/abs/2006.11477
+Reference: https://arxiv.org/abs/1904.05862
 FairSeq needs to be installed: https://fairseq.readthedocs.io/en/latest/
 
 Authors
@@ -9,8 +10,9 @@ Authors
 """
 
 import fairseq
-from torch import nn
+import torch
 import torch.nn.functional as F
+from torch import nn
 from speechbrain.utils.data_utils import download_file
 
 
@@ -81,10 +83,14 @@ class FairseqWav2Vec2(nn.Module):
             A batch of audio signals to transform to features.
         """
 
-        # If freeze is specified, we remove the model from the gradient graph.
+        # If we freeze, we simply remove all grads and features from the graph.
         if self.freeze:
-            for p in self.model.parameters():
-                p.requires_grad = True
+            with torch.no_grad():
+                return self.extract_features(wav).detach()
+
+        return self.extract_features(wav)
+
+    def extract_features(self, wav):
 
         # We normalize the input signal if needed.
         if self.normalize:

--- a/speechbrain/lobes/models/fairseq_wav2vec.py
+++ b/speechbrain/lobes/models/fairseq_wav2vec.py
@@ -94,10 +94,10 @@ class FairseqWav2Vec2(nn.Module):
 
         # We normalize the input signal if needed.
         if self.normalize:
-            x = F.layer_norm(wav, wav.shape)
+            wav = F.layer_norm(wav, wav.shape)
 
         # Extract wav2vec output
-        out = self.model.extract_features(x, padding_mask=None, mask=False)[0]
+        out = self.model.extract_features(wav, padding_mask=None, mask=False)[0]
 
         # We normalize the output if required
         if self.output_norm:

--- a/speechbrain/lobes/models/fairseq_wav2vec2.py
+++ b/speechbrain/lobes/models/fairseq_wav2vec2.py
@@ -14,7 +14,7 @@ import torch.nn.functional as F
 from speechbrain.utils.data_utils import download_file
 
 
-class FaiseqWav2Vec2(nn.Module):
+class FairseqWav2Vec2(nn.Module):
     """This lobes enables the integration of fairseq pretrained wav2vec2.0 models.
 
     Source paper: https://arxiv.org/abs/2006.11477
@@ -40,7 +40,9 @@ class FaiseqWav2Vec2(nn.Module):
     Example
     -------
     >>> inputs = torch.rand([10, 600])
-    >>> model = FairseqWav2Vec2()
+    >>> model_url = "https://dl.fbaipublicfiles.com/fairseq/wav2vec/wav2vec_small.pt"
+    >>> save_path = "models_checkpoints/wav2vec2.pt"
+    >>> model = FairseqWav2Vec2(model_url, save_path)
     >>> outputs = model(inputs)
     >>> outputs.shape
     torch.Size([10, 768])
@@ -62,9 +64,7 @@ class FaiseqWav2Vec2(nn.Module):
 
         # wav2vec pretrained models may need the input waveform to be normalized
         # Hence, we check of the model has be trained with or without it.
-        self.normalize = ("normalize" in cfg["task"]) and cfg["task"][
-            "normalize"
-        ]
+        self.normalize = cfg.normalize
         model = model[0]
         self.model = model
         self.freeze = freeze
@@ -98,7 +98,7 @@ class FaiseqWav2Vec2(nn.Module):
         out = self.model.extract_features(x, padding_mask=None, mask=False)[0]
 
         # We normalize the output if required
-        if self.output_nom:
+        if self.output_norm:
             out = F.layer_norm(out, out.shape)
 
         return out

--- a/speechbrain/lobes/models/fairseq_wav2vec2.py
+++ b/speechbrain/lobes/models/fairseq_wav2vec2.py
@@ -45,7 +45,7 @@ class FairseqWav2Vec2(nn.Module):
     >>> model = FairseqWav2Vec2(model_url, save_path)
     >>> outputs = model(inputs)
     >>> outputs.shape
-    torch.Size([10, 768])
+    torch.Size([10, 100, 768])
     """
 
     def __init__(

--- a/speechbrain/lobes/models/fairseq_wav2vec2.py
+++ b/speechbrain/lobes/models/fairseq_wav2vec2.py
@@ -45,7 +45,7 @@ class FairseqWav2Vec2(nn.Module):
     >>> model = FairseqWav2Vec2(model_url, save_path)
     >>> outputs = model(inputs)
     >>> outputs.shape
-    torch.Size([10, 100, 768])
+    torch.Size([10, 100,  768])
     """
 
     def __init__(

--- a/speechbrain/lobes/models/fairseq_wav2vec2.py
+++ b/speechbrain/lobes/models/fairseq_wav2vec2.py
@@ -1,0 +1,104 @@
+"""This lobes enables the integration of fairseq pretrained wav2vec2.0 models.
+
+Source paper: https://arxiv.org/abs/2006.11477
+FairSeq needs to be installed: https://fairseq.readthedocs.io/en/latest/
+
+Authors
+ * Titouan Parcollet 2021
+ * Salima Mdhaffar 2021
+"""
+
+import fairseq
+from torch import nn
+import torch.nn.functional as F
+from speechbrain.utils.data_utils import download_file
+
+
+class FaiseqWav2Vec2(nn.Module):
+    """This lobes enables the integration of fairseq pretrained wav2vec2.0 models.
+
+    Source paper: https://arxiv.org/abs/2006.11477
+    FairSeq needs to be installed: https://fairseq.readthedocs.io/en/latest/
+
+    The model can be used as a fixed features extractor or can be finetuned. It
+    will download automatically the model if a url is given (e.g FairSeq
+    repository).
+
+    Arguments
+    ---------
+    pretrained_path : str
+        Path of the pretrained wav2vec2 model. It can be a url or a local path.
+    save_path : str
+        Path and filename of the downloaded model.
+    output_norm : bool (default: True)
+        If True, a layer_norm (affine) will be applied to the output obtained
+        from the wav2vec model.
+    freeze : bool (default: True)
+        If True, the model is frozen. If False, the model will be trained
+        alongside with the rest of the pipeline.
+
+    Example
+    -------
+    >>> inputs = torch.rand([10, 600])
+    >>> model = FairseqWav2Vec2()
+    >>> outputs = model(inputs)
+    >>> outputs.shape
+    torch.Size([10, 768])
+    """
+
+    def __init__(
+        self, pretrained_path, save_path, output_norm=True, freeze=True
+    ):
+        super().__init__()
+
+        # Download the pretrained wav2vec2 model. It can be local or online.
+        download_file(pretrained_path, save_path)
+
+        (
+            model,
+            cfg,
+            task,
+        ) = fairseq.checkpoint_utils.load_model_ensemble_and_task([save_path])
+
+        # wav2vec pretrained models may need the input waveform to be normalized
+        # Hence, we check of the model has be trained with or without it.
+        self.normalize = ("normalize" in cfg["task"]) and cfg["task"][
+            "normalize"
+        ]
+        model = model[0]
+        self.model = model
+        self.freeze = freeze
+        self.output_norm = output_norm
+        if self.freeze:
+            model.eval()
+
+    def forward(self, x):
+        """Takes an input waveform and return its corresponding wav2vec encoding.
+
+        Arguments
+        ---------
+        x : torch.Tensor (signal)
+
+        Outputs
+        --------
+        x : torch.Tensor [batch, time, features]
+
+        """
+
+        # If freeze is specified, we remove the model from the gradient graph.
+        if self.freeze:
+            for p in self.model.parameters():
+                p.requires_grad = True
+
+        # We normalize the input signal if needed.
+        if self.normalize:
+            x = F.layer_norm(x, x.shape)
+
+        # Extract wav2vec output
+        out = self.model.extract_features(x, padding_mask=None, mask=False)[0]
+
+        # We normalize the output if required
+        if self.output_nom:
+            out = F.layer_norm(out, out.shape)
+
+        return out

--- a/speechbrain/lobes/models/fairseq_wav2vec2.py
+++ b/speechbrain/lobes/models/fairseq_wav2vec2.py
@@ -72,17 +72,13 @@ class FairseqWav2Vec2(nn.Module):
         if self.freeze:
             model.eval()
 
-    def forward(self, x):
+    def forward(self, wav):
         """Takes an input waveform and return its corresponding wav2vec encoding.
 
         Arguments
         ---------
-        x : torch.Tensor (signal)
-
-        Outputs
-        --------
-        x : torch.Tensor [batch, time, features]
-
+        wav : torch.Tensor (signal)
+            A batch of audio signals to transform to features.
         """
 
         # If freeze is specified, we remove the model from the gradient graph.
@@ -92,7 +88,7 @@ class FairseqWav2Vec2(nn.Module):
 
         # We normalize the input signal if needed.
         if self.normalize:
-            x = F.layer_norm(x, x.shape)
+            x = F.layer_norm(wav, wav.shape)
 
         # Extract wav2vec output
         out = self.model.extract_features(x, padding_mask=None, mask=False)[0]
@@ -100,5 +96,65 @@ class FairseqWav2Vec2(nn.Module):
         # We normalize the output if required
         if self.output_norm:
             out = F.layer_norm(out, out.shape)
+
+        return out
+
+
+class FairseqWav2Vec1(nn.Module):
+    """This lobes enables the integration of fairseq pretrained wav2vec1.0 models.
+
+    Arguments
+    ---------
+    pretrained_path : str
+        Path of the pretrained wav2vec2 model. It can be a url or a local path.
+    save_path : str
+        Path and filename of the downloaded model.
+    output_norm : bool (default: True)
+        If True, a layer_norm (affine) will be applied to the output obtained
+        from the wav2vec model.
+    freeze : bool (default: True)
+        If True, the model is frozen. If False, the model will be trained
+        alongside with the rest of the pipeline.
+
+    Example
+    -------
+    >>> inputs = torch.rand([10, 600])
+    >>> model_url = ""
+    >>> save_path = "models_checkpoints/wav2vec2.pt"
+    >>> model = FairseqWav2Vec2(model_url, save_path)
+    >>> outputs = model(inputs)
+    >>> outputs.shape
+    torch.Size([10, 100, 512])
+    """
+
+    def __init__(
+        self, pretrained_path, save_path, output_norm=True, freeze=True
+    ):
+        super().__init__()
+
+        # Download the pretrained wav2vec1 model. It can be local or online.
+        download_file(pretrained_path, save_path)
+
+        (
+            model,
+            cfg,
+            task,
+        ) = fairseq.checkpoint_utils.load_model_ensemble_and_task(
+            [pretrained_path]
+        )
+        self.model = model
+        self.model = self.model[0]
+
+    def forward(self, wav):
+        """Takes an input waveform and return its corresponding wav2vec encoding.
+
+        Arguments
+        ---------
+        wav : torch.Tensor (signal)
+            A batch of audio signals to transform to features.
+        """
+        out = self.model.feature_extractor(wav)
+        out = self.model.feature_aggregator(out).squeeze(0)
+        out = out.transpose(2, 1)
 
         return out


### PR DESCRIPTION
This PR will enable our users to simply specify a pretrained fairseq wav2vec model and simply instantiate it in speechbrain for fine-tuning or features extraction. 