### PR TITLE
Add action for when a release is published

### DIFF
--- a/.github/workflows/mainmerge.yml
+++ b/.github/workflows/mainmerge.yml
@@ -1,0 +1,20 @@
+name: "Draft release when pushing to main"
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - "main"
+
+jobs:
+  pre-release:
+    name: "Draft release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: "marvinpinto/action-automatic-releases@v1.1.2"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          draft: True
+          prerelease: False
+          title: "Change this to vX.Y.Z"

--- a/.github/workflows/newtag.yml
+++ b/.github/workflows/newtag.yml
@@ -1,9 +1,9 @@
-name: "Draft release when pushing to main"
+name: "Draft release when pushing new tag"
 
 on:  # yamllint disable-line rule:truthy
   push:
-    branches:
-      - "main"
+    tags:
+      - "v*"
 
 jobs:
   pre-release:
@@ -11,10 +11,8 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - uses: "marvinpinto/action-automatic-releases@v1.1.2"
+      - uses: "marvinpinto/action-automatic-releases@v1.2.0"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "latest"
           draft: True
           prerelease: False
-          title: "Change this to vX.Y.Z"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+# Automatically publish to PyPI when a GitHub release is published
+name: Publish to PyPI
+
+# Run this action when a release is published
+on:  # yamllint disable-line rule:truthy
+  release:
+    types: [published]
+
+# Updates version.txt, builds, and pushes to PyPI
+jobs:
+  release:
+    name: Builds and publishes to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: main
+      - uses: actions/setup-python@v2
+      - uses: battila7/get-version-action@v2
+      - name: Update version.txt
+        run: |
+          echo ${{ steps.get_version.outputs.version-without-v }} > speechbrain/version.txt
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add speechbrain/version.txt
+          git commit -m 'Auto-update version.txt'
+          git push
+      - name: Install pypa/build
+        run: python -m pip install build --user
+      - name: Build binary wheel and source tarball
+        run: python -m build --sdist --wheel --outdir dist/
+      - name: Publish to PyPI
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
         with:
           ref: main
       - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
       - uses: battila7/get-version-action@v2
       - name: Update version.txt
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - uses: battila7/get-version-action@v2
-      - name: Update version.txt
-        run: |
-          echo ${{ steps.get_version.outputs.version-without-v }} > speechbrain/version.txt
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git add speechbrain/version.txt
-          git commit -m 'Auto-update version.txt'
-          git push
       - name: Install pypa/build
         run: python -m pip install build --user
       - name: Build binary wheel and source tarball

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -133,7 +133,7 @@ and where the implemented algorithm needs clarification.
 - The CI pipeline is triggered by pull requests.
 - Runs in a Ubuntu environment provided by GitHub
 - GitHub offers a limited amount of CI pipeline minutes for free.
-- CD would stand for continuous deployment, though we’re not doing that yet
+- CD stands for continuous deployment, check out the "Releasing a new version" section.
 
 ### Our test suite
 - Code linters are run. This means black and flake8. These are run on everything in speechbrain (the library directory), everything in recipes and everything in tests.
@@ -172,3 +172,43 @@ Fifthly, the code review is a place for professional constructive criticism,
 a nice strategy to show (and validate) that you understand what the PR is really
 doing is to provide some affirmative comments on its strengths.
 
+## Releasing a new version
+
+Here are a few guidelines for when and how to release a new version.
+To begin with, as hinted in the "Continuous Integration" section, we would like to follow a
+pretty tight release schedule, known as "Continuous Deployment". For us, this means a new
+version should be released roughly once a week.
+
+As for how to name the released version, we try to follow semantic versioning for this. More details
+can be found at [semver.org](http://semver.org). As it applies to SpeechBrain, some examples
+of what this would likely mean:
+ * Changes to the Brain class or other core elements often warrant a major version bump (e.g. 1.5.3 -> 2.0.0)
+ * Added classes or features warrant a minor version bump. Most weekly updates should fall into this.
+ * Patch version bumps should happen only for bug fixes.
+
+When releasing a new version, there are only two user-initiated action that need to occur.
+First, the `develop` branch should be merged to the `main` branch. This means that
+the `main` branch now includes the latest changes to the repository. Second,
+the `main` branch should be tagged with the new version. This is done by
+navigating to the `Releases` page, drafting a new release, and publishing it.
+
+The published release should include a summary of changes from the prior
+version. We have created a GitHub action that is run when the `develop`
+branch is merged with the `main` branch that creates a draft release
+titled "Latest". This draft release should include commits since
+the previous release, but will require some editing to summarize or
+highlight important changes.
+
+Publishing a new release kicks off a series of automatic tools, listed below:
+
+ * The file `version.txt` gets updated with the version (excluding "v") named
+   in the release. This update gets pushed to both `main` and `develop` branches.
+ * The `main` branch is checked out and used for building a python package.
+ * The built package is uploaded to PyPI and the release is published there.
+ * Read the Docs uses Webhooks to get notified when a new version is published.
+   Read the Docs then builds the documentation and publishes the new version.
+
+Maintainers of relevant accounts:
+ * Mirco Ravanelli maintains the GitHub and PyPI accounts
+ * Titouan Parcollet maintains the website at [speechbrain.github.io](speechbrain.github.io)
+   as well as accounts at Read the Docs and Discourse

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -186,23 +186,24 @@ of what this would likely mean:
  * Added classes or features warrant a minor version bump. Most weekly updates should fall into this.
  * Patch version bumps should happen only for bug fixes.
 
-When releasing a new version, there are only two user-initiated action that need to occur.
-First, the `develop` branch should be merged to the `main` branch. This means that
-the `main` branch now includes the latest changes to the repository. Second,
-the `main` branch should be tagged with the new version. This is done by
-navigating to the `Releases` page, drafting a new release, and publishing it.
+When releasing a new version, there are a few user-initiated action that need to occur.
+ 1. On the `develop` branch, update `speechbrain/version.txt` to say the new version:
+    X.Y.Z
+ 2. Merge the `develop` branch into the `main` branch:
+    git checkout main
+    git merge develop
+ 3. Push the `main` branch to github:
+    git push
+ 4. Tag the `main` branch with the new version:
+    git tag vX.Y.Z
+ 5. Push the new tag to github:
+    git push --tags
 
-The published release should include a summary of changes from the prior
-version. We have created a GitHub action that is run when the `develop`
-branch is merged with the `main` branch that creates a draft release
-titled "Latest". This draft release should include commits since
-the previous release, but will require some editing to summarize or
-highlight important changes.
-
+This kicks off an automatic action that creates a draft release with release notes.
+Review the notes to make sure they make sense and remove commits that aren't important.
+You can then publish the release to make it public.
 Publishing a new release kicks off a series of automatic tools, listed below:
 
- * The file `version.txt` gets updated with the version (excluding "v") named
-   in the release. This update gets pushed to both `main` and `develop` branches.
  * The `main` branch is checked out and used for building a python package.
  * The built package is uploaded to PyPI and the release is published there.
  * Read the Docs uses Webhooks to get notified when a new version is published.


### PR DESCRIPTION
We need to automate the process of creating a new version as much as possible, because there's a bunch of parts and its easy to miss one. This PR is an attempt to reduce user workload to solely creating a new release tag on GitHub.

Things that need to happen each time we tag a new released version on GitHub:
- [x] Update `speechbrain/version.txt`
- [x] Push new `version.txt` to `main`
- [ ] Push new `version.txt` to `develop`
- [x] Build distribution files
- [x] Upload to PyPI

So far this PR just updates `version.txt` and pushes to `main` and builds and uploads to PyPI.

I think that since Mirco owns the PyPI account he's the one that has to create the PyPI API token and add it as a secret token on GitHub i.e. `PYPI_API_KEY`.

Also, I'm not sure exactly how we test this without just merging it and creating a new tag.