### PR TITLE
Fix typo

### DIFF
--- a/speechbrain/lobes/features.py
+++ b/speechbrain/lobes/features.py
@@ -207,7 +207,7 @@ class MFCC(torch.nn.Module):
     >>> feature_maker = MFCC()
     >>> feats = feature_maker(inputs)
     >>> feats.shape
-    torch.Size([10, 101, 660])
+    torch.Size([10, 101, 60])
     """
 
     def __init__(


### PR DESCRIPTION
Line 210 showed a shape of torch.Size([10, 101, 660]), I think it probably should be torch.Size([10, 101, 60]) (3 * 20 MFCCS = MFCCS + Deltas + DeltaDeltas)