### PR TITLE
Allows TorchScript tracing of pretrained ASR models

### DIFF
--- a/speechbrain/nnet/CNN.py
+++ b/speechbrain/nnet/CNN.py
@@ -845,8 +845,7 @@ def get_padding_elem(L_in: int, stride: int, kernel_size: int, dilation: int):
         padding = [kernel_size // 2, kernel_size // 2]
 
     else:
-        L_out = (L_in - dilation * (kernel_size - 1) - 1) / stride + 1
-        L_out = int(L_out)
+        L_out = (L_in - dilation * (kernel_size - 1) - 1) // stride + 1
 
         padding = [(L_in - L_out) // 2, (L_in - L_out) // 2]
     return padding

--- a/speechbrain/processing/NMF.py
+++ b/speechbrain/processing/NMF.py
@@ -175,8 +175,10 @@ def reconstruct_results(
                 dim=-1,
             )
         )
-        shat1 = ISTFT(X1hat_stft.unsqueeze(0).permute(0, 2, 1, 3))
-        shat2 = ISTFT(X2hat_stft.unsqueeze(0).permute(0, 2, 1, 3))
+        X1hat_stft = X1hat_stft.unsqueeze(0).permute(0, 2, 1, 3)
+        X2hat_stft = X2hat_stft.unsqueeze(0).permute(0, 2, 1, 3)
+        shat1 = ISTFT(X1hat_stft)
+        shat2 = ISTFT(X2hat_stft)
 
         div_factor = 10
         x1 = shat1 / (div_factor * shat1.std())

--- a/speechbrain/processing/features.py
+++ b/speechbrain/processing/features.py
@@ -696,9 +696,7 @@ class Filterbank(torch.nn.Module):
         x_db -= self.multiplier * self.db_multiplier
 
         # Setting up dB max
-        new_x_db_max = torch.tensor(
-            float(x_db.max()) - self.top_db, dtype=x_db.dtype, device=x.device,
-        )
+        new_x_db_max = x_db.max() - self.top_db
         # Clipping to dB max
         x_db = torch.max(x_db, new_x_db_max)
 

--- a/speechbrain/processing/features.py
+++ b/speechbrain/processing/features.py
@@ -193,7 +193,7 @@ class ISTFT(torch.nn.Module):
 
     This class computes the Inverse Short-Term Fourier Transform of
     an audio signal. It supports multi-channel audio inputs
-    (batch, time_step, n_fft, 2, n_channels [optional]).
+    (batch, time_step, n_fft, n_channels [optional], 2).
 
     Arguments
     ---------
@@ -301,6 +301,9 @@ class ISTFT(torch.nn.Module):
             x = x.reshape(-1, x.shape[2], x.shape[3], x.shape[4])
         elif len(or_shape) == 4:
             x = x.permute(0, 2, 1, 3)
+
+        # isft ask complex input
+        x = torch.complex(x[...,0], x[...,1])
 
         istft = torch.istft(
             input=x,

--- a/speechbrain/processing/features.py
+++ b/speechbrain/processing/features.py
@@ -1011,7 +1011,7 @@ class InputNormalization(torch.nn.Module):
         for snt_id in range(N_batches):
 
             # Avoiding padded time steps
-            actual_size = int(torch.round(lengths[snt_id] * x.shape[1]))
+            actual_size = torch.round(lengths[snt_id] * x.shape[1]).int()
 
             # computing statistics
             current_mean, current_std = self._compute_current_stats(

--- a/speechbrain/processing/features.py
+++ b/speechbrain/processing/features.py
@@ -303,7 +303,7 @@ class ISTFT(torch.nn.Module):
             x = x.permute(0, 2, 1, 3)
 
         # isft ask complex input
-        x = torch.complex(x[...,0], x[...,1])
+        x = torch.complex(x[..., 0], x[..., 1])
 
         istft = torch.istft(
             input=x,

--- a/speechbrain/processing/multi_mic.py
+++ b/speechbrain/processing/multi_mic.py
@@ -715,7 +715,7 @@ class GccPhat(torch.nn.Module):
         """
 
         # Get useful dimensions
-        n_samples = int((XXs.shape[2] - 1) * 2)
+        n_samples = (XXs.shape[2] - 1) * 2
 
         # Extracting the tensors needed
         XXs_val, XXs_idx = torch.unique(XXs, return_inverse=True, dim=4)

--- a/tests/unittests/test_CNN.py
+++ b/tests/unittests/test_CNN.py
@@ -13,6 +13,8 @@ def test_SincConv():
     output = convolve(input)
     assert output.shape[-1] == 8
 
+    assert torch.jit.trace(convolve, input)
+
 
 def test_Conv1d():
 
@@ -31,6 +33,8 @@ def test_Conv1d():
     convolve.conv.bias = torch.nn.Parameter(torch.tensor([0]).float())
     output = convolve(input)
     assert torch.all(torch.eq(torch.ones(input.shape), output))
+
+    assert torch.jit.trace(convolve, input)
 
 
 def test_Conv2d():
@@ -60,3 +64,5 @@ def test_Conv2d():
     convolve.conv.bias = torch.nn.Parameter(torch.tensor([0]).float())
     output = convolve(input)
     assert torch.all(torch.eq(input, output))
+
+    assert torch.jit.trace(convolve, input)

--- a/tests/unittests/test_RNN.py
+++ b/tests/unittests/test_RNN.py
@@ -36,6 +36,7 @@ def test_RNN():
     assert torch.all(
         torch.lt(torch.add(hn_t, -hn), 1e-3)
     ), "GRU hidden states mismatch"
+    assert torch.jit.trace(net, inputs)
 
     # Check GRU
     inputs = torch.randn(4, 2, 7)
@@ -59,6 +60,7 @@ def test_RNN():
     assert torch.all(
         torch.lt(torch.add(hn_t, -hn), 1e-3)
     ), "GRU hidden states mismatch"
+    assert torch.jit.trace(net, inputs)
 
     # Check LSTM
     inputs = torch.randn(4, 2, 7)
@@ -82,6 +84,7 @@ def test_RNN():
     assert torch.all(torch.lt(torch.add(hn_t[0], -hn[0]), 1e-3)) and torch.all(
         torch.lt(torch.add(hn_t[1], -hn[1]), 1e-3)
     ), "LSTM hidden states mismatch"
+    assert torch.jit.trace(net, inputs)
 
     # Check LiGRU
     inputs = torch.randn(1, 2, 2)
@@ -135,6 +138,7 @@ def test_RNN():
     ) and torch.all(
         torch.lt(torch.add(hn_t[1], -hn[1][1]), 1e-3)
     ), "QuasiRNN hidden states mismatch"
+    assert torch.jit.trace(net, inputs)
 
     # Check RNNCell
     inputs = torch.randn(4, 2, 7)
@@ -166,3 +170,4 @@ def test_RNN():
     assert torch.all(torch.lt(torch.add(hn_t[0], -hn[0]), 1e-3)) and torch.all(
         torch.lt(torch.add(hn_t[1], -hn[1]), 1e-3)
     ), "RNNCell hidden states mismatch"
+    assert torch.jit.trace(rnn, inputs)

--- a/tests/unittests/test_activations.py
+++ b/tests/unittests/test_activations.py
@@ -10,3 +10,5 @@ def test_softmax():
     act = Softmax(apply_log=False)
     outputs = act(inputs)
     assert torch.argmax(outputs) == 2
+
+    assert torch.jit.trace(act, inputs)

--- a/tests/unittests/test_dataloader.py
+++ b/tests/unittests/test_dataloader.py
@@ -28,7 +28,7 @@ def test_saveable_dataloader_multiprocess(tmpdir):
 
     save_file = tmpdir + "/dataloader.ckpt"
     dataset = torch.randn(10, 1)
-    for num_parallel in [1, 2, 10, 12]:
+    for num_parallel in [1, 2, 3, 4]:
         dataloader = SaveableDataLoader(
             dataset, num_workers=num_parallel, collate_fn=None
         )  # Note num_workers

--- a/tests/unittests/test_dropout.py
+++ b/tests/unittests/test_dropout.py
@@ -14,3 +14,5 @@ def test_dropout():
     drop = Dropout2d(drop_rate=1.0)
     outputs = drop(inputs)
     assert torch.all(torch.eq(torch.zeros(inputs.shape), outputs))
+
+    assert torch.jit.trace(drop, inputs)

--- a/tests/unittests/test_embedding.py
+++ b/tests/unittests/test_embedding.py
@@ -22,3 +22,5 @@ def test_embedding():
     inputs = torch.randint(0, 40, (5, 10))
     output = emb(inputs)
     assert output.shape == (5, 10, 128)
+
+    assert torch.jit.trace(emb, inputs)

--- a/tests/unittests/test_features.py
+++ b/tests/unittests/test_features.py
@@ -11,6 +11,8 @@ def test_deltas():
     out = torch.zeros(size)
     assert torch.sum(compute_deltas(inp) == out) == out.numel()
 
+    assert torch.jit.trace(compute_deltas, inp)
+
 
 def test_context_window():
 
@@ -24,6 +26,8 @@ def test_context_window():
     inp = torch.rand([2, 10, 5])
     compute_cw = ContextWindow(left_frames=0, right_frames=0)
     assert torch.sum(compute_cw(inp) == inp) == inp.numel()
+
+    assert torch.jit.trace(compute_cw, inp)
 
 
 def test_istft():
@@ -39,3 +43,34 @@ def test_istft():
     out = compute_istft(compute_stft(inp), sig_length=16000)
 
     assert torch.sum(torch.abs(inp - out) < 1e-6) >= inp.numel() - 5
+
+    assert torch.jit.trace(compute_stft, inp)
+    assert torch.jit.trace(compute_istft, compute_stft(inp))
+
+
+def test_filterbank():
+
+    from speechbrain.processing.features import Filterbank
+
+    compute_fbanks = Filterbank()
+    inputs = torch.ones([10, 101, 201])
+    assert torch.jit.trace(compute_fbanks, inputs)
+
+
+def test_dtc():
+
+    from speechbrain.processing.features import DCT
+
+    compute_dct = DCT(input_size=40)
+    inputs = torch.randn([10, 101, 40])
+    assert torch.jit.trace(compute_dct, inputs)
+
+
+def test_input_normalization():
+
+    from speechbrain.processing.features import InputNormalization
+
+    norm = InputNormalization()
+    inputs = torch.randn([10, 101, 20])
+    inp_len = torch.ones([10])
+    assert torch.jit.trace(norm, (inputs, inp_len))

--- a/tests/unittests/test_features.py
+++ b/tests/unittests/test_features.py
@@ -74,3 +74,10 @@ def test_input_normalization():
     inputs = torch.randn([10, 101, 20])
     inp_len = torch.ones([10])
     assert torch.jit.trace(norm, (inputs, inp_len))
+
+    norm = InputNormalization()
+    inputs = torch.FloatTensor([1, 2, 3, 0, 0, 0]).unsqueeze(0).unsqueeze(2)
+    inp_len = torch.FloatTensor([0.5])
+    out_norm = norm(inputs, inp_len).squeeze()
+    target = torch.FloatTensor([-1, 0, 1, -2, -2, -2])
+    assert torch.equal(out_norm, target)

--- a/tests/unittests/test_linear.py
+++ b/tests/unittests/test_linear.py
@@ -11,3 +11,5 @@ def test_linear():
     lin_t.w.weight = torch.nn.Parameter(torch.eye(inputs.shape[-1]))
     outputs = lin_t(inputs)
     assert torch.all(torch.eq(inputs, outputs))
+
+    assert torch.jit.trace(lin_t, inputs)

--- a/tests/unittests/test_multi_mic.py
+++ b/tests/unittests/test_multi_mic.py
@@ -28,3 +28,6 @@ def test_gccphat():
 
     n_valid_tdoas = torch.sum(torch.abs(tdoas[..., 1] - delay) < 1e-3)
     assert n_valid_tdoas == Xs.shape[0] * Xs.shape[1]
+    assert torch.jit.trace(stft, xs)
+    assert torch.jit.trace(cov, Xs)
+    assert torch.jit.trace(gccphat, XXs)

--- a/tests/unittests/test_normalization.py
+++ b/tests/unittests/test_normalization.py
@@ -50,6 +50,8 @@ def test_BatchNorm1d():
     current_std = output.std(dim=0).mean()
     assert torch.abs(1.0 - current_std) < 0.01
 
+    assert torch.jit.trace(norm, input)
+
 
 def test_BatchNorm2d():
 
@@ -65,6 +67,8 @@ def test_BatchNorm2d():
 
     current_std = output.std(dim=0).mean()
     assert torch.abs(1.0 - current_std) < 0.01
+
+    assert torch.jit.trace(norm, input)
 
 
 def test_LayerNorm():
@@ -93,6 +97,8 @@ def test_LayerNorm():
     current_std = output.std(dim=[2, 3]).mean()
     assert torch.abs(1.0 - current_std) < 0.01
 
+    assert torch.jit.trace(norm, input)
+
 
 def test_InstanceNorm1d():
 
@@ -109,6 +115,8 @@ def test_InstanceNorm1d():
     current_std = output.std(dim=2).mean()
     assert torch.abs(1.0 - current_std) < 0.01
 
+    assert torch.jit.trace(norm, input)
+
 
 def test_InstanceNorm2d():
 
@@ -124,3 +132,5 @@ def test_InstanceNorm2d():
 
     current_std = output.std(dim=[2, 3]).mean()
     assert torch.abs(1.0 - current_std) < 0.01
+
+    assert torch.jit.trace(norm, input)

--- a/tests/unittests/test_pooling.py
+++ b/tests/unittests/test_pooling.py
@@ -15,6 +15,8 @@ def test_pooling1d():
     output = pool(input)
     assert output == 2
 
+    assert torch.jit.trace(pool, input)
+
 
 def test_pooling2d():
 
@@ -41,3 +43,5 @@ def test_pooling2d():
     output = pool(input)
     assert output[0][0] == 2
     assert output[0][1] == 5
+
+    assert torch.jit.trace(pool, input)


### PR DESCRIPTION
Fixes the `torch.jit.trace` warnings and errors on pretrained ASR models `compute_features`, `normalize` and `asr_encoder` models.

Tracing of `beeam_search` still fails but it is going to be significantly more work to make it work.