### PR TITLE
Remove train modality check in augment.py

### DIFF
--- a/speechbrain/lobes/augment.py
+++ b/speechbrain/lobes/augment.py
@@ -291,11 +291,10 @@ class TimeDomainSpecAugment(torch.nn.Module):
             The waveforms to distort
         """
         # Augmentation
-        if self.training:
-            with torch.no_grad():
-                waveforms = self.speed_perturb(waveforms)
-                waveforms = self.drop_freq(waveforms)
-                waveforms = self.drop_chunk(waveforms, lengths)
+        with torch.no_grad():
+            waveforms = self.speed_perturb(waveforms)
+            waveforms = self.drop_freq(waveforms)
+            waveforms = self.drop_chunk(waveforms, lengths)
 
         return waveforms
 
@@ -416,17 +415,16 @@ class EnvCorrupt(torch.nn.Module):
             The waveforms to distort.
         """
         # Augmentation
-        if self.training:
-            with torch.no_grad():
-                if hasattr(self, "add_reverb"):
-                    try:
-                        waveforms = self.add_reverb(waveforms, lengths)
-                    except Exception:
-                        pass
-                if hasattr(self, "add_babble"):
-                    waveforms = self.add_babble(waveforms, lengths)
-                if hasattr(self, "add_noise"):
-                    waveforms = self.add_noise(waveforms, lengths)
+        with torch.no_grad():
+            if hasattr(self, "add_reverb"):
+                try:
+                    waveforms = self.add_reverb(waveforms, lengths)
+                except Exception:
+                    pass
+            if hasattr(self, "add_babble"):
+                waveforms = self.add_babble(waveforms, lengths)
+            if hasattr(self, "add_noise"):
+                waveforms = self.add_noise(waveforms, lengths)
 
         return waveforms
 


### PR DESCRIPTION
This PR removes the check on train/eval modality done internally in augment.py. The check is already done in train.py. With this small change, users might use augmentation also when the system is in eval modality (if they want it for some reason).

This topic was discussed in #780.