### PR TITLE
Fix: Remove separate linter messages which failed from forks

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -22,7 +22,7 @@ jobs:
               run: |
                   python -m pip install --upgrade pip
                   pip install -r lint-requirements.txt
-            - name: Run lint again for error code
+            - name: Run linters
               run: |
                   flake8 . --count --show-source --statistics
                   black --check --diff .

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -22,13 +22,6 @@ jobs:
               run: |
                   python -m pip install --upgrade pip
                   pip install -r lint-requirements.txt
-            - name: Show Python errors separately
-              uses: samuelmeuli/lint-action@v1
-              with:
-                  github_token: ${{ secrets.github_token }}
-                  # Enable linters
-                  black: True
-                  flake8: True
             - name: Run lint again for error code
               run: |
                   flake8 . --count --show-source --statistics


### PR DESCRIPTION
Separate nice linter flags seemed to fail from forks. Propose removing those for now.