### PR TITLE
fixed incorrect argument order in docstring example

### DIFF
--- a/recipes/LibriSpeech/librispeech_prepare.py
+++ b/recipes/LibriSpeech/librispeech_prepare.py
@@ -73,9 +73,11 @@ def prepare_librispeech(
     Example
     -------
     >>> data_folder = 'datasets/LibriSpeech'
-    >>> splits = ['train-clean-100', 'dev-clean', 'test-clean']
+    >>> tr_splits = ['train-clean-100']
+    >>> dev_splits = ['dev-clean']
+    >>> te_splits = ['test-clean']
     >>> save_folder = 'librispeech_prepared'
-    >>> prepare_librispeech(data_folder, save_folder, splits)
+    >>> prepare_librispeech(data_folder, tr_splits, dev_splits, te_splits, save_folder)
     """
 
     if skip_prep:

--- a/recipes/LibriSpeech/librispeech_prepare.py
+++ b/recipes/LibriSpeech/librispeech_prepare.py
@@ -75,7 +75,7 @@ def prepare_librispeech(
     >>> data_folder = 'datasets/LibriSpeech'
     >>> splits = ['train-clean-100', 'dev-clean', 'test-clean']
     >>> save_folder = 'librispeech_prepared'
-    >>> prepare_librispeech(data_folder, splits, save_folder)
+    >>> prepare_librispeech(data_folder, save_folder, splits)
     """
 
     if skip_prep:


### PR DESCRIPTION
The order of the function arguments in the docstring example for `prepare_librispeech()` were in the wrong order (`splits` before `save_folder`)  - I have corrected the docstring to reflect the correct order. 