### PR TITLE
Fix: Pretrained downloading location and error messages

### DIFF
--- a/speechbrain/pretrained/interfaces.py
+++ b/speechbrain/pretrained/interfaces.py
@@ -88,7 +88,7 @@ class Pretrained:
         self.modules = torch.nn.ModuleDict(modules).to(self.device)
         for mod in self.MODULES_NEEDED:
             if mod not in modules:
-                raise ValueError("Need modules['{mod}']")
+                raise ValueError(f"Need modules['{mod}']")
 
         # Check MODULES_NEEDED and HPARAMS_NEEDED and
         # make hyperparams available with dot notation
@@ -98,7 +98,7 @@ class Pretrained:
             # Also first check that all required params are found:
             for hp in self.HPARAMS_NEEDED:
                 if hp not in hparams:
-                    raise ValueError("Need hparams['{hp}']")
+                    raise ValueError(f"Need hparams['{hp}']")
             self.hparams = SimpleNamespace(**hparams)
 
         # Prepare modules for computation, e.g. jit

--- a/speechbrain/pretrained/interfaces.py
+++ b/speechbrain/pretrained/interfaces.py
@@ -189,7 +189,7 @@ class Pretrained:
         source,
         hparams_file="hyperparams.yaml",
         overrides={},
-        savedir="./pretrained_model_checkpoints",
+        savedir=None,
         **kwargs,
     ):
         """Fetch and load based from outside source based on HyperPyYAML file
@@ -214,8 +214,12 @@ class Pretrained:
         overrides : dict
             Any changes to make to the hparams file when it is loaded.
         savedir : str or Path
-            Where to put the pretraining material.
+            Where to put the pretraining material. If not given, will use
+            ./pretrained_checkpoints/<class-name>-hash(source).
         """
+        if savedir is None:
+            clsname = cls.__name__
+            savedir = f"./pretrained_checkpoints/{clsname}-{hash(source)}"
         hparams_local_path = fetch(hparams_file, source, savedir)
 
         # Load the modules:


### PR DESCRIPTION
As discussed on Slack, proposing a new source-dependent download location. Since the source can be a relative path in the file system, we shouldn't use it straight as is. Instead I'm proposing taking a hash of the source, and prepending that with the class name, so we end up with paths like: `./pretrained_checkpoints/EncoderDecoderASR-14812749793863090`

Also, the Pretrained interface had missing f's for f-strings in the error messages, fixed those.