### PR TITLE
Fix merging and splitting not using the "space" arg

### DIFF
--- a/recipes/Voicebank/MTL/ASR_enhance/hparams/robust_asr.yaml
+++ b/recipes/Voicebank/MTL/ASR_enhance/hparams/robust_asr.yaml
@@ -241,6 +241,8 @@ pesq_stats: !name:speechbrain.utils.metric_stats.MetricStats
     metric: !name:train.pesq_eval
     n_jobs: 30
 err_rate_stats: !name:speechbrain.utils.metric_stats.ErrorRateStats
+    merge_tokens: True
+    space_token: " "
 
 train_logger: !new:speechbrain.utils.train_logger.FileTrainLogger
     save_file: !ref <train_log>

--- a/speechbrain/dataio/dataio.py
+++ b/speechbrain/dataio/dataio.py
@@ -965,7 +965,7 @@ def merge_char(sequences, space="_"):
     """
     results = []
     for seq in sequences:
-        words = "".join(seq).split("_")
+        words = "".join(seq).split(space)
         results.append(words)
     return results
 
@@ -1035,6 +1035,6 @@ def split_word(sequences, space="_"):
     """
     results = []
     for seq in sequences:
-        chars = list("_".join(seq))
+        chars = list(space.join(seq))
         results.append(chars)
     return results

--- a/speechbrain/utils/metric_stats.py
+++ b/speechbrain/utils/metric_stats.py
@@ -160,6 +160,16 @@ class ErrorRateStats(MetricStats):
     merge_tokens : bool
         Whether to merge the successive tokens (used for e.g.,
         creating words out of character tokens).
+        See ``speechbrain.dataio.dataio.merge_char``.
+    split_tokens : bool
+        Whether to split tokens (used for e.g. creating
+        characters out of word tokens).
+        See ``speechbrain.dataio.dataio.split_word``.
+    space_token : str
+        The character to use for boundaries. Used with ``merge_tokens``
+        this represents character to split on after merge.
+        Used with ``split_tokens`` the sequence is joined with
+        this token in between, and then the whole sequence is split.
 
     Example
     -------
@@ -183,10 +193,11 @@ class ErrorRateStats(MetricStats):
     1
     """
 
-    def __init__(self, merge_tokens=False, split_tokens=False):
+    def __init__(self, merge_tokens=False, split_tokens=False, space_token="_"):
         self.clear()
         self.merge_tokens = merge_tokens
         self.split_tokens = split_tokens
+        self.space_token = space_token
 
     def append(
         self,
@@ -232,12 +243,12 @@ class ErrorRateStats(MetricStats):
             target = ind2lab(target)
 
         if self.merge_tokens:
-            predict = merge_char(predict)
-            target = merge_char(target)
+            predict = merge_char(predict, space=self.space_token)
+            target = merge_char(target, space=self.space_token)
 
         if self.split_tokens:
-            predict = split_word(predict)
-            target = split_word(target)
+            predict = split_word(predict, space=self.space_token)
+            target = split_word(target, space=self.space_token)
 
         scores = wer_details_for_batch(ids, target, predict, True)
 


### PR DESCRIPTION
Bug with merging and splitting tokens, used by error rate metrics. Also add option to use different character in the merging and splitting, and use this new functionality to fix the mimic loss recipe.