### PR TITLE
Change boolean run options to flags

### DIFF
--- a/docs/experiment.md
+++ b/docs/experiment.md
@@ -43,10 +43,11 @@ For more details on YAML and our extensions, please see our dedicated [tutorial]
 ## Running arguments
 SpeechBrain defines a set of running arguments that can be set from the command line args (or within the YAML file).
 - `device`: set the device to be used for computation.
-- `data_parallel_backend`: default False, if True, use `data_parallel` for multigpu training on a single machine.
-- `data_parallel_count`: default "-1" (use all gpus), if > 0, use a subset of gpus available [0, 1, ..., data_parallel_count].
-- `distributed_launch`: default False, if True, we assume that we already use `torch.distributed.launch` for multiGPU training. the `local_rank` and `rank` UNIX arguments are then parsed for running multigpu training.
-- `distributed_backend`: default "nccl", options: ["nccl", "gloo", "mpi"], this backend will be used as a DDP communication protocol. See Pytorch Doc for more details.
+- `debug`: a flag that enables debug mode, only running a few iterations to verify that program won't crash.
+- `data_parallel_backend`: a flag that enables `data_parallel` for multigpu training on a single machine.
+- `data_parallel_count`: default "-1" (use all gpus), if > 0, use a subset of gpus available `[0, 1, ..., data_parallel_count]`.
+- `distributed_launch`: A flag that enables training with `ddp` for multiGPU training. Assumes `torch.distributed.launch` was used to start script. the `local_rank` and `rank` UNIX arguments are parsed.
+- `distributed_backend`: default "nccl", options: `["nccl", "gloo", "mpi"]`, this backend will be used as a DDP communication protocol. See PyTorch documentation for more details.
 - Additional runtime arguments are documented in the Brain class.
 
 Please note that we provide a dedicated [tutorial](https://colab.research.google.com/drive/13pBUacPiotw1IvyffvGZ-HrtBr9T6l15?usp=sharing) to document the different multi-gpu training strategies:

--- a/docs/multigpu.md
+++ b/docs/multigpu.md
@@ -7,7 +7,7 @@ The common pattern for using multi-GPU training over a single machine with Data 
 
 ```
 > cd recipes/<dataset>/<task>/
-> python experiment.py params.yaml --data_parallel_backend=True --data_parallel_count=2
+> python experiment.py params.yaml --data_parallel_backend --data_parallel_count=2
 ```
 
 Important: the batch size for each GPU process will be: `batch_size / data_parallel_count`. So you should consider changing the batch_size value according to you need.
@@ -20,7 +20,7 @@ more prone to exhibit unexpected bugs. Indeed, DDP is quite server dependent and
 The common pattern for using multi-GPU training with DDP (on a single machine with 4 GPUs):
 ```
 cd recipes/<dataset>/<task>/
-python -m torch.distributed.launch --nproc_per_node=4 experiment.py hyperparams.yaml --distributed_launch=True --distributed_backend='nccl'
+python -m torch.distributed.launch --nproc_per_node=4 experiment.py hyperparams.yaml --distributed_launch --distributed_backend='nccl'
 ```
 Try to switch the DDP backend if you have issues with `nccl`.
 
@@ -30,11 +30,11 @@ To using DDP, you should consider using `torch.distributed.launch` for setting t
 ```
 # Machine 1
 cd recipes/<dataset>/<task>/
-python -m torch.distributed.launch --nproc_per_node=2 --nnodes=2 --node=0 --master_addr machine_1_adress --master_port 5555 experiment.py hyperparams.yaml --distributed_launch=True --distributed_backend='nccl'
+python -m torch.distributed.launch --nproc_per_node=2 --nnodes=2 --node=0 --master_addr machine_1_adress --master_port 5555 experiment.py hyperparams.yaml --distributed_launch --distributed_backend='nccl'
 
 # Machine 2
 cd recipes/<dataset>/<task>/
-python -m torch.distributed.launch --nproc_per_node=2 --nnodes=2 --node=1 --master_addr machine_1_adress --master_port 5555 experiment.py hyperparams.yaml --distributed_launch=True --distributed_backend='nccl'
+python -m torch.distributed.launch --nproc_per_node=2 --nnodes=2 --node=1 --master_addr machine_1_adress --master_port 5555 experiment.py hyperparams.yaml --distributed_launch --distributed_backend='nccl'
 ```
 Machine 1 will have 2 subprocess (subprocess1: with `local_rank=0`, `rank=0`, and subprocess2: with `local_rank=1`, `rank=1`).
 Machine 2 will have 2 subprocess (subprocess1: with `local_rank=0`, `rank=2`, and subprocess2: with `local_rank=1`, `rank=3`).

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -201,14 +201,14 @@ def parse_arguments(arg_list):
     )
     parser.add_argument(
         "--data_parallel_backend",
-        type=bool,
         default=False,
+        action="store_true",
         help="If True, data_parallel is used.",
     )
     parser.add_argument(
         "--distributed_launch",
-        type=bool,
         default=False,
+        action="store_true",
         help="if True, use DDP",
     )
     parser.add_argument(
@@ -225,7 +225,8 @@ def parse_arguments(arg_list):
     )
     parser.add_argument(
         "--auto_mix_prec",
-        type=bool,
+        default=False,
+        action="store_true",
         help="If True, automatic mixed-precision is used.",
     )
     parser.add_argument(
@@ -240,8 +241,9 @@ def parse_arguments(arg_list):
         help="Max number of batches per epoch to skip if loss is nonfinite.",
     )
     parser.add_argument(
-        "--progressbar",
-        type=bool,
+        "--noprogressbar",
+        default=False,
+        action="store_true",
         help="If True, displays a progressbar indicating dataset progress.",
     )
     parser.add_argument(
@@ -386,8 +388,8 @@ class Brain:
         nonfinite_patience (int)
             Number of times to ignore non-finite losses before stopping.
             Default: ``3``.
-        progressbar (bool)
-            Whether to display a progressbar when training. Default: ``True``.
+        noprogressbar (bool)
+            Whether to turn off progressbar when training. Default: ``False``.
         ckpt_interval_minutes (float)
             Amount of time between saving intra-epoch checkpoints,
             in minutes, default: ``15.0``. If non-positive, these are not saved.
@@ -433,7 +435,7 @@ class Brain:
             "auto_mix_prec": False,
             "max_grad_norm": 5.0,
             "nonfinite_patience": 3,
-            "progressbar": True,
+            "noprogressbar": False,
             "ckpt_interval_minutes": 0,
         }
         for arg, default in run_opt_defaults.items():
@@ -977,7 +979,7 @@ class Brain:
         self.on_fit_start()
 
         if progressbar is None:
-            progressbar = self.progressbar
+            progressbar = not self.noprogressbar
 
         # Iterate epochs
         for epoch in epoch_counter:
@@ -1145,7 +1147,7 @@ class Brain:
         average test loss
         """
         if progressbar is None:
-            progressbar = self.progressbar
+            progressbar = not self.noprogressbar
 
         if not isinstance(test_set, DataLoader):
             test_loader_kwargs["ckpt_prefix"] = None

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -203,13 +203,14 @@ def parse_arguments(arg_list):
         "--data_parallel_backend",
         default=False,
         action="store_true",
-        help="If True, data_parallel is used.",
+        help="This flag enables training with data_parallel.",
     )
     parser.add_argument(
         "--distributed_launch",
         default=False,
         action="store_true",
-        help="if True, use DDP",
+        help="This flag enables training with DDP. Assumes script run with "
+        "`torch.distributed.launch`",
     )
     parser.add_argument(
         "--distributed_backend",
@@ -227,7 +228,7 @@ def parse_arguments(arg_list):
         "--auto_mix_prec",
         default=False,
         action="store_true",
-        help="If True, automatic mixed-precision is used.",
+        help="This flag enables training with automatic mixed-precision.",
     )
     parser.add_argument(
         "--max_grad_norm",
@@ -244,7 +245,7 @@ def parse_arguments(arg_list):
         "--noprogressbar",
         default=False,
         action="store_true",
-        help="If True, displays a progressbar indicating dataset progress.",
+        help="This flag disables the data loop progressbars.",
     )
     parser.add_argument(
         "--ckpt_interval_minutes",


### PR DESCRIPTION
Several boolean run options are set up to pass values, but record `True` regardless of value, e.g.

```bash
> python train.py train.yaml --auto_mix_prec=True
> python train.py train.yaml --auto_mix_prec=False
```
both set `auto_mix_prec` option to `True`.

More canonical approach is to use flags instead of taking values, this PR changes it to:
```bash
> python train.py train.yaml --auto_mix_prec
```