### PR TITLE
KenLM as optional dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 -r lint-requirements.txt
-https://github.com/kpu/kenlm/archive/master.zip
 huggingface_hub>=0.0.6
 hyperpyyaml>=0.0.1
 joblib>=0.14.1

--- a/speechbrain/decoders/scorer.py
+++ b/speechbrain/decoders/scorer.py
@@ -214,7 +214,7 @@ class KenLMScorer(BaseScorerInterface):
             by default. Install it with:
             > pip install https://github.com/kpu/kenlm/archive/master.zip
             """
-            raise ImportError
+            raise ImportError(MSG)
         self.lm = self.kenlm.Model(lm_path)
         self.vocab_size = vocab_size
         self.full_candidates = np.arange(self.vocab_size)

--- a/speechbrain/tokenizers/SentencePiece.py
+++ b/speechbrain/tokenizers/SentencePiece.py
@@ -461,3 +461,24 @@ class SentencePiece:
                 ).split(" ")
                 for i, utt_seq in enumerate(batch)
             ]
+
+
+def get_spm_tokens(model_path):
+    """Fetch list of tokens, can be indexed by token id
+
+    The resulting list can be used to map id to token.
+
+    Arguments
+    ---------
+    model_path : str
+        Path to SentencePiece model
+
+    Returns
+    -------
+    list
+        Tokens in order by id (can be indexed by id)
+    """
+    model = spm.SentencePieceProcessor()
+    model.load(model_path)
+    mapping = [model.id_to_piece(i) for i in range(model.vocab_size())]
+    return mapping


### PR DESCRIPTION
Either use this PR as a reference for how this could be implemented or just merge.

Changes:
- KenLM as optional dependency
- Removed Sentencepiece tokenizer stuff from the KenLM class, that functionality seemed totally orthogonal
- Renamed to KenLMScorer. I am happy to reverse this as well, since KenLM supports any ARPA LM probably? But I think this name is the clearest.