### PR TITLE
Implicitly discover doctests so we follow rules in conftest.py

### DIFF
--- a/tests/.run-doctests.sh
+++ b/tests/.run-doctests.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
 set -e -u -o pipefail
 
-# It is ugly but currently we have to specifically filter out transducer loss here.
-# Otherwise pytest will stubbornly fail on import if you don't have numba.
-# (In contrast, implicitly discovered files which produce ImportErrors are ignored.)
-git ls-files speechbrain | grep -e "\.py$" | grep -v "transducer_loss.py" | xargs pytest --doctest-modules
+pytest --doctest-modules speechbrain/

--- a/tests/.run-doctests.sh
+++ b/tests/.run-doctests.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 set -e -u -o pipefail
 
-pytest --doctest-modules speechbrain/
+# We filter out tests that require not mandatory dependencies.
+avoid="transducer_loss.py\|fairseq_wav2vec.py\|huggingface_wav2vec.py"
+git ls-files speechbrain | grep -e "\.py$" | grep -v $avoid | xargs pytest --doctest-modules

--- a/tests/.run-doctests.sh
+++ b/tests/.run-doctests.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e -u -o pipefail
 
-# We filter out tests that require not mandatory dependencies.
+# To run doctests locally, the easiest approach is to do:
+# > pytest --doctest-modules speechbrain/
+# However, we take this more complex approach to avoid testing files not
+# tracked by git. We filter out tests that require optional dependencies.
 avoid="transducer_loss.py\|fairseq_wav2vec.py\|huggingface_wav2vec.py"
 git ls-files speechbrain | grep -e "\.py$" | grep -v $avoid | xargs pytest --doctest-modules


### PR DESCRIPTION
Doctests are failing locally due to failure to skip tests that require `fairseq`. I'm not sure why this is working on GitHub CI, its possible `fairseq` is getting installed. This fix just uses automatic docstring discovery to run the tests, but I'm not sure why the old approach was used, so maybe we need a different approach to fixing this.

We also need to decide if we want these tests to be run on GitHub (if they aren't already).