### PR TITLE
Include ckpt_interval_minutes: 15

### DIFF
--- a/recipes/LibriSpeech/ASR/transformer/hparams/transformer.yaml
+++ b/recipes/LibriSpeech/ASR/transformer/hparams/transformer.yaml
@@ -38,7 +38,7 @@ valid_csv: !ref <data_folder>/dev-clean.csv
 test_csv:
     - !ref <data_folder>/test-clean.csv
     - !ref <data_folder>/test-other.csv
-ckpt_interval_minutes: 15 # save checkpoint every N min    
+ckpt_interval_minutes: 15 # save checkpoint every N min
 
 # Training parameters
 number_of_epochs: 110

--- a/recipes/LibriSpeech/ASR/transformer/hparams/transformer.yaml
+++ b/recipes/LibriSpeech/ASR/transformer/hparams/transformer.yaml
@@ -38,6 +38,7 @@ valid_csv: !ref <data_folder>/dev-clean.csv
 test_csv:
     - !ref <data_folder>/test-clean.csv
     - !ref <data_folder>/test-other.csv
+ckpt_interval_minutes: 15 # save checkpoint every N min    
 
 # Training parameters
 number_of_epochs: 110

--- a/recipes/LibriSpeech/ASR/transformer/hparams/transformer.yaml
+++ b/recipes/LibriSpeech/ASR/transformer/hparams/transformer.yaml
@@ -38,7 +38,7 @@ valid_csv: !ref <data_folder>/dev-clean.csv
 test_csv:
     - !ref <data_folder>/test-clean.csv
     - !ref <data_folder>/test-other.csv
-ckpt_interval_minutes: 15 # save checkpoint every N min
+ckpt_interval_minutes: 30 # save checkpoint every N min
 
 # Training parameters
 number_of_epochs: 110


### PR DESCRIPTION
Looks like this recipe didn't get the checkpointing interval set.  Given an epoch can take a while, and prone to memory overflow on smaller GPUs, it is nice to have more intra-epoch checkpoints.