### PR TITLE
Add single value (per Epoch) logging to TensorboardLogger

### DIFF
--- a/recipes/Voicebank/enhance/MetricGAN/hparams/train.yaml
+++ b/recipes/Voicebank/enhance/MetricGAN/hparams/train.yaml
@@ -24,7 +24,7 @@ train_log: !ref <output_folder>/train_log.txt
 enhanced_folder: !ref <output_folder>/enhanced_wavs
 
 # Basic parameters
-use_tensorboard: False
+use_tensorboard: True
 tensorboard_logs: !ref <output_folder>/logs/
 
 # FFT paremeters
@@ -104,3 +104,7 @@ resynth: !name:speechbrain.processing.signal_processing.resynthesize
 
 train_logger: !new:speechbrain.utils.train_logger.FileTrainLogger
     save_file: !ref <train_log>
+
+# Tensorboard logger (optional)
+tensorboard_train_logger: !new:speechbrain.utils.train_logger.TensorboardLogger
+    save_dir: !ref <tensorboard_logs>

--- a/recipes/Voicebank/enhance/spectral_mask/hparams/train.yaml
+++ b/recipes/Voicebank/enhance/spectral_mask/hparams/train.yaml
@@ -20,7 +20,7 @@ train_log: !ref <output_folder>/train_log.txt
 enhanced_folder: !ref <output_folder>/enhanced_wavs
 
 # Basic parameters
-use_tensorboard: False
+use_tensorboard: True
 tensorboard_logs: !ref <output_folder>/logs/
 
 # FFT paremeters
@@ -91,3 +91,7 @@ mean_var_norm: !new:speechbrain.processing.features.InputNormalization
 
 train_logger: !new:speechbrain.utils.train_logger.FileTrainLogger
     save_file: !ref <train_log>
+
+# Tensorboard logger (optional)
+tensorboard_train_logger: !new:speechbrain.utils.train_logger.TensorboardLogger
+    save_dir: !ref <tensorboard_logs>

--- a/recipes/Voicebank/enhance/waveform_map/hparams/train.yaml
+++ b/recipes/Voicebank/enhance/waveform_map/hparams/train.yaml
@@ -18,7 +18,7 @@ train_log: !ref <output_folder>/train_log.txt
 enhanced_folder: !ref <output_folder>/enhanced
 
 # Basic parameters
-use_tensorboard: False
+use_tensorboard: True
 tensorboard_logs: !ref <output_folder>/logs/
 
 # FFT paremeters
@@ -80,3 +80,7 @@ compute_ISTFT: !new:speechbrain.processing.features.ISTFT
 
 train_logger: !new:speechbrain.utils.train_logger.FileTrainLogger
     save_file: !ref <train_log>
+
+# Tensorboard logger (optional)
+tensorboard_train_logger: !new:speechbrain.utils.train_logger.TensorboardLogger
+    save_dir: !ref <tensorboard_logs>

--- a/speechbrain/utils/train_logger.py
+++ b/speechbrain/utils/train_logger.py
@@ -144,7 +144,19 @@ class TensorboardLogger(TrainLogger):
                 if stat not in self.global_step[dataset]:
                     self.global_step[dataset][stat] = 0
                 tag = f"{stat}/{dataset}"
-                for value in value_list:
+				
+                # Both single value (per Epoch) and list (Per batch) logging is supported
+				# TODO: Remove list (Per batch) logging since it won't be very useful nor 
+				# readable (lots of values) and because the steps won't represent the real training
+				# epoch number.
+                if isinstance(value_list, list):
+                    for value in value_list:
+                        new_global_step = self.global_step[dataset][stat] + 1
+                        self.writer.add_scalar(tag, value, new_global_step)
+                        self.global_step[dataset][stat] = new_global_step
+                else:
+                    value = value_list
                     new_global_step = self.global_step[dataset][stat] + 1
                     self.writer.add_scalar(tag, value, new_global_step)
                     self.global_step[dataset][stat] = new_global_step
+

--- a/speechbrain/utils/train_logger.py
+++ b/speechbrain/utils/train_logger.py
@@ -146,9 +146,9 @@ class TensorboardLogger(TrainLogger):
                 tag = f"{stat}/{dataset}"
 				
                 # Both single value (per Epoch) and list (Per batch) logging is supported
-				# TODO: Remove list (Per batch) logging since it won't be very useful nor 
-				# readable (lots of values) and because the steps won't represent the real training
-				# epoch number.
+                # TODO: Remove list (Per batch) logging since it won't be very useful nor 
+                # readable (lots of values) and because the steps won't represent the real training
+                # epoch number.
                 if isinstance(value_list, list):
                     for value in value_list:
                         new_global_step = self.global_step[dataset][stat] + 1

--- a/speechbrain/utils/train_logger.py
+++ b/speechbrain/utils/train_logger.py
@@ -146,9 +146,6 @@ class TensorboardLogger(TrainLogger):
                 tag = f"{stat}/{dataset}"
 
                 # Both single value (per Epoch) and list (Per batch) logging is supported
-                # TODO: Remove list (Per batch) logging since it won't be very useful nor
-                # readable (lots of values) and because the steps won't represent the real
-                # training epoch number.
                 if isinstance(value_list, list):
                     for value in value_list:
                         new_global_step = self.global_step[dataset][stat] + 1

--- a/speechbrain/utils/train_logger.py
+++ b/speechbrain/utils/train_logger.py
@@ -144,11 +144,11 @@ class TensorboardLogger(TrainLogger):
                 if stat not in self.global_step[dataset]:
                     self.global_step[dataset][stat] = 0
                 tag = f"{stat}/{dataset}"
-				
+
                 # Both single value (per Epoch) and list (Per batch) logging is supported
-                # TODO: Remove list (Per batch) logging since it won't be very useful nor 
-                # readable (lots of values) and because the steps won't represent the real training
-                # epoch number.
+                # TODO: Remove list (Per batch) logging since it won't be very useful nor
+                # readable (lots of values) and because the steps won't represent the real
+                # training epoch number.
                 if isinstance(value_list, list):
                     for value in value_list:
                         new_global_step = self.global_step[dataset][stat] + 1
@@ -159,4 +159,3 @@ class TensorboardLogger(TrainLogger):
                     new_global_step = self.global_step[dataset][stat] + 1
                     self.writer.add_scalar(tag, value, new_global_step)
                     self.global_step[dataset][stat] = new_global_step
-


### PR DESCRIPTION
I noticed that when logging to Tensorboard using TensorboardLogger a full list of per batch metrics is logged at each epoch (a lot of values). This makes visualization of training progress basically unreadable and defats the purpose of using Tensorboard.

I did a minor change to make it possible to log a single value at the end of the epoch. And it is now much more readable, and we can clearly see the progress of the training at each epoch.

I also kept the list (Per batch) logging for now (Will auto detect if single value or a list is submitted to log_stats() ). This is to keep backward compatibility with existing recipes.
But I think we need to remove it all together since it will not be very useful nor readable (lots of values) and because the steps won't represent the real training epoch number in this case.
