### PR TITLE
Add threshold paramater to verify_files

### DIFF
--- a/speechbrain/pretrained/interfaces.py
+++ b/speechbrain/pretrained/interfaces.py
@@ -715,7 +715,7 @@ class SpeakerRecognition(EncoderClassifier):
         score = self.similarity(emb1, emb2)
         return score, score > threshold
 
-    def verify_files(self, path_x, path_y):
+    def verify_files(self, path_x, path_y, threshold=0.25):
         """Speaker verification with cosine distance
 
         Returns the score and the decision (0 different speakers,
@@ -736,7 +736,7 @@ class SpeakerRecognition(EncoderClassifier):
         batch_x = waveform_x.unsqueeze(0)
         batch_y = waveform_y.unsqueeze(0)
         # Verify:
-        score, decision = self.verify_batch(batch_x, batch_y)
+        score, decision = self.verify_batch(batch_x, batch_y, threshold=threshold)
         # Squeeze:
         return score[0], decision[0]
 

--- a/speechbrain/pretrained/interfaces.py
+++ b/speechbrain/pretrained/interfaces.py
@@ -736,7 +736,9 @@ class SpeakerRecognition(EncoderClassifier):
         batch_x = waveform_x.unsqueeze(0)
         batch_y = waveform_y.unsqueeze(0)
         # Verify:
-        score, decision = self.verify_batch(batch_x, batch_y, threshold=threshold)
+        score, decision = self.verify_batch(
+            batch_x, batch_y, threshold=threshold
+        )
         # Squeeze:
         return score[0], decision[0]
 


### PR DESCRIPTION
This PR adds an additional `threshold` parameter to the `verify_files()` function of the `SpeakerRecognition` interface. `verify_files()` internally calls `verify_batch()`, which accepts a `threshold` parameter that determines the decision boundary for cosine similarity. Previously, the internal call only used the default parameter value of 0.25; this PR allows users to use different threshold values when calling `verify_files()`.