### PR TITLE
Modify Fbank to expose f_max, win_length and hop_length arguments.

### DIFF
--- a/speechbrain/lobes/features.py
+++ b/speechbrain/lobes/features.py
@@ -245,6 +245,7 @@ class MFCC(torch.nn.Module):
         )
 
         self.compute_fbanks = Filterbank(
+            sample_rate=sample_rate,
             n_fft=n_fft,
             n_mels=n_mels,
             f_min=f_min,

--- a/speechbrain/lobes/features.py
+++ b/speechbrain/lobes/features.py
@@ -32,8 +32,15 @@ class Fbank(torch.nn.Module):
     sample_rate : int (default: 160000)
         Sampling rate for the input waveforms.
     f_min : int (default: 0)
-        Lowest frequency for the Mel filters. Note that f_max (i.e highest
-        frequency for the Mel filters) is determined by sample_rate // 2.
+        Lowest frequency for the Mel filters.
+    f_max : int (default: None)
+        Highest frequency for the Mel filters. Note that if f_max is not
+        specified it will be set to sample_rate // 2.
+    win_length : float (default: 25)
+        Length (in ms) of the sliding window used to compute the STFT.
+    hop_length : float (default: 10)
+        Length (in ms) of the hop of the sliding window used to compute
+        the STFT.
     n_fft : int (default: 400)
         Number of samples to use in each stft.
     n_mels : int (default: 40)
@@ -145,44 +152,51 @@ class MFCC(torch.nn.Module):
 
     Arguments
     ---------
-    deltas : bool
+    deltas : bool (default: True)
         Whether or not to append derivatives and second derivatives
         to the features.
-    context : bool
+    context : bool (default: True)
         Whether or not to append forward and backward contexts to
         the features.
-    requires_grad : bool
+    requires_grad : bool (default: False)
         Whether to allow parameters (i.e. fbank centers and
         spreads) to update during training.
-    sample_rate : int
+    sample_rate : int (default: 16000)
         Sampling rate for the input waveforms.
-    f_min : int
-        Lowest frequency for the Mel filters. Note that f_max (i.e highest
-        frequency for the Mel filters) is determined by sample_rate // 2.
-    n_fft : int
+    f_min : int (default: 0)
+        Lowest frequency for the Mel filters.
+    f_max : int (default: None)
+        Highest frequency for the Mel filters. Note that if f_max is not
+        specified it will be set to sample_rate // 2.
+    win_length : float (default: 25)
+        Length (in ms) of the sliding window used to compute the STFT.
+    hop_length : float (default: 10)
+        Length (in ms) of the hop of the sliding window used to compute
+        the STFT.
+    n_fft : int (default: 400)
         Number of samples to use in each stft.
-    n_mels : int
+    n_mels : int (default: 23)
         Number of filters to use for creating filterbank.
-    n_mfcc : int
+    n_mfcc : int (default: 20)
         Number of output coefficients
-    filter_shape : str
+    filter_shape : str (default 'triangular')
         Shape of the filters ('triangular', 'rectangular', 'gaussian').
-    param_change_factor: bool
+    param_change_factor: bool (default 1.0)
         If freeze=False, this parameter affects the speed at which the filter
         parameters (i.e., central_freqs and bands) can be changed.  When high
         (e.g., param_change_factor=1) the filters change a lot during training.
         When low (e.g. param_change_factor=0.1) the filter parameters are more
         stable during training.
-    param_rand_factor: float
+    param_rand_factor: float (default 0.0)
         This parameter can be used to randomly change the filter parameters
         (i.e, central frequencies and bands) during training.  It is thus a
         sort of regularization. param_rand_factor=0 does not affect, while
         param_rand_factor=0.15 allows random variations within +-15% of the
         standard values of the filter parameters (e.g., if the central freq
         is 100 Hz, we can randomly change it from 85 Hz to 115 Hz).
-    left_frames : int
+    left_frames : int (default 5)
         Number of frames of left context to add.
-    right_frames : int
+    right_frames : int (default 5)
         Number of frames of right context to add.
 
     Example
@@ -202,6 +216,7 @@ class MFCC(torch.nn.Module):
         requires_grad=False,
         sample_rate=16000,
         f_min=0,
+        f_max=None,
         n_fft=400,
         n_mels=23,
         n_mfcc=20,
@@ -210,18 +225,29 @@ class MFCC(torch.nn.Module):
         param_rand_factor=0.0,
         left_frames=5,
         right_frames=5,
+        win_length=25,
+        hop_length=10,
     ):
         super().__init__()
         self.deltas = deltas
         self.context = context
         self.requires_grad = requires_grad
 
-        self.compute_STFT = STFT(sample_rate=sample_rate, n_fft=n_fft)
+        if f_max is None:
+            f_max = sample_rate / 2
+
+        self.compute_STFT = STFT(
+            sample_rate=sample_rate,
+            n_fft=n_fft,
+            win_length=win_length,
+            hop_length=hop_length,
+        )
+
         self.compute_fbanks = Filterbank(
             n_fft=n_fft,
             n_mels=n_mels,
             f_min=f_min,
-            f_max=sample_rate / 2,
+            f_max=f_max,
             freeze=not requires_grad,
             filter_shape=filter_shape,
             param_change_factor=param_change_factor,

--- a/speechbrain/lobes/features.py
+++ b/speechbrain/lobes/features.py
@@ -108,6 +108,7 @@ class Fbank(torch.nn.Module):
             hop_length=hop_length,
         )
         self.compute_fbanks = Filterbank(
+            sample_rate=sample_rate,
             n_fft=n_fft,
             n_mels=n_mels,
             f_min=f_min,

--- a/speechbrain/lobes/features.py
+++ b/speechbrain/lobes/features.py
@@ -75,6 +75,7 @@ class Fbank(torch.nn.Module):
         requires_grad=False,
         sample_rate=16000,
         f_min=0,
+        f_max=None,
         n_fft=400,
         n_mels=40,
         filter_shape="triangular",
@@ -82,18 +83,28 @@ class Fbank(torch.nn.Module):
         param_rand_factor=0.0,
         left_frames=5,
         right_frames=5,
+        win_length=25,
+        hop_length=10,
     ):
         super().__init__()
         self.deltas = deltas
         self.context = context
         self.requires_grad = requires_grad
 
-        self.compute_STFT = STFT(sample_rate=sample_rate, n_fft=n_fft)
+        if f_max is None:
+            f_max = sample_rate / 2
+
+        self.compute_STFT = STFT(
+            sample_rate=sample_rate,
+            n_fft=n_fft,
+            win_length=win_length,
+            hop_length=hop_length,
+        )
         self.compute_fbanks = Filterbank(
             n_fft=n_fft,
             n_mels=n_mels,
             f_min=f_min,
-            f_max=sample_rate / 2,
+            f_max=f_max,
             freeze=not requires_grad,
             filter_shape=filter_shape,
             param_change_factor=param_change_factor,


### PR DESCRIPTION
It would be very useful to have the `f_max`, `win_length` and `hop_length `arguments exposed. Otherwise it is impossible to set the desired number of output time steps when using `Fbank`.

The default values have been set based on `STFT()` and `Filterbank()` default values to keep the same behavior for existing recipes.