### PR TITLE
add bleu script

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -11,3 +11,7 @@ try:
     from transformers import Wav2Vec2Model  # noqa: F401
 except ModuleNotFoundError:
     collect_ignore.append("speechbrain/lobes/models/huggingface_wav2vec.py")
+try:
+    import sacrebleu  # noqa: F401
+except ModuleNotFoundError:
+    collect_ignore.append("speechbrain/utils/bleu.py")

--- a/docs/docs-requirements.txt
+++ b/docs/docs-requirements.txt
@@ -1,6 +1,6 @@
 better-apidoc>=0.3.1
+numba
 recommonmark>=0.7.1
+six
 sphinx-rtd-theme>=0.4.3
 Sphinx>=3.4.3
-six
-numba

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ joblib>=0.14.1
 numpy>=1.17.0
 packaging
 pre-commit>=2.3.0
-sacrebleu>=1.5.1
 scipy>=1.4.1
 sentencepiece>=0.1.91
 SoundFile; sys_platform == 'win32'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,14 @@
 -r lint-requirements.txt
+huggingface_hub>=0.0.6
 hyperpyyaml>=0.0.1
 joblib>=0.14.1
 numpy>=1.17.0
 packaging
 pre-commit>=2.3.0
+sacrebleu>=1.5.1
 scipy>=1.4.1
 sentencepiece>=0.1.91
+SoundFile; sys_platform == 'win32'
 torch>=1.7.1
 torchaudio>=0.7.2
 tqdm>=4.42.0
-huggingface_hub>=0.0.6
-SoundFile; sys_platform == 'win32'

--- a/speechbrain/utils/bleu.py
+++ b/speechbrain/utils/bleu.py
@@ -3,12 +3,7 @@ from speechbrain.utils.metric_stats import MetricStats
 try:
     import sacrebleu
 except ImportError:
-    import pip
-
-    pip.main(["install", "sacrebleu"])
-    import sacrebleu
-
-    # raise ImportError("Please install sacrebleu (https://github.com/mjpost/sacreble) in order to use the BLEU metric")
+    print("Please install sacrebleu (https://github.com/mjpost/sacreble) in order to use the BLEU metric")
 
 
 def merge_words(sequences):

--- a/speechbrain/utils/bleu.py
+++ b/speechbrain/utils/bleu.py
@@ -3,7 +3,10 @@ from speechbrain.utils.metric_stats import MetricStats
 try:
     import sacrebleu
 except ImportError:
-    print("Please install sacrebleu (https://github.com/mjpost/sacreble) in order to use the BLEU metric")
+
+    print(
+        "Please install sacrebleu (https://github.com/mjpost/sacreble) in order to use the BLEU metric"
+    )
 
 
 def merge_words(sequences):

--- a/speechbrain/utils/bleu.py
+++ b/speechbrain/utils/bleu.py
@@ -3,12 +3,12 @@ from speechbrain.utils.metric_stats import MetricStats
 try:
     import sacrebleu
 except ImportError:
-    print(
-        "Please install sacrebleu (https://github.com/mjpost/sacreble) in order to use the BLEU metric"
-    )
-    import sys
+    import pip
 
-    sys.exit()
+    pip.main(["install", "sacrebleu"])
+    import sacrebleu
+
+    # raise ImportError("Please install sacrebleu (https://github.com/mjpost/sacreble) in order to use the BLEU metric")
 
 
 def merge_words(sequences):

--- a/speechbrain/utils/bleu.py
+++ b/speechbrain/utils/bleu.py
@@ -1,0 +1,149 @@
+import sacrebleu
+import torch
+from speechbrain.dataio.dataio import merge_char
+from speechbrain.utils.metric_stats import MetricStats
+
+def merge_words(sequences):
+    results = []
+    for seq in sequences:
+        words = " ".join(seq)
+        results.append(words)
+    return results
+
+def detokenize_batch(detokenizer, sentences):
+    """
+    detokenizer: object
+        Detokenizer to be used
+    sentences: list
+        List of sentences to de detokenzied
+    """
+    detok_sentences = []
+    for sentence in sentences:
+        sentence = detokenizer.detokenize(sentence)
+        detok_sentences.append(sentence)
+
+    return detok_sentences
+
+class BLEUStats(MetricStats):
+    """A class for tracking BLEU.
+    Arguments
+    ---------
+    merge_tokens : bool
+        Whether to merge the successive tokens (used for e.g.,
+        creating words out of character tokens).
+        See ``speechbrain.dataio.dataio.merge_char``.
+    merge_words: bool
+        Whether to merge the successive tokens (used for e.g.,
+        creating words out of character tokens).
+    split_tokens : bool
+        Whether to split tokens (used for e.g. creating
+        characters out of word tokens).
+        See ``speechbrain.dataio.dataio.split_word``.
+    space_token : str
+        The character to use for boundaries. Used with ``merge_tokens``
+        this represents character to split on after merge.
+        Used with ``split_tokens`` the sequence is joined with
+        this token in between, and then the whole sequence is split.
+    Example
+    -------
+    >>> bleu = BLEUStats()
+    >>> i2l = {0: 'a', 1: 'b'}
+    >>> bleu.append(
+    ...     ids=['utterance1'],
+    ...     predict=torch.tensor([[0, 1, 1]]),
+    ...     target=torch.tensor([[0, 1, 0]]),
+    ...     ind2lab=lambda batch: [[i2l[int(x)] for x in seq] for seq in batch],
+    ... )
+    >>> stats = bleu.summarize()
+    >>> stats['BLEU']
+    0.0
+    """
+
+    def __init__(self, lang='en', merge_words=True, merge_tokens=False, split_tokens=False, space_token="_"):
+        self.clear()
+        self.merge_words = merge_words
+        self.merge_tokens = merge_tokens
+        self.split_tokens = split_tokens
+        self.space_token = space_token
+
+        self.predicts = []
+        self.targets = []
+        
+
+    def append(
+        self,
+        ids,
+        predict,
+        target,
+        ind2lab=None,
+    ):
+        """Add stats to the relevant containers.
+        * See MetricStats.append()
+        Arguments
+        ---------
+        ids : list
+            List of ids corresponding to utterances.
+        predict : torch.tensor
+            A predicted output, for comparison with the target output
+        target : torch.tensor
+            The correct reference output, for comparison with the prediction.
+        ind2lab : callable
+            Callable that maps from indices to labels, operating on batches,
+            for writing alignments.
+        """
+        self.ids.extend(ids)
+        
+        if ind2lab is not None:
+            predict = ind2lab(predict)
+            target = ind2lab(target)
+
+        if self.merge_tokens:
+            predict = merge_char(predict, space=self.space_token)
+            target = merge_char(target, space=self.space_token)
+
+        if self.split_tokens:
+            predict = split_word(predict, space=self.space_token)
+            target = split_word(target, space=self.space_token)
+        
+        if self.merge_words:
+            predict = merge_words(predict)
+            target = merge_words(target)
+
+        self.predicts.extend(predict)
+        self.targets.extend(target)
+
+
+    def summarize(self, field=None):
+        """Summarize the BLEU and return relevant statistics.
+        * See MetricStats.summarize()
+        """
+ 
+        scores = sacrebleu.corpus_bleu(self.predicts, [self.targets])
+        details = {}
+        details['BLEU'] = scores.score
+        details['BP'] = scores.bp
+        details['ratio'] = scores.sys_len / scores.ref_len
+        details['hyp_len'] = scores.sys_len
+        details['ref_len'] = scores.ref_len
+        details['precisions'] = scores.precisions
+        
+        self.scores = scores
+        self.summary = details
+
+        # Add additional, more generic key
+        self.summary["bleu_score"] = self.summary["BLEU"]
+
+        if field is not None:
+            return self.summary[field]
+        else:
+            return self.summary
+
+    def write_stats(self, filestream):
+        """Write all relevant info (e.g., error rate alignments) to file.
+        * See MetricStats.write_stats()
+        """
+        if not self.summary:
+            self.summarize()
+        
+        print(self.scores, file=filestream)
+

--- a/tests/.run-doctests.sh
+++ b/tests/.run-doctests.sh
@@ -5,5 +5,5 @@ set -e -u -o pipefail
 # > pytest --doctest-modules speechbrain/
 # However, we take this more complex approach to avoid testing files not
 # tracked by git. We filter out tests that require optional dependencies.
-avoid="transducer_loss.py\|fairseq_wav2vec.py\|huggingface_wav2vec.py"
+avoid="transducer_loss.py\|fairseq_wav2vec.py\|huggingface_wav2vec.py\|bleu.py"
 git ls-files speechbrain | grep -e "\.py$" | grep -v $avoid | xargs pytest --doctest-modules


### PR DESCRIPTION
This PR introduces a BLEU measuring script, which exploits sacrebleu (https://github.com/mjpost/sacrebleu) to measure BLEU scores for Speech Translation tasks. It is therefore necessary to install sacrebleu for the script to work:

`pip install sacrebleu`