### PR TITLE
Checkpoint Averaging in best LibriSpeech Transformer recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ SpeechBrain supports state-of-the-art methods for end-to-end speech recognition:
 ### Feature extraction and augmentation
 
 SpeechBrain provides efficient and GPU-friendly speech augmentation pipelines and acoustic feature extraction:
-- On-the-fly and fully-differentiable acoustic feature extraction: filter banks can be learned. This simplifies the training pipeline (you don't have to dump features on disk). 
+- On-the-fly and fully-differentiable acoustic feature extraction: filter banks can be learned. This simplifies the training pipeline (you don't have to dump features on disk).
 - On-the-fly feature normalization (global, sentence, batch, or speaker level).
 - On-the-fly environmental corruptions based on noise, reverberation, and babble for robust model training.
 - On-the-fly frequency and time domain SpecAugment.
@@ -64,7 +64,7 @@ The recipes released with speechbrain implement speech processing systems with c
 
 | Dataset        | Task           | System  | Performance  |
 | ------------- |:-------------:| -----:|-----:|
-| LibriSpeech      | Speech Recognition | CNN + Transformer | WER=2.50% (test-clean) |
+| LibriSpeech      | Speech Recognition | CNN + Transformer | WER=2.46% (test-clean) |
 | TIMIT      | Speech Recognition | CRDNN + distillation | PER=13.1% (test) |
 | CommonVoice (French) | Speech Recognition | CRDNN | WER=17.7% (test) |
 | VoxCeleb2      | Speaker Verification | ECAPA-TDNN | EER=0.69% (vox1-test) |

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The recipes released with speechbrain implement speech processing systems with c
 
 | Dataset        | Task           | System  | Performance  |
 | ------------- |:-------------:| -----:|-----:|
-| LibriSpeech      | Speech Recognition | ContextNet + Transformer | WER=2.55% (test-clean) |
+| LibriSpeech      | Speech Recognition | CNN + Transformer | WER=2.50% (test-clean) |
 | TIMIT      | Speech Recognition | CRDNN + distillation | PER=13.1% (test) |
 | CommonVoice (French) | Speech Recognition | CRDNN | WER=17.7% (test) |
 | VoxCeleb2      | Speaker Verification | ECAPA-TDNN | EER=0.69% (vox1-test) |

--- a/recipes/LibriSpeech/ASR/transformer/README.md
+++ b/recipes/LibriSpeech/ASR/transformer/README.md
@@ -12,5 +12,5 @@ python train.py train/train.yaml
 
 | Release | hyperparams file | Test Clean WER | HuggingFace link | Model link | GPUs |
 |:-------------:|:---------------------------:| :-----:| :-----:| :-----:| :--------:|
-| 20-05-22 | transformer.yaml | 2.55 | [HuggingFace](https://huggingface.co/speechbrain/asr-transformer-transformerlm-librispeech) | Not Available | 1xV100 32GB |
+| 20-05-22 | transformer.yaml | 2.46 | [HuggingFace](https://huggingface.co/speechbrain/asr-transformer-transformerlm-librispeech) | [GoogleDrive](https://drive.google.com/drive/folders/1ZudxqMWb8VNCJKvY2Ws5oNY3WI1To0I7?usp=sharing) | 1xV100 32GB |
 | 20-05-22 | conformer.yaml | -.-- | Not Available | Not Available | 1xV100 32GB |

--- a/recipes/LibriSpeech/ASR/transformer/README.md
+++ b/recipes/LibriSpeech/ASR/transformer/README.md
@@ -12,5 +12,5 @@ python train.py train/train.yaml
 
 | Release | hyperparams file | Test Clean WER | HuggingFace link | Model link | GPUs |
 |:-------------:|:---------------------------:| :-----:| :-----:| :-----:| :--------:|
-| 20-05-22 | transformer.yaml | 2.46 | [HuggingFace](https://huggingface.co/speechbrain/asr-transformer-transformerlm-librispeech) | [GoogleDrive](https://drive.google.com/drive/folders/1ZudxqMWb8VNCJKvY2Ws5oNY3WI1To0I7?usp=sharing) | 1xV100 32GB |
-| 20-05-22 | conformer.yaml | -.-- | Not Available | Not Available | 1xV100 32GB |
+| 20-05-22 | transformer.yaml | 2.46 | [HuggingFace](https://huggingface.co/speechbrain/asr-transformer-transformerlm-librispeech) | [GoogleDrive](https://drive.google.com/drive/folders/1ZudxqMWb8VNCJKvY2Ws5oNY3WI1To0I7?usp=sharing) | 2xRTX8000 42GB |
+| 20-05-22 | conformer.yaml | -.-- | Not Available | Not Available | 4xV100 32GB |

--- a/recipes/LibriSpeech/ASR/transformer/hparams/transformer.yaml
+++ b/recipes/LibriSpeech/ASR/transformer/hparams/transformer.yaml
@@ -96,7 +96,7 @@ valid_search_interval: 10
 valid_beam_size: 10
 test_beam_size: 66
 lm_weight: 0.60
-ctc_weight_decode: 0.52
+ctc_weight_decode: 0.40
 
 ############################## models ################################
 

--- a/recipes/LibriSpeech/ASR/transformer/hparams/transformer.yaml
+++ b/recipes/LibriSpeech/ASR/transformer/hparams/transformer.yaml
@@ -263,5 +263,5 @@ pretrainer: !new:speechbrain.utils.parameter_transfer.Pretrainer
         lm: !ref <lm_model>
         tokenizer: !ref <tokenizer>
     paths:
-        lm: !ref /network/tmp1/jianyuan.zhong/TransformerLM/Transformer_bz32_w150000/2223/save/CKPT+2021-03-05+22-50-18+00/model.ckpt
+        lm: !ref <pretrained_lm_tokenizer_path>/lm.ckpt
         tokenizer: !ref <pretrained_lm_tokenizer_path>/tokenizer.ckpt

--- a/recipes/LibriSpeech/ASR/transformer/hparams/transformer.yaml
+++ b/recipes/LibriSpeech/ASR/transformer/hparams/transformer.yaml
@@ -263,5 +263,5 @@ pretrainer: !new:speechbrain.utils.parameter_transfer.Pretrainer
         lm: !ref <lm_model>
         tokenizer: !ref <tokenizer>
     paths:
-        lm: !ref <pretrained_lm_tokenizer_path>/lm.ckpt
+        lm: !ref /network/tmp1/jianyuan.zhong/TransformerLM/Transformer_bz32_w150000/2223/save/CKPT+2021-03-05+22-50-18+00/model.ckpt
         tokenizer: !ref <pretrained_lm_tokenizer_path>/tokenizer.ckpt

--- a/recipes/LibriSpeech/ASR/transformer/train.py
+++ b/recipes/LibriSpeech/ASR/transformer/train.py
@@ -17,8 +17,7 @@ targets and sub-word units estimated with Byte Pairwise Encoding (BPE)
 are used as basic recognition tokens. Training is performed on the full
 LibriSpeech dataset (960 h).
 
-The best model is the avergage of the avergage of the checkpoints from last
-5 epochs.
+The best model is the avergage of the checkpoints from last 5 epochs.
 
 The experiment file is flexible enough to support a large variety of
 different systems. By properly changing the parameter files, you can try
@@ -237,7 +236,7 @@ class ASR(sb.core.Brain):
             with open(self.hparams.wer_file, "w") as w:
                 self.wer_metric.write_stats(w)
 
-            # save the averaged checkpoint at the end of the evalation statge
+            # save the averaged checkpoint at the end of the evalation stage
             # delete the rest of the intermediate checkpoints
             self.checkpointer.save_and_keep_only(
                 meta={"ACC": 1.1, "epoch": epoch},

--- a/recipes/LibriSpeech/ASR/transformer/train.py
+++ b/recipes/LibriSpeech/ASR/transformer/train.py
@@ -238,7 +238,7 @@ class ASR(sb.core.Brain):
 
             # save the averaged checkpoint at the end of the evalation stage
             # delete the rest of the intermediate checkpoints
-            # ACC is set to 1.1 such the checkpointer only keeps the averaged checkpoint            
+            # ACC is set to 1.1 so checkpointer only keeps the averaged checkpoint
             self.checkpointer.save_and_keep_only(
                 meta={"ACC": 1.1, "epoch": epoch},
                 max_keys=["ACC"],

--- a/recipes/LibriSpeech/ASR/transformer/train.py
+++ b/recipes/LibriSpeech/ASR/transformer/train.py
@@ -238,6 +238,7 @@ class ASR(sb.core.Brain):
 
             # save the averaged checkpoint at the end of the evalation stage
             # delete the rest of the intermediate checkpoints
+            # ACC is set to 1.1 such the checkpointer only keeps the averaged checkpoint            
             self.checkpointer.save_and_keep_only(
                 meta={"ACC": 1.1, "epoch": epoch},
                 max_keys=["ACC"],

--- a/speechbrain/lobes/models/transformer/TransformerASR.py
+++ b/speechbrain/lobes/models/transformer/TransformerASR.py
@@ -151,7 +151,6 @@ class TransformerASR(TransformerInterface):
             memory=encoder_out,
             tgt_mask=tgt_mask,
             tgt_key_padding_mask=tgt_key_padding_mask,
-            memory_key_padding_mask=src_key_padding_mask,
         )
 
         return encoder_out, decoder_out

--- a/speechbrain/utils/checkpoints.py
+++ b/speechbrain/utils/checkpoints.py
@@ -1088,6 +1088,7 @@ def average_checkpoints(
     recoverable_name,
     parameter_loader=torch.load,
     averager=average_state_dicts,
+    device=None,
 ):
     """Average parameters from multiple checkpoints.
 
@@ -1149,8 +1150,16 @@ def average_checkpoints(
     tensor([8.])
     """
 
-    parameter_iterator = (
-        parameter_loader(ckpt.paramfiles[recoverable_name])
-        for ckpt in checkpoint_list
-    )
+    try:
+        parameter_iterator = (
+            parameter_loader(
+                ckpt.paramfiles[recoverable_name], map_location=device
+            )
+            for ckpt in checkpoint_list
+        )
+    except TypeError:
+        parameter_iterator = (
+            parameter_loader(ckpt.paramfiles[recoverable_name])
+            for ckpt in checkpoint_list
+        )
     return averager(parameter_iterator)

--- a/speechbrain/utils/checkpoints.py
+++ b/speechbrain/utils/checkpoints.py
@@ -1151,6 +1151,7 @@ def average_checkpoints(
     """
 
     try:
+        # try to map the ckps to the correct device
         parameter_iterator = (
             parameter_loader(
                 ckpt.paramfiles[recoverable_name], map_location=device


### PR DESCRIPTION
As mentioned in #564, this is the PR for updating the transformer recipe to support checkpoint averaging. With this technique, the performance of our Transformer recipe reached **2.46%** on test-clean, librispeech.