### PR TITLE
CTC segmentation for Speechbrain

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -43,7 +43,8 @@ jobs:
             - name: Full dependencies
               run: |
                   pip install -r requirements.txt
-                  pip install --editable .[full]
+                  pip install --editable .
+                  pip install ctc-segmentation
             - name: Unittests with pytest
               run: |
                   pytest tests/unittests

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -43,7 +43,7 @@ jobs:
             - name: Full dependencies
               run: |
                   pip install -r requirements.txt
-                  pip install --editable .
+                  pip install --editable .[full]
             - name: Unittests with pytest
               run: |
                   pytest tests/unittests

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         "tqdm",
         "huggingface_hub",
     ],
-    extras_require={"full": ["ctc-segmentation<1.8,>=1.6.6"],},  # noqa: E231
     python_requires=">=3.7",
     url="https://speechbrain.github.io/",
 )

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "tqdm",
         "huggingface_hub",
     ],
+    extras_require={"full": ["ctc-segmentation<1.8,>=1.6.6"],},  # noqa: E231
     python_requires=">=3.7",
     url="https://speechbrain.github.io/",
 )

--- a/speechbrain/alignment/ctc_segmentation.py
+++ b/speechbrain/alignment/ctc_segmentation.py
@@ -1,0 +1,655 @@
+#!/usr/bin/env python3
+# 2021, Technische Universität München, Ludwig Kürzinger
+"""Perform CTC segmentation to align utterances within audio files."""
+
+import logging
+from pathlib import Path
+from typing import Optional
+from typing import Union
+
+import numpy as np
+import torch
+from typeguard import check_argument_types
+from typeguard import check_return_type
+from typing import List
+
+# speechbrain interface
+from speechbrain.pretrained.interfaces import EncoderDecoderASR
+
+# imports for CTC segmentation
+from ctc_segmentation import ctc_segmentation
+from ctc_segmentation import CtcSegmentationParameters
+from ctc_segmentation import determine_utterance_segments
+from ctc_segmentation import prepare_text
+from ctc_segmentation import prepare_token_list
+
+logger = logging.getLogger(__name__)
+
+
+class CTCSegmentationTask:
+    """Task object for CTC segmentation.
+
+    When formatted with str(·), this object returns
+    results in a kaldi-style segments file formatting.
+    The human-readable output can be configured with
+    the printing options.
+
+    Properties
+    ----------
+    text : list
+        Utterance texts, separated by line. But without the utterance
+            name at the beginning of the line (as in kaldi-style text).
+    ground_truth_mat
+        Ground truth matrix (CTC segmentation).
+    utt_begin_indices
+        Utterance separator for the Ground truth matrix.
+    timings
+        Time marks of the corresponding chars.
+    state_list
+        Estimated alignment of chars/tokens.
+    segments
+        Calculated segments as: (start, end, confidence score).
+    config
+        CTC Segmentation configuration object.
+    name
+        Name of aligned audio file (Optional). If given, name is
+        considered when generating the text.
+    utt_ids
+        The list of utterance names (Optional). This list should
+        have the same length as the number of utterances.
+    lpz
+        CTC posterior log probabilities (Optional).
+
+    Properties for printing
+    -----------------------
+    print_confidence_score
+        Includes the confidence score.
+    print_utterance_text
+        Includes utterance text.
+
+
+    """
+
+    text = None
+    ground_truth_mat = None
+    utt_begin_indices = None
+    timings = None
+    char_probs = None
+    state_list = None
+    segments = None
+    config = None
+    done = False
+    # Optional
+    name = "utt"
+    utt_ids = None
+    lpz = None
+    # Printing
+    print_confidence_score = True
+    print_utterance_text = True
+
+    def __init__(self, **kwargs):
+        """Initialize the module."""
+        self.set(**kwargs)
+
+    def set(self, **kwargs):
+        """Update properties.
+
+        Args:
+        **kwargs
+            Key-value dict that contains all properties
+            with their new values. Unknown properties are ignored.
+        """
+        for key in kwargs:
+            if (
+                not key.startswith("_")
+                and hasattr(self, key)
+                and kwargs[key] is not None
+            ):
+                setattr(self, key, kwargs[key])
+
+    def __str__(self):
+        """Return a kaldi-style ``segments`` file (string)."""
+        output = ""
+        num_utts = len(self.segments)
+        if self.utt_ids is None:
+            utt_names = [f"{self.name}_{i:04}" for i in range(num_utts)]
+        else:
+            # ensure correct mapping of segments to utterance ids
+            assert num_utts == len(self.utt_ids)
+            utt_names = self.utt_ids
+        for i, boundary in enumerate(self.segments):
+            # utterance name and file name
+            utt_entry = f"{utt_names[i]} {self.name} "
+            # segment start and end
+            utt_entry += f"{boundary[0]:.2f} {boundary[1]:.2f}"
+            # confidence score
+            if self.print_confidence_score:
+                utt_entry += f" {boundary[2]:3.4f}"
+            # utterance ground truth
+            if self.print_utterance_text:
+                utt_entry += f" {self.text[i]}"
+            output += utt_entry + "\n"
+        return output
+
+
+class CTCSegmentation:
+    """Align text to audio using CTC segmentation.
+
+    Usage
+    -----
+    Initialize with given ASR model and parameters.
+    If needed, parameters for CTC segmentation can be set with ``set_config(·)``.
+    Then call the instance as function to align text within an audio file.
+
+    Example
+    -------
+        >>> # using example file included in the SpeechBrain repository
+        >>> from speechbrain.pretrained import EncoderDecoderASR
+        >>> from speechbrain.alignment.ctc_segmentation import CTCSegmentation
+        >>> # load an ASR model
+        >>> pre_trained = "speechbrain/asr-transformer-transformerlm-librispeech"
+        >>> asr_model = EncoderDecoderASR.from_hparams(source=pre_trained)
+        >>> aligner = CTCSegmentation(asr_model, kaldi_style_text=False)
+        >>> # load data
+        >>> audio_path = "./samples/audio_samples/example1.wav"
+        >>> text = ["THE BIRCH CANOE", "SLID ON THE", "SMOOTH PLANKS"]
+        >>> segments = aligner(audio_path, text, name="example1")
+        >>> print( segments )
+        example1_0000 example1 0.04 0.70 -0.0304 THE BIRCH CANOE
+        example1_0001 example1 0.97 1.97 -0.0131 SLID ON THE
+        example1_0002 example1 1.97 3.00 -0.0375 SMOOTH PLANKS
+        <BLANKLINE>
+
+    On multiprocessing
+    ------------------
+    To parallelize the computation with multiprocessing, these three steps
+    can be separated:
+    (1) ``get_lpz``: obtain the lpz,
+    (2) ``prepare_segmentation_task``: prepare the task, and
+    (3) ``get_segments``: perform CTC segmentation.
+    Note that the function `get_segments` is a staticmethod and therefore
+    independent of an already initialized CTCSegmentation obj́ect.
+
+    References
+    ----------
+    CTC-Segmentation of Large Corpora for German End-to-end Speech Recognition
+    2020, Kürzinger, Winkelbauer, Li, Watzel, Rigoll
+    https://arxiv.org/abs/2007.09127
+
+    More parameters are described in https://github.com/lumaku/ctc-segmentation
+
+    """
+
+    samples_to_frames_ratio = None
+    time_stamps = "auto"
+    choices_time_stamps = ["auto", "fixed"]
+    text_converter = "tokenize"
+    choices_text_converter = ["tokenize", "classic"]
+    warned_about_misconfiguration = False
+    config = CtcSegmentationParameters()
+
+    def __init__(
+        self,
+        asr_model: EncoderDecoderASR,
+        kaldi_style_text: bool = True,
+        text_converter: str = "tokenize",
+        time_stamps: str = "auto",
+        **ctc_segmentation_args,
+    ):
+        """Initialize the CTCSegmentation module.
+
+        Args
+        ----
+        asr_model : EncoderDecoderASR
+            Speechbrain ASR interface. This requires a model that has a
+            trained CTC layer for inference. It is better to use a model with
+            single-character tokens to get a better time resolution.
+            Please note that the inference complexity with Transformer models
+            usually increases quadratically with audio length.
+            It is therefore recommended to use RNN-based models, if available.
+        kaldi_style_text : bool
+            A kaldi-style text file includes the name of the
+            utterance at the start of the line. If True, the utterance name
+            is expected as first word at each line. If False, utterance
+            names are automatically generated. Set this option according to
+            your input data. Default: True.
+        text_converter : str
+            How CTC segmentation handles text.
+            "tokenize": Use the ASR model tokenizer to tokenize the text.
+            "classic": The text is preprocessed as text pieces which takes
+            token length into account. If the ASR model has longer tokens,
+            this option may yield better results. Default: "tokenize".
+        time_stamps : str
+            Choose the method how the time stamps are
+            calculated. While "fixed" and "auto" use both the sample rate,
+            the ratio of samples to one frame is either automatically
+            determined for each inference or fixed at a certain ratio that
+            is initially determined by the module, but can be changed via
+            the parameter ``samples_to_frames_ratio``. Recommended for
+            longer audio files: "auto".
+        **ctc_segmentation_args
+            Parameters for CTC segmentation.
+        """
+        assert check_argument_types()
+
+        # Prepare ASR model
+        if not (
+            hasattr(asr_model, "modules")
+            and hasattr(asr_model.modules, "decoder")
+            and hasattr(asr_model.modules.decoder, "ctc_weight")
+            and asr_model.modules.decoder.ctc_weight != 0.0
+        ):
+            raise AttributeError(
+                "The given asr_model has no CTC decoder in asr_model.modules.decoder!"
+            )
+        if not hasattr(asr_model, "tokenizer"):
+            raise AttributeError(
+                "The given asr_model has no tokenizer in asr_model.tokenizer!"
+            )
+        self.asr_model = asr_model
+        self._encode = self.asr_model.encode_batch
+        # Assumption: log-softmax is already included in ctc_forward_step
+        self._ctc = self.asr_model.modules.decoder.ctc_forward_step
+        self._tokenizer = self.asr_model.tokenizer
+
+        # Apply configuration
+        self.set_config(
+            fs=self.asr_model.hparams.sample_rate,
+            time_stamps=time_stamps,
+            kaldi_style_text=kaldi_style_text,
+            text_converter=text_converter,
+            **ctc_segmentation_args,
+        )
+
+        # determine token or character list
+        char_list = [
+            asr_model.tokenizer.id_to_piece(i)
+            for i in range(asr_model.hparams.vocab_size)
+        ]
+        self.config.char_list = char_list
+
+        # Warn about possible misconfigurations
+        max_char_len = max([len(c) for c in char_list])
+        if len(char_list) > 500 and max_char_len >= 8:
+            logger.warning(
+                f"The dictionary has {len(char_list)} tokens with "
+                f"a max length of {max_char_len}. This may lead "
+                f"to low alignment performance and low accuracy."
+            )
+
+    def set_config(self, **kwargs):
+        """Set CTC segmentation parameters.
+
+        Parameters for timing
+        ---------------------
+        time_stamps : str
+            Select method how CTC index duration is estimated, and
+            thus how the time stamps are calculated.
+        fs : int
+            Sample rate. Usually derived from ASR model; use this parameter
+            to overwrite the setting.
+        samples_to_frames_ratio : int
+            If you want to directly determine the
+            ratio of samples to CTC frames, set this parameter, and
+            set ``time_stamps`` to "fixed".
+            Note: If you want to calculate the time stamps from a model
+            with fixed subsampling, set this parameter to:
+            ``subsampling_factor * frame_duration / 1000``.
+
+        Parameters for text preparation
+        -------------------------------
+        set_blank : int
+            Index of blank in token list. Default: 0.
+        replace_spaces_with_blanks : bool
+            Inserts blanks between words, which is
+            useful for handling long pauses between words. Only used in
+            ``text_converter="classic"`` preprocessing mode. Default: False.
+        kaldi_style_text : bool
+            Determines whether the utterance name is expected
+            as fist word of the utterance. Set at module initialization.
+        text_converter : str
+            How CTC segmentation handles text.
+            Set at module initialization.
+
+        Parameters for alignment
+        ------------------------
+        min_window_size : int
+            Minimum number of frames considered for a single
+            utterance. The current default value of 8000 corresponds to
+            roughly 4 minutes (depending on ASR model) and should be OK in
+            most cases. If your utterances are further apart, increase
+            this value, or decrease it for smaller audio files.
+        max_window_size : int
+            Maximum window size. It should not be necessary
+            to change this value.
+        gratis_blank : bool
+            If True, the transition cost of blank is set to zero.
+            Useful for long preambles or if there are large unrelated segments
+            between utterances. Default: False.
+
+        Parameters for calculation of confidence score
+        ----------------------------------------------
+        scoring_length : int
+            Block length to calculate confidence score. The
+            default value of 30 should be OK in most cases.
+            30 corresponds to roughly 1-2s of audio.
+        """
+        # Parameters for timing
+        if "time_stamps" in kwargs:
+            if kwargs["time_stamps"] not in self.choices_time_stamps:
+                raise NotImplementedError(
+                    f"Parameter ´time_stamps´ has to be one of "
+                    f"{list(self.choices_time_stamps)}",
+                )
+            self.time_stamps = kwargs["time_stamps"]
+        if "fs" in kwargs:
+            self.fs = float(kwargs["fs"])
+        if "samples_to_frames_ratio" in kwargs:
+            self.samples_to_frames_ratio = float(
+                kwargs["samples_to_frames_ratio"]
+            )
+        # Parameters for text preparation
+        if "set_blank" in kwargs:
+            assert isinstance(kwargs["set_blank"], int)
+            self.config.blank = kwargs["set_blank"]
+        if "replace_spaces_with_blanks" in kwargs:
+            self.config.replace_spaces_with_blanks = bool(
+                kwargs["replace_spaces_with_blanks"]
+            )
+        if "kaldi_style_text" in kwargs:
+            assert isinstance(kwargs["kaldi_style_text"], bool)
+            self.kaldi_style_text = kwargs["kaldi_style_text"]
+        if "text_converter" in kwargs:
+            if kwargs["text_converter"] not in self.choices_text_converter:
+                raise NotImplementedError(
+                    f"Parameter ´text_converter´ has to be one of "
+                    f"{list(self.choices_text_converter)}",
+                )
+            self.text_converter = kwargs["text_converter"]
+        # Parameters for alignment
+        if "min_window_size" in kwargs:
+            assert isinstance(kwargs["min_window_size"], int)
+            self.config.min_window_size = kwargs["min_window_size"]
+        if "max_window_size" in kwargs:
+            assert isinstance(kwargs["max_window_size"], int)
+            self.config.max_window_size = kwargs["max_window_size"]
+        if "gratis_blank" in kwargs:
+            self.config.blank_transition_cost_zero = bool(
+                kwargs["gratis_blank"]
+            )
+        if (
+            self.config.blank_transition_cost_zero
+            and self.config.replace_spaces_with_blanks
+            and not self.warned_about_misconfiguration
+        ):
+            logger.error(
+                "Blanks are inserted between words, and also the transition cost of"
+                " blank is zero. This configuration may lead to misalignments!"
+            )
+            self.warned_about_misconfiguration = True
+        # Parameter for calculation of confidence score
+        if "scoring_length" in kwargs:
+            assert isinstance(kwargs["scoring_length"], int)
+            self.config.score_min_mean_over_L = kwargs["scoring_length"]
+
+    def get_timing_config(self, speech_len=None, lpz_len=None):
+        """Obtain parameters to determine time stamps."""
+        timing_cfg = {
+            "index_duration": self.config.index_duration,
+        }
+        # As the parameter ctc_index_duration vetoes the other
+        if self.time_stamps == "fixed":
+            # Initialize the value, if not yet available
+            if self.samples_to_frames_ratio is None:
+                ratio = self.estimate_samples_to_frames_ratio()
+                self.samples_to_frames_ratio = ratio
+            index_duration = self.samples_to_frames_ratio / self.fs
+        else:
+            assert self.time_stamps == "auto"
+            samples_to_frames_ratio = speech_len / lpz_len
+            index_duration = samples_to_frames_ratio / self.fs
+        timing_cfg["index_duration"] = index_duration
+        return timing_cfg
+
+    def estimate_samples_to_frames_ratio(self, speech_len=215040):
+        """Determine the ratio of encoded frames to sample points.
+
+        This method helps to determine the time a single encoded frame occupies.
+        As the sample rate already gave the number of samples, only the ratio
+        of samples per encoded CTC frame are needed. This function estimates them by
+        doing one inference, which is only needed once.
+
+        Args
+        ----
+        speech_len : int
+            Length of randomly generated speech vector for single
+            inference. Default: 215040.
+
+        Returns
+        -------
+        int
+            Estimated ratio.
+        """
+        random_input = torch.rand(speech_len)
+        lpz = self.get_lpz(random_input)
+        lpz_len = lpz.shape[0]
+        # CAVEAT assumption: Frontend does not discard trailing data!
+        samples_to_frames_ratio = speech_len // lpz_len
+        return samples_to_frames_ratio
+
+    @torch.no_grad()
+    def get_lpz(self, speech: Union[torch.Tensor, np.ndarray]):
+        """Obtain CTC posterior log probabilities for given speech data.
+
+        Args
+        ----
+        speech : Union[torch.Tensor, np.ndarray]
+            Speech audio input.
+
+        Returns
+        -------
+        np.ndarray
+            Numpy vector with CTC log posterior probabilities.
+        """
+        if isinstance(speech, np.ndarray):
+            speech = torch.tensor(speech)
+        # Batch data: (Nsamples,) -> (1, Nsamples)
+        speech = speech.unsqueeze(0).to(self.asr_model.device)
+        wav_lens = torch.tensor([1.0]).to(self.asr_model.device)
+        enc = self._encode(speech, wav_lens)
+        # Apply ctc layer to obtain log character probabilities
+        lpz = self._ctc(enc).detach()
+        #  Shape should be ( <time steps>, <classes> )
+        lpz = lpz.squeeze(0).cpu().numpy()
+        return lpz
+
+    def _split_text(self, text):
+        """Convert text to list and extract utterance IDs."""
+        utt_ids = None
+        # Handle multiline strings
+        if isinstance(text, str):
+            text = text.splitlines()
+        # Remove empty lines
+        text = list(filter(len, text))
+        # Handle kaldi-style text format
+        if self.kaldi_style_text:
+            utt_ids_and_text = [utt.split(" ", 1) for utt in text]
+            # remove utterances with empty text
+            utt_ids_and_text = filter(lambda ui: len(ui) == 2, utt_ids_and_text)
+            utt_ids_and_text = list(utt_ids_and_text)
+            utt_ids = [utt[0] for utt in utt_ids_and_text]
+            text = [utt[1] for utt in utt_ids_and_text]
+        return utt_ids, text
+
+    def prepare_segmentation_task(self, text, lpz, name=None, speech_len=None):
+        """Preprocess text, and gather text and lpz into a task object.
+
+        Text is pre-processed and tokenized depending on configuration.
+        If ``speech_len`` is given, the timing configuration is updated.
+        Text, lpz, and configuration is collected in a CTCSegmentationTask
+        object. The resulting object can be serialized and passed in a
+        multiprocessing computation.
+
+        It is recommended that you normalize the text beforehand, e.g.,
+        change numbers into their spoken equivalent word, remove special
+        characters, and convert UTF-8 characters to chars corresponding to
+        your ASR model dictionary.
+
+        The text is tokenized based on the ``text_converter`` setting:
+
+        The "tokenize" method is more efficient and the easiest for models
+        based on latin or cyrillic script that only contain the main chars,
+        ["a", "b", ...] or for Japanese or Chinese ASR models with ~3000
+        short Kanji / Hanzi tokens.
+
+        The "classic" method improves the the accuracy of the alignments
+        for models that contain longer tokens, but with a greater complexity
+        for computation. The function scans for partial tokens which may
+        improve time resolution.
+        For example, the word "▁really" will be broken down into
+        ``['▁', '▁r', '▁re', '▁real', '▁really']``. The alignment will be
+        based on the most probable activation sequence given by the network.
+
+        Args
+        ----
+        text : list
+            List or multiline-string with utterance ground truths.
+        lpz : np.ndarray
+            Log CTC posterior probabilities obtained from the CTC-network;
+            numpy array shaped as ( <time steps>, <classes> ).
+        name : str
+            Audio file name that will be included in the segments output.
+            Choose a unique name, or the original audio
+            file name, to distinguish multiple audio files. Default: None.
+        speech_len : int
+            Number of sample points. If given, the timing
+            configuration is automatically derived from length of fs, length
+            of speech and length of lpz. If None is given, make sure the
+            timing parameters are correct, see time_stamps for reference!
+            Default: None.
+
+        Returns
+        -------
+        CTCSegmentationTask
+            Task object that can be passed to
+            ``CTCSegmentation.get_segments()`` in order to obtain alignments.
+        """
+        config = self.config
+        # Update timing parameters, if needed
+        if speech_len is not None:
+            lpz_len = lpz.shape[0]
+            timing_cfg = self.get_timing_config(speech_len, lpz_len)
+            config.set(**timing_cfg)
+        # `text` is needed in the form of a list.
+        utt_ids, text = self._split_text(text)
+        # Obtain utterance & label sequence from text
+        if self.text_converter == "tokenize":
+            # list of str --tokenize--> list of np.array
+            token_list = [
+                np.array(self._tokenizer.encode_as_ids(utt)) for utt in text
+            ]
+            # filter out any instances of the <unk> token
+            unk = config.char_list.index("<unk>")
+            token_list = [utt[utt != unk] for utt in token_list]
+            ground_truth_mat, utt_begin_indices = prepare_token_list(
+                config, token_list
+            )
+        else:
+            assert self.text_converter == "classic"
+            text_pieces = [
+                "".join(self._tokenizer.encode_as_pieces(utt)) for utt in text
+            ]
+            # filter out any instances of the <unk> token
+            text_pieces = [utt.replace("<unk>", "") for utt in text_pieces]
+            ground_truth_mat, utt_begin_indices = prepare_text(
+                config, text_pieces
+            )
+        task = CTCSegmentationTask(
+            config=config,
+            name=name,
+            text=text,
+            ground_truth_mat=ground_truth_mat,
+            utt_begin_indices=utt_begin_indices,
+            utt_ids=utt_ids,
+            lpz=lpz,
+        )
+        return task
+
+    @staticmethod
+    def get_segments(task: CTCSegmentationTask):
+        """Obtain segments for given utterance texts and CTC log posteriors.
+
+        Args
+        ----
+        task : CTCSegmentationTask
+            Task object that contains ground truth and
+            CTC posterior probabilities.
+
+        Returns
+        -------
+        dict
+            Dictionary with alignments. Combine this with the task
+            object to obtain a human-readable segments representation.
+        """
+        assert check_argument_types()
+        assert task.config is not None
+        config = task.config
+        lpz = task.lpz
+        ground_truth_mat = task.ground_truth_mat
+        utt_begin_indices = task.utt_begin_indices
+        text = task.text
+        # Align using CTC segmentation
+        timings, char_probs, state_list = ctc_segmentation(
+            config, lpz, ground_truth_mat
+        )
+        # Obtain list of utterances with time intervals and confidence score
+        segments = determine_utterance_segments(
+            config, utt_begin_indices, char_probs, timings, text
+        )
+        # Store results
+        result = {
+            "name": task.name,
+            "timings": timings,
+            "char_probs": char_probs,
+            "state_list": state_list,
+            "segments": segments,
+            "done": True,
+        }
+        return result
+
+    def __call__(
+        self,
+        speech: Union[torch.Tensor, np.ndarray, str, Path],
+        text: Union[List[str], str],
+        name: Optional[str] = None,
+    ) -> CTCSegmentationTask:
+        """Align utterances.
+
+        Args
+        ----
+        speech : Union[torch.Tensor, np.ndarray, str, Path]
+            Audio file that can be given as path or as array.
+        text : Union[List[str], str]
+            List or multiline-string with utterance ground truths.
+            The required formatting depends on the setting ``kaldi_style_text``.
+        name : str
+            Name of the file. Utterance names are derived from it.
+
+        Returns
+        -------
+        CTCSegmentationTask
+            Task object with segments. Apply str(·) or print(·) on it
+            to obtain the segments list.
+        """
+        assert check_argument_types()
+        if isinstance(speech, str) or isinstance(speech, Path):
+            speech = self.asr_model.load_audio(speech)
+        # Get log CTC posterior probabilities
+        lpz = self.get_lpz(speech)
+        # Conflate text & lpz & config as a segmentation task object
+        task = self.prepare_segmentation_task(text, lpz, name, speech.shape[0])
+        # Apply CTC segmentation
+        segments = self.get_segments(task)
+        task.set(**segments)
+        assert check_return_type(task)
+        return task

--- a/speechbrain/alignment/ctc_segmentation.py
+++ b/speechbrain/alignment/ctc_segmentation.py
@@ -9,19 +9,24 @@ from typing import Union
 
 import numpy as np
 import torch
-from typeguard import check_argument_types
-from typeguard import check_return_type
 from typing import List
 
 # speechbrain interface
 from speechbrain.pretrained.interfaces import EncoderDecoderASR
 
 # imports for CTC segmentation
-from ctc_segmentation import ctc_segmentation
-from ctc_segmentation import CtcSegmentationParameters
-from ctc_segmentation import determine_utterance_segments
-from ctc_segmentation import prepare_text
-from ctc_segmentation import prepare_token_list
+try:
+    from ctc_segmentation import ctc_segmentation
+    from ctc_segmentation import CtcSegmentationParameters
+    from ctc_segmentation import determine_utterance_segments
+    from ctc_segmentation import prepare_text
+    from ctc_segmentation import prepare_token_list
+except ImportError:
+    print(
+        "ImportError: "
+        "Is the ctc_segmentation module installed "
+        "and in your PYTHONPATH?"
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +99,8 @@ class CTCSegmentationTask:
     def set(self, **kwargs):
         """Update properties.
 
-        Args:
+        Args
+        ----
         **kwargs
             Key-value dict that contains all properties
             with their new values. Unknown properties are ignored.
@@ -230,8 +236,6 @@ class CTCSegmentation:
         **ctc_segmentation_args
             Parameters for CTC segmentation.
         """
-        assert check_argument_types()
-
         # Prepare ASR model
         if not (
             hasattr(asr_model, "modules")
@@ -350,15 +354,13 @@ class CTCSegmentation:
             )
         # Parameters for text preparation
         if "set_blank" in kwargs:
-            assert isinstance(kwargs["set_blank"], int)
-            self.config.blank = kwargs["set_blank"]
+            self.config.blank = int(kwargs["set_blank"])
         if "replace_spaces_with_blanks" in kwargs:
             self.config.replace_spaces_with_blanks = bool(
                 kwargs["replace_spaces_with_blanks"]
             )
         if "kaldi_style_text" in kwargs:
-            assert isinstance(kwargs["kaldi_style_text"], bool)
-            self.kaldi_style_text = kwargs["kaldi_style_text"]
+            self.kaldi_style_text = bool(kwargs["kaldi_style_text"])
         if "text_converter" in kwargs:
             if kwargs["text_converter"] not in self.choices_text_converter:
                 raise NotImplementedError(
@@ -368,11 +370,9 @@ class CTCSegmentation:
             self.text_converter = kwargs["text_converter"]
         # Parameters for alignment
         if "min_window_size" in kwargs:
-            assert isinstance(kwargs["min_window_size"], int)
-            self.config.min_window_size = kwargs["min_window_size"]
+            self.config.min_window_size = int(kwargs["min_window_size"])
         if "max_window_size" in kwargs:
-            assert isinstance(kwargs["max_window_size"], int)
-            self.config.max_window_size = kwargs["max_window_size"]
+            self.config.max_window_size = int(kwargs["max_window_size"])
         if "gratis_blank" in kwargs:
             self.config.blank_transition_cost_zero = bool(
                 kwargs["gratis_blank"]
@@ -389,8 +389,7 @@ class CTCSegmentation:
             self.warned_about_misconfiguration = True
         # Parameter for calculation of confidence score
         if "scoring_length" in kwargs:
-            assert isinstance(kwargs["scoring_length"], int)
-            self.config.score_min_mean_over_L = kwargs["scoring_length"]
+            self.config.score_min_mean_over_L = int(kwargs["scoring_length"])
 
     def get_timing_config(self, speech_len=None, lpz_len=None):
         """Obtain parameters to determine time stamps."""
@@ -591,7 +590,7 @@ class CTCSegmentation:
             Dictionary with alignments. Combine this with the task
             object to obtain a human-readable segments representation.
         """
-        assert check_argument_types()
+        assert type(task) == CTCSegmentationTask
         assert task.config is not None
         config = task.config
         lpz = task.lpz
@@ -641,7 +640,6 @@ class CTCSegmentation:
             Task object with segments. Apply str(·) or print(·) on it
             to obtain the segments list.
         """
-        assert check_argument_types()
         if isinstance(speech, str) or isinstance(speech, Path):
             speech = self.asr_model.load_audio(speech)
         # Get log CTC posterior probabilities
@@ -651,5 +649,4 @@ class CTCSegmentation:
         # Apply CTC segmentation
         segments = self.get_segments(task)
         task.set(**segments)
-        assert check_return_type(task)
         return task

--- a/tests/unittests/test_ctc_segmentation.py
+++ b/tests/unittests/test_ctc_segmentation.py
@@ -12,7 +12,6 @@ def asr_model():
     return asr_model
 
 
-@pytest.mark.execution_timeout(5)
 def test_CTCSegmentation(asr_model: EncoderDecoderASR):
     """Test CTC segmentation.
 

--- a/tests/unittests/test_ctc_segmentation.py
+++ b/tests/unittests/test_ctc_segmentation.py
@@ -1,0 +1,85 @@
+from speechbrain.pretrained import EncoderDecoderASR
+import pytest
+
+
+@pytest.fixture()
+def asr_model():
+    """Load model for the CTC segmentation test."""
+
+    asr_model = EncoderDecoderASR.from_hparams(
+        source="speechbrain/asr-transformer-transformerlm-librispeech"
+    )
+    return asr_model
+
+
+@pytest.mark.execution_timeout(5)
+def test_CTCSegmentation(asr_model: EncoderDecoderASR):
+    """Test CTC segmentation.
+
+    Instead of pre-loading an ASR model and inferring an audio file, it is also
+    possible to use randomly generated ASR models and speech data. Please note
+    that with random data, there will be a small chance that this test might
+    randomly fail.
+    """
+
+    import numpy as np
+    from speechbrain.alignment.ctc_segmentation import CTCSegmentation
+    from speechbrain.alignment.ctc_segmentation import CTCSegmentationTask
+
+    # speech either from the test audio file or random
+    # example file included in the speechbrain repository
+    # speech = "./samples/audio_samples/example1.wav"
+    num_samples = 100000
+    speech = np.random.randn(num_samples)
+
+    # text includes:
+    #   one blank line
+    #   kaldi-style utterance names
+    #   one char not included in char list
+    text = (
+        "\n"
+        "utt_a THE BIRCH CANOE\n"
+        "utt_b SLID ON THE\n"
+        "utt_c SMOOTH PLANKS\n"
+    )
+    aligner = CTCSegmentation(
+        asr_model=asr_model, kaldi_style_text=True, min_window_size=10,
+    )
+    segments = aligner(speech, text)
+    # check segments
+    assert isinstance(segments, CTCSegmentationTask)
+    kaldi_text = str(segments)
+    first_line = kaldi_text.splitlines()[0]
+    assert "utt_a" == first_line.split(" ")[0]
+    start, end, score = segments.segments[0]
+    assert start > 0.0
+    assert end >= start
+    assert score < 0.0
+    # check options and align with "classic" text converter
+    option_dict = {
+        "time_stamps": "fixed",
+        "samples_to_frames_ratio": 512,
+        "min_window_size": 100,
+        "max_window_size": 20000,
+        "set_blank": 0,
+        "scoring_length": 10,
+        "replace_spaces_with_blanks": True,
+        "gratis_blank": True,
+        "kaldi_style_text": False,
+        "text_converter": "classic",
+    }
+    aligner.set_config(**option_dict)
+    assert aligner.warned_about_misconfiguration
+    text = [
+        "THE LITTLE GIRL",
+        "HAD BEEN ASLEEP",
+        "BUT SHE HEARD THE RAPS",
+        "AND OPENED THE DOOR",
+    ]
+    segments = aligner(speech, text, name="foo")
+    segments_str = str(segments)
+    first_line = segments_str.splitlines()[0]
+    assert "foo_0000" == first_line.split(" ")[0]
+    # test the ratio estimation (result: 509)
+    ratio = aligner.estimate_samples_to_frames_ratio()
+    assert 400 <= ratio <= 700


### PR DESCRIPTION
Text-to-audio alignment using CTC segmentation for Speechbrain.

CTC segmentation is useful to align utterances in long audio files and also to obtain a log probability estimate of how well does the ground truth fit to the audio data. The alignment requires only the CTC log posterior probabilities of a pre-trained ASR model.
https://arxiv.org/abs/2007.09127

Example:

```python
from speechbrain.pretrained import EncoderDecoderASR
from speechbrain.alignment.ctc_segmentation import CTCSegmentation

# Requires a model with CTC output
asr_model = EncoderDecoderASR.from_hparams(source="speechbrain/asr-transformer-transformerlm-librispeech")
aligner = CTCSegmentation(asr_model, kaldi_style_text=False)

# example file included in the speechbrain repository
audio_path = "./samples/audio_samples/example1.wav"
text = ["THE BIRCH CANOE", "SLID ON THE", "SMOOTH PLANKS"]
segments = aligner(audio_path, text, name="example1")
print(segments)
# example1_0000 example1 0.04 0.70 -0.0122 THE BIRCH CANOE
# example1_0001 example1 0.97 1.97 -0.0295 SLID ON THE
# example1_0002 example1 1.97 3.00 -0.0258 SMOOTH PLANKS

# here: from mini_librispeech dev data
# !wget https://www.openslr.org/resources/31/dev-clean-2.tar.gz
# !tar -xvzf dev-clean-2.tar.gz
audio_path = "./LibriSpeech/dev-clean-2/1272/135031/1272-135031-0003.flac"
text = ["THE LITTLE GIRL", "HAD BEEN ASLEEP", "BUT SHE HEARD THE RAPS", "AND OPENED THE DOOR"]
# align
segments = aligner(audio_path, text, name="1272-135031-0003")
print(segments)
# 1272-135031-0003_0000 1272-135031-0003 0.12 0.74 -0.0173 THE LITTLE GIRL
# 1272-135031-0003_0001 1272-135031-0003 0.74 1.54 -0.0012 HAD BEEN ASLEEP
# 1272-135031-0003_0002 1272-135031-0003 1.78 3.30 -0.0581 BUT SHE HEARD THE RAPS
# 1272-135031-0003_0003 1272-135031-0003 3.30 4.02 -0.0085 AND OPENED THE DOOR
```

Some notes / questions:

* This module requires the ctc-segmentation python package. I did not add ctc-segmentation to the requirements yet, as it is only needed for the alignment use-case. It can be installed via pip: `pip install ctc-segmentation` or from the Github repo https://github.com/lumaku/ctc-segmentation It is at least needed for the tests. What would be a good way to add it?

* As the ASR model in the example has very long tokens (e.g., `▁CHARACTERISTIC` is a single token), then the time resolution is bad, maybe it's only useful for sentences (instead of words). Is there by chance a pre-trained model with CTC that only contains the single characters as tokens?

* For the interface to speechbrain that obtains the CTC log probabilites, I assumed that the CTC functions of `EncoderDecoderASR` are in `<asr_module>.modules.decoder.ctc_forward_step`. How reliable is this function? If not, what is the best method to obtain these log posteriors?

* Tests: Currently, the test loads a pre-trained model. This may take too long for a test. Do you prefer a mock model?