### PR TITLE
Fix multichannel fbank

### DIFF
--- a/speechbrain/processing/features.py
+++ b/speechbrain/processing/features.py
@@ -539,6 +539,7 @@ class Filterbank(torch.nn.Module):
 
         # Managing multi-channels case (batch, time, channels)
         if len(sp_shape) == 4:
+            spectrogram = spectrogram.permute(0, 3, 1, 2)
             spectrogram = spectrogram.reshape(
                 sp_shape[0] * sp_shape[3], sp_shape[1], sp_shape[2]
             )
@@ -552,8 +553,9 @@ class Filterbank(torch.nn.Module):
         if len(sp_shape) == 4:
             fb_shape = fbanks.shape
             fbanks = fbanks.reshape(
-                sp_shape[0], fb_shape[1], fb_shape[2], sp_shape[3]
+                sp_shape[0], fb_shape[3], fb_shape[1], sp_shape[2]
             )
+            fbanks = fbanks.permute(0, 2, 3, 1)
 
         return fbanks
 

--- a/speechbrain/processing/features.py
+++ b/speechbrain/processing/features.py
@@ -553,7 +553,7 @@ class Filterbank(torch.nn.Module):
         if len(sp_shape) == 4:
             fb_shape = fbanks.shape
             fbanks = fbanks.reshape(
-                sp_shape[0], fb_shape[3], fb_shape[1], sp_shape[2]
+                sp_shape[0], sp_shape[3], fb_shape[1], fb_shape[2]
             )
             fbanks = fbanks.permute(0, 2, 3, 1)
 

--- a/tests/unittests/test_features.py
+++ b/tests/unittests/test_features.py
@@ -81,3 +81,16 @@ def test_input_normalization():
     out_norm = norm(inputs, inp_len).squeeze()
     target = torch.FloatTensor([-1, 0, 1, -2, -2, -2])
     assert torch.equal(out_norm, target)
+
+
+def test_features_multimic():
+
+    from speechbrain.processing.features import Filterbank
+
+    compute_fbanks = Filterbank()
+    inputs = torch.rand([10, 101, 201])
+    output = compute_fbanks(inputs)
+    inputs_ch2 = torch.stack((inputs, inputs), -1)
+    output_ch2 = compute_fbanks(inputs_ch2)
+    output_ch2 = output_ch2[..., 0]
+    assert torch.sum(output - output_ch2) < 1e-05


### PR DESCRIPTION
Filterbank forward can't generate right feature for multi-channel input，I can reproduce the error use the code as below
```python
from speechbrain.processing.features import Filterbank
compute_fbanks = Filterbank()
inputs = torch.ones([10, 101, 201])
output = compute_fbanks(inputs)
inputs_ch2 = torch.stack((inputs,inputs),-1)
output_ch2 = compute_fbanks(inputs_ch2)
torch.sum(output - output_ch2[..., 0])
```