### PR TITLE
Add language identification recipe using the Voxlingua107 dataset

### DIFF
--- a/recipes/CommonLanguage/README.md
+++ b/recipes/CommonLanguage/README.md
@@ -1,114 +1,65 @@
-# VoxLingua107 Dataset [[download]](http://bark.phon.ioc.ee/voxlingua107/)
+# CommonLanguage Dataset [[download]](https://zenodo.org/record/5036977/files/CommonLanguage.tar.gz?download=1)
 
-VoxLingua107 is a speech dataset for training spoken language identification models. 
-The dataset consists of short speech segments automatically extracted from YouTube videos and labeled according the language of the video title and description, with some post-processing steps to filter out false positives.
+This dataset is composed of speakers of 45 languages that were carefully selected from [CommonVoice](https://commonvoice.mozilla.org/) database. The total duration of audio recordings is 45.1 hours. The data is already split into train, dev (validation) and test sets.
 
-VoxLingua107 contains data for 107 languages. The total amount of speech in the training set is 6628 hours. 
-The average amount of data per language is 62 hours. However, the real amount per language varies a lot. There is also a seperate development set containing 1609 speech segments from 33 languages, validated by at least two volunteers to really contain the given language.
+## Statistics of CommonLanguage:
 
-For more information, see the paper [J&ouml;rgen Valk, Tanel Alum&auml;e. _VoxLingua107: a Dataset for Spoken Language Recognition_. Proc. SLT 2021](https://arxiv.org/abs/2011.12998).
+| Name                              | Train  | Dev    | Test  |
+|:---------------------------------:|:------:|:------:|:-----:|
+| **# of utterances**               | 177552 | 47104  | 47704 |
+| **# unique speakers**             | 11189  | 1297   | 1322  |
+| **Total duration, hr**            | 30.04  | 7.53   | 7.53  |
+| **Min duration, sec**             | 0.86   | 0.98   | 0.89  |
+| **Mean duration, sec**            | 4.87   | 4.61   | 4.55  |
+| **Max duration, sec**             | 21.72  | 105.67 | 29.83 |
+| **Duration per language, min**    | ~40    | ~10    | ~10   |
 
-## Collection method
+## List of languages:
+* Arabic
+* Basque
+* Breton
+* Catalan
+* Chinese_China
+* Chinese_Hongkong
+* Chinese_Taiwan
+* Chuvash
+* Czech
+* Dhivehi
+* Dutch
+* English
+* Esperanto
+* Estonian
+* French
+* Frisian
+* Georgian
+* German
+* Greek
+* Hakha_Chin
+* Indonesian
+* Interlingua
+* Italian
+* Japanese
+* Kabyle
+* Kinyarwanda
+* Kyrgyz
+* Latvian
+* Maltese
+* Mangolian
+* Persian
+* Polish
+* Portuguese
+* Romanian
+* Romansh_Sursilvan
+* Russian
+* Sakha
+* Slovenian
+* Spanish
+* Swedish
+* Tamil
+* Tatar
+* Turkish
+* Ukranian
+* Welsh
 
-We extracted audio data from YouTube videos that are retrieved using language-specific search phrases (random phrases from Wikipedia of the particular language).
-If the language of the video title and description matched with the language of the search phrase, 
-the audio in the video was deemed likely to be in that particular language. This allowed to collect large amounts of somewhat noisy data relatively cheaply.
-Speech/non-speech detection and speaker diarization was used to segment the videos into short sentence-like utterances.
-A data-driven post-filtering step was applied to remove clips that were very different from other clips in this language's dataset, and thus likely not in the given language.
-Due to the automatic data collection process, there are still clips in the dataset that are not in the given language or contain non-speech  (around 2% overall) 
-
-
-
-## Statistics of VoxLingua107:
-
-Training data per language:
-
-- [Abkhazian](ab.zip) (10 hours, 980M), [sample](samples/ab.wav) 
-- [Afrikaans](af.zip) (108 hours, 10G), [sample](samples/af.wav) 
-- [Amharic](am.zip) (81 hours, 7.7G), [sample](samples/am.wav) 
-- [Arabic](ar.zip) (59 hours, 5.5G), [sample](samples/ar.wav) 
-- [Assamese](as.zip) (155 hours, 15G), [sample](samples/as.wav) 
-- [Azerbaijani](az.zip) (58 hours, 5.6G), [sample](samples/az.wav) 
-- [Bashkir](ba.zip) (58 hours, 5.5G), [sample](samples/ba.wav) 
-- [Belarusian](be.zip) (133 hours, 13G), [sample](samples/be.wav) 
-- [Bulgarian](bg.zip) (50 hours, 4.7G), [sample](samples/bg.wav) 
-- [Bengali](bn.zip) (55 hours, 5.4G), [sample](samples/bn.wav) 
-- [Tibetan](bo.zip) (101 hours, 9.3G), [sample](samples/bo.wav) 
-- [Breton](br.zip) (44 hours, 4.2G), [sample](samples/br.wav) 
-- [Bosnian](bs.zip) (105 hours, 9.7G), [sample](samples/bs.wav) 
-- [Catalan](ca.zip) (88 hours, 8.1G), [sample](samples/ca.wav) 
-- [Cebuano](ceb.zip) (6 hours, 589M), [sample](samples/ceb.wav) 
-- [Czech](cs.zip) (67 hours, 6.3G), [sample](samples/cs.wav) 
-- [Welsh](cy.zip) (76 hours, 6.6G), [sample](samples/cy.wav) 
-- [Danish](da.zip) (28 hours, 2.6G), [sample](samples/da.wav) 
-- [German](de.zip) (39 hours, 3.7G), [sample](samples/de.wav) 
-- [Greek](el.zip) (66 hours, 6.2G), [sample](samples/el.wav) 
-- [English](en.zip) (49 hours, 4.6G), [sample](samples/en.wav) 
-- [Esperanto](eo.zip) (10 hours, 916M), [sample](samples/eo.wav) 
-- [Spanish](es.zip) (39 hours, 3.7G), [sample](samples/es.wav) 
-- [Estonian](et.zip) (38 hours, 3.5G), [sample](samples/et.wav) 
-- [Basque](eu.zip) (29 hours, 2.8G), [sample](samples/eu.wav) 
-- [Persian](fa.zip) (56 hours, 5.2G), [sample](samples/fa.wav) 
-- [Finnish](fi.zip) (33 hours, 3.1G), [sample](samples/fi.wav) 
-- [Faroese](fo.zip) (67 hours, 6.0G), [sample](samples/fo.wav) 
-- [French](fr.zip) (67 hours, 6.2G), [sample](samples/fr.wav) 
-- [Galician](gl.zip) (72 hours, 6.7G), [sample](samples/gl.wav) 
-- [Guarani](gn.zip) (2 hours, 250M), [sample](samples/gn.wav) 
-- [Gujarati](gu.zip) (46 hours, 4.5G), [sample](samples/gu.wav) 
-- [Manx](gv.zip) (4 hours, 374M), [sample](samples/gv.wav) 
-- [Hausa](ha.zip) (106 hours, 10G), [sample](samples/ha.wav) 
-- [Hawaiian](haw.zip) (12 hours, 1.2G), [sample](samples/haw.wav) 
-- [Hindi](hi.zip) (81 hours, 7.7G), [sample](samples/hi.wav) 
-- [Croatian](hr.zip) (118 hours, 11G), [sample](samples/hr.wav) 
-- [Haitian](ht.zip) (96 hours, 9.2G), [sample](samples/ht.wav) 
-- [Hungarian](hu.zip) (73 hours, 6.9G), [sample](samples/hu.wav) 
-- [Armenian](hy.zip) (69 hours, 6.6G), [sample](samples/hy.wav) 
-- [Interlingua](ia.zip) (3 hours, 241M), [sample](samples/ia.wav) 
-- [Indonesian](id.zip) (40 hours, 3.8G), [sample](samples/id.wav) 
-- [Icelandic](is.zip) (92 hours, 8.4G), [sample](samples/is.wav) 
-- [Italian](it.zip) (51 hours, 4.8G), [sample](samples/it.wav) 
-- [Hebrew](iw.zip) (96 hours, 8.9G), [sample](samples/iw.wav) 
-- [Japanese](ja.zip) (56 hours, 5.1G), [sample](samples/ja.wav) 
-- [Javanese](jw.zip) (53 hours, 5.0G), [sample](samples/jw.wav) 
-- [Georgian](ka.zip) (98 hours, 9.2G), [sample](samples/ka.wav) 
-- [Kazakh](kk.zip) (78 hours, 7.3G), [sample](samples/kk.wav) 
-- [Central Khmer](km.zip) (41 hours, 4.0G), [sample](samples/km.wav) 
-- [Kannada](kn.zip) (46 hours, 4.4G), [sample](samples/kn.wav) 
-- [Korean](ko.zip) (77 hours, 7.1G), [sample](samples/ko.wav) 
-- [Latin](la.zip) (67 hours, 6.0G), [sample](samples/la.wav) 
-- [Luxembourgish](lb.zip) (75 hours, 7.1G), [sample](samples/lb.wav) 
-- [Lingala](ln.zip) (90 hours, 8.7G), [sample](samples/ln.wav) 
-- [Lao](lo.zip) (42 hours, 4.0G), [sample](samples/lo.wav) 
-- [Lithuanian](lt.zip) (82 hours, 7.7G), [sample](samples/lt.wav) 
-- [Latvian](lv.zip) (42 hours, 4.0G), [sample](samples/lv.wav) 
-- [Malagasy](mg.zip) (109 hours, 11G), [sample](samples/mg.wav) 
-- [Maori](mi.zip) (34 hours, 3.2G), [sample](samples/mi.wav) 
-- [Macedonian](mk.zip) (112 hours, 11G), [sample](samples/mk.wav) 
-- [Malayalam](ml.zip) (47 hours, 4.6G), [sample](samples/ml.wav) 
-- [Mongolian](mn.zip) (71 hours, 6.4G), [sample](samples/mn.wav) 
-- [Marathi](mr.zip) (85 hours, 8.1G), [sample](samples/mr.wav) 
-- [Malay](ms.zip) (83 hours, 7.8G), [sample](samples/ms.wav) 
-- [Maltese](mt.zip) (66 hours, 6.1G), [sample](samples/mt.wav) 
-- [Burmese](my.zip) (41 hours, 4.0G), [sample](samples/my.wav) 
-- [Nepali](ne.zip) (72 hours, 7.1G), [sample](samples/ne.wav) 
-- [Dutch](nl.zip) (40 hours, 3.8G), [sample](samples/nl.wav) 
-- [Norwegian Nynorsk](nn.zip) (57 hours, 4.8G), [sample](samples/nn.wav) 
-- [Norwegian](no.zip) (107 hours, 9.7G), [sample](samples/no.wav) 
-- [Occitan](oc.zip) (15 hours, 1.5G), [sample](samples/oc.wav) 
-- [Panjabi](pa.zip) (54 hours, 5.2G), [sample](samples/pa.wav) 
-- [Polish](pl.zip) (80 hours, 7.6G), [sample](samples/pl.wav) 
-- [Pushto](ps.zip) (47 hours, 4.5G), [sample](samples/ps.wav) 
-- [Portuguese](pt.zip) (64 hours, 6.1G), [sample](samples/pt.wav) 
-- [Romanian](ro.zip) (65 hours, 6.1G), [sample](samples/ro.wav) 
-- [Russian](ru.zip) (73 hours, 6.9G), [sample](samples/ru.wav) 
-
-
-### Citing
-
-```
-@inproceedings{valk2021slt,
-  title={{VoxLingua107}: a Dataset for Spoken Language Recognition},
-  author={J{\"o}rgen Valk and Tanel Alum{\"a}e},
-  booktitle={Proc. IEEE SLT Workshop},
-  year={2021},
-}
+## Other information
+In addition to the language label, the datapoints have `age`, `gender` and `utterance transcription` associated with each utterance.

--- a/recipes/CommonLanguage/README.md
+++ b/recipes/CommonLanguage/README.md
@@ -1,65 +1,114 @@
-# CommonLanguage Dataset [[download]](https://zenodo.org/record/5036977/files/CommonLanguage.tar.gz?download=1)
+# VoxLingua107 Dataset [[download]](http://bark.phon.ioc.ee/voxlingua107/)
 
-This dataset is composed of speakers of 45 languages that were carefully selected from [CommonVoice](https://commonvoice.mozilla.org/) database. The total duration of audio recordings is 45.1 hours. The data is already split into train, dev (validation) and test sets.
+VoxLingua107 is a speech dataset for training spoken language identification models. 
+The dataset consists of short speech segments automatically extracted from YouTube videos and labeled according the language of the video title and description, with some post-processing steps to filter out false positives.
 
-## Statistics of CommonLanguage:
+VoxLingua107 contains data for 107 languages. The total amount of speech in the training set is 6628 hours. 
+The average amount of data per language is 62 hours. However, the real amount per language varies a lot. There is also a seperate development set containing 1609 speech segments from 33 languages, validated by at least two volunteers to really contain the given language.
 
-| Name                              | Train  | Dev    | Test  |
-|:---------------------------------:|:------:|:------:|:-----:|
-| **# of utterances**               | 177552 | 47104  | 47704 |
-| **# unique speakers**             | 11189  | 1297   | 1322  |
-| **Total duration, hr**            | 30.04  | 7.53   | 7.53  |
-| **Min duration, sec**             | 0.86   | 0.98   | 0.89  |
-| **Mean duration, sec**            | 4.87   | 4.61   | 4.55  |
-| **Max duration, sec**             | 21.72  | 105.67 | 29.83 |
-| **Duration per language, min**    | ~40    | ~10    | ~10   |
+For more information, see the paper [J&ouml;rgen Valk, Tanel Alum&auml;e. _VoxLingua107: a Dataset for Spoken Language Recognition_. Proc. SLT 2021](https://arxiv.org/abs/2011.12998).
 
-## List of languages:
-* Arabic
-* Basque
-* Breton
-* Catalan
-* Chinese_China
-* Chinese_Hongkong
-* Chinese_Taiwan
-* Chuvash
-* Czech
-* Dhivehi
-* Dutch
-* English
-* Esperanto
-* Estonian
-* French
-* Frisian
-* Georgian
-* German
-* Greek
-* Hakha_Chin
-* Indonesian
-* Interlingua
-* Italian
-* Japanese
-* Kabyle
-* Kinyarwanda
-* Kyrgyz
-* Latvian
-* Maltese
-* Mangolian
-* Persian
-* Polish
-* Portuguese
-* Romanian
-* Romansh_Sursilvan
-* Russian
-* Sakha
-* Slovenian
-* Spanish
-* Swedish
-* Tamil
-* Tatar
-* Turkish
-* Ukranian
-* Welsh
+## Collection method
 
-## Other information
-In addition to the language label, the datapoints have `age`, `gender` and `utterance transcription` associated with each utterance.
+We extracted audio data from YouTube videos that are retrieved using language-specific search phrases (random phrases from Wikipedia of the particular language).
+If the language of the video title and description matched with the language of the search phrase, 
+the audio in the video was deemed likely to be in that particular language. This allowed to collect large amounts of somewhat noisy data relatively cheaply.
+Speech/non-speech detection and speaker diarization was used to segment the videos into short sentence-like utterances.
+A data-driven post-filtering step was applied to remove clips that were very different from other clips in this language's dataset, and thus likely not in the given language.
+Due to the automatic data collection process, there are still clips in the dataset that are not in the given language or contain non-speech  (around 2% overall) 
+
+
+
+## Statistics of VoxLingua107:
+
+Training data per language:
+
+- [Abkhazian](ab.zip) (10 hours, 980M), [sample](samples/ab.wav) 
+- [Afrikaans](af.zip) (108 hours, 10G), [sample](samples/af.wav) 
+- [Amharic](am.zip) (81 hours, 7.7G), [sample](samples/am.wav) 
+- [Arabic](ar.zip) (59 hours, 5.5G), [sample](samples/ar.wav) 
+- [Assamese](as.zip) (155 hours, 15G), [sample](samples/as.wav) 
+- [Azerbaijani](az.zip) (58 hours, 5.6G), [sample](samples/az.wav) 
+- [Bashkir](ba.zip) (58 hours, 5.5G), [sample](samples/ba.wav) 
+- [Belarusian](be.zip) (133 hours, 13G), [sample](samples/be.wav) 
+- [Bulgarian](bg.zip) (50 hours, 4.7G), [sample](samples/bg.wav) 
+- [Bengali](bn.zip) (55 hours, 5.4G), [sample](samples/bn.wav) 
+- [Tibetan](bo.zip) (101 hours, 9.3G), [sample](samples/bo.wav) 
+- [Breton](br.zip) (44 hours, 4.2G), [sample](samples/br.wav) 
+- [Bosnian](bs.zip) (105 hours, 9.7G), [sample](samples/bs.wav) 
+- [Catalan](ca.zip) (88 hours, 8.1G), [sample](samples/ca.wav) 
+- [Cebuano](ceb.zip) (6 hours, 589M), [sample](samples/ceb.wav) 
+- [Czech](cs.zip) (67 hours, 6.3G), [sample](samples/cs.wav) 
+- [Welsh](cy.zip) (76 hours, 6.6G), [sample](samples/cy.wav) 
+- [Danish](da.zip) (28 hours, 2.6G), [sample](samples/da.wav) 
+- [German](de.zip) (39 hours, 3.7G), [sample](samples/de.wav) 
+- [Greek](el.zip) (66 hours, 6.2G), [sample](samples/el.wav) 
+- [English](en.zip) (49 hours, 4.6G), [sample](samples/en.wav) 
+- [Esperanto](eo.zip) (10 hours, 916M), [sample](samples/eo.wav) 
+- [Spanish](es.zip) (39 hours, 3.7G), [sample](samples/es.wav) 
+- [Estonian](et.zip) (38 hours, 3.5G), [sample](samples/et.wav) 
+- [Basque](eu.zip) (29 hours, 2.8G), [sample](samples/eu.wav) 
+- [Persian](fa.zip) (56 hours, 5.2G), [sample](samples/fa.wav) 
+- [Finnish](fi.zip) (33 hours, 3.1G), [sample](samples/fi.wav) 
+- [Faroese](fo.zip) (67 hours, 6.0G), [sample](samples/fo.wav) 
+- [French](fr.zip) (67 hours, 6.2G), [sample](samples/fr.wav) 
+- [Galician](gl.zip) (72 hours, 6.7G), [sample](samples/gl.wav) 
+- [Guarani](gn.zip) (2 hours, 250M), [sample](samples/gn.wav) 
+- [Gujarati](gu.zip) (46 hours, 4.5G), [sample](samples/gu.wav) 
+- [Manx](gv.zip) (4 hours, 374M), [sample](samples/gv.wav) 
+- [Hausa](ha.zip) (106 hours, 10G), [sample](samples/ha.wav) 
+- [Hawaiian](haw.zip) (12 hours, 1.2G), [sample](samples/haw.wav) 
+- [Hindi](hi.zip) (81 hours, 7.7G), [sample](samples/hi.wav) 
+- [Croatian](hr.zip) (118 hours, 11G), [sample](samples/hr.wav) 
+- [Haitian](ht.zip) (96 hours, 9.2G), [sample](samples/ht.wav) 
+- [Hungarian](hu.zip) (73 hours, 6.9G), [sample](samples/hu.wav) 
+- [Armenian](hy.zip) (69 hours, 6.6G), [sample](samples/hy.wav) 
+- [Interlingua](ia.zip) (3 hours, 241M), [sample](samples/ia.wav) 
+- [Indonesian](id.zip) (40 hours, 3.8G), [sample](samples/id.wav) 
+- [Icelandic](is.zip) (92 hours, 8.4G), [sample](samples/is.wav) 
+- [Italian](it.zip) (51 hours, 4.8G), [sample](samples/it.wav) 
+- [Hebrew](iw.zip) (96 hours, 8.9G), [sample](samples/iw.wav) 
+- [Japanese](ja.zip) (56 hours, 5.1G), [sample](samples/ja.wav) 
+- [Javanese](jw.zip) (53 hours, 5.0G), [sample](samples/jw.wav) 
+- [Georgian](ka.zip) (98 hours, 9.2G), [sample](samples/ka.wav) 
+- [Kazakh](kk.zip) (78 hours, 7.3G), [sample](samples/kk.wav) 
+- [Central Khmer](km.zip) (41 hours, 4.0G), [sample](samples/km.wav) 
+- [Kannada](kn.zip) (46 hours, 4.4G), [sample](samples/kn.wav) 
+- [Korean](ko.zip) (77 hours, 7.1G), [sample](samples/ko.wav) 
+- [Latin](la.zip) (67 hours, 6.0G), [sample](samples/la.wav) 
+- [Luxembourgish](lb.zip) (75 hours, 7.1G), [sample](samples/lb.wav) 
+- [Lingala](ln.zip) (90 hours, 8.7G), [sample](samples/ln.wav) 
+- [Lao](lo.zip) (42 hours, 4.0G), [sample](samples/lo.wav) 
+- [Lithuanian](lt.zip) (82 hours, 7.7G), [sample](samples/lt.wav) 
+- [Latvian](lv.zip) (42 hours, 4.0G), [sample](samples/lv.wav) 
+- [Malagasy](mg.zip) (109 hours, 11G), [sample](samples/mg.wav) 
+- [Maori](mi.zip) (34 hours, 3.2G), [sample](samples/mi.wav) 
+- [Macedonian](mk.zip) (112 hours, 11G), [sample](samples/mk.wav) 
+- [Malayalam](ml.zip) (47 hours, 4.6G), [sample](samples/ml.wav) 
+- [Mongolian](mn.zip) (71 hours, 6.4G), [sample](samples/mn.wav) 
+- [Marathi](mr.zip) (85 hours, 8.1G), [sample](samples/mr.wav) 
+- [Malay](ms.zip) (83 hours, 7.8G), [sample](samples/ms.wav) 
+- [Maltese](mt.zip) (66 hours, 6.1G), [sample](samples/mt.wav) 
+- [Burmese](my.zip) (41 hours, 4.0G), [sample](samples/my.wav) 
+- [Nepali](ne.zip) (72 hours, 7.1G), [sample](samples/ne.wav) 
+- [Dutch](nl.zip) (40 hours, 3.8G), [sample](samples/nl.wav) 
+- [Norwegian Nynorsk](nn.zip) (57 hours, 4.8G), [sample](samples/nn.wav) 
+- [Norwegian](no.zip) (107 hours, 9.7G), [sample](samples/no.wav) 
+- [Occitan](oc.zip) (15 hours, 1.5G), [sample](samples/oc.wav) 
+- [Panjabi](pa.zip) (54 hours, 5.2G), [sample](samples/pa.wav) 
+- [Polish](pl.zip) (80 hours, 7.6G), [sample](samples/pl.wav) 
+- [Pushto](ps.zip) (47 hours, 4.5G), [sample](samples/ps.wav) 
+- [Portuguese](pt.zip) (64 hours, 6.1G), [sample](samples/pt.wav) 
+- [Romanian](ro.zip) (65 hours, 6.1G), [sample](samples/ro.wav) 
+- [Russian](ru.zip) (73 hours, 6.9G), [sample](samples/ru.wav) 
+
+
+### Citing
+
+```
+@inproceedings{valk2021slt,
+  title={{VoxLingua107}: a Dataset for Spoken Language Recognition},
+  author={J{\"o}rgen Valk and Tanel Alum{\"a}e},
+  booktitle={Proc. IEEE SLT Workshop},
+  year={2021},
+}

--- a/recipes/VoxLingua107/README.md
+++ b/recipes/VoxLingua107/README.md
@@ -1,0 +1,135 @@
+# VoxLingua107
+
+VoxLingua107 is a speech dataset for training spoken language identification models. 
+The dataset consists of short speech segments automatically extracted from YouTube videos and labeled according the language of the video title and description, with some post-processing steps to filter out false positives.
+
+VoxLingua107 contains data for 107 languages. The total amount of speech in the training set is 6628 hours. 
+The average amount of data per language is 62 hours. However, the real amount per language varies a lot. There is also a seperate development set containing 1609 speech segments from 33 languages, validated by at least two volunteers to really contain the given language.
+
+For more information, see the paper [J&ouml;rgen Valk, Tanel Alum&auml;e. _VoxLingua107: a Dataset for Spoken Language Recognition_. Proc. SLT 2021].
+
+## Why
+
+VoxLingua107 can be used for training spoken language recognition models that work well with real-world, varying speech data. 
+
+## How 
+
+We extracted audio data from YouTube videos that are retrieved using language-specific search phrases .
+If the language of the video title and description matched with the language of the search phrase, 
+the audio in the video was deemed likely to be in that particular language. This allowed to collect large amounts of somewhat noisy data relatively cheaply.
+Speech/non-speech detection and speaker diarization was used to segment the videos into short sentence-like utterances.
+A data-driven post-filtering step was applied to remove clips that were very different from other clips in this language's dataset, and thus likely not in the given language.
+Due to the automatic data collection process, there are still clips in the dataset that are not in the given language or contain non-speech.
+
+## Languages
+
+Amount of training data per language:
+
+- Abkhazian  (10 hours, 980M)
+- Afrikaans  (108 hours, 10G)
+- Amharic  (81 hours, 7.7G)
+- Arabic  (59 hours, 5.5G)
+- Assamese  (155 hours, 15G)
+- Azerbaijani  (58 hours, 5.6G)
+- Bashkir  (58 hours, 5.5G)
+- Belarusian  (133 hours, 13G)
+- Bulgarian  (50 hours, 4.7G)
+- Bengali  (55 hours, 5.4G)
+- Tibetan  (101 hours, 9.3G)
+- Breton  (44 hours, 4.2G)
+- Bosnian  (105 hours, 9.7G)
+- Catalan  (88 hours, 8.1G)
+- Cebuano  (6 hours, 589M)
+- Czech  (67 hours, 6.3G)
+- Welsh  (76 hours, 6.6G)
+- Danish  (28 hours, 2.6G)
+- German  (39 hours, 3.7G)
+- Greek  (66 hours, 6.2G)
+- English  (49 hours, 4.6G)
+- Esperanto  (10 hours, 916M)
+- Spanish  (39 hours, 3.7G)
+- Estonian  (38 hours, 3.5G)
+- Basque  (29 hours, 2.8G)
+- Persian  (56 hours, 5.2G)
+- Finnish  (33 hours, 3.1G)
+- Faroese  (67 hours, 6.0G)
+- French  (67 hours, 6.2G)
+- Galician  (72 hours, 6.7G)
+- Guarani  (2 hours, 250M)
+- Gujarati  (46 hours, 4.5G)
+- Manx  (4 hours, 374M)
+- Hausa  (106 hours, 10G)
+- Hawaiian  (12 hours, 1.2G)
+- Hindi  (81 hours, 7.7G)
+- Croatian  (118 hours, 11G)
+- Haitian  (96 hours, 9.2G)
+- Hungarian  (73 hours, 6.9G)
+- Armenian  (69 hours, 6.6G)
+- Interlingua  (3 hours, 241M)
+- Indonesian  (40 hours, 3.8G)
+- Icelandic  (92 hours, 8.4G)
+- Italian  (51 hours, 4.8G)
+- Hebrew  (96 hours, 8.9G)
+- Japanese  (56 hours, 5.1G)
+- Javanese  (53 hours, 5.0G)
+- Georgian  (98 hours, 9.2G)
+- Kazakh  (78 hours, 7.3G)
+- Central Khmer  (41 hours, 4.0G)
+- Kannada  (46 hours, 4.4G)
+- Korean  (77 hours, 7.1G)
+- Latin  (67 hours, 6.0G)
+- Luxembourgish  (75 hours, 7.1G)
+- Lingala  (90 hours, 8.7G)
+- Lao  (42 hours, 4.0G)
+- Lithuanian  (82 hours, 7.7G)
+- Latvian  (42 hours, 4.0G)
+- Malagasy  (109 hours, 11G)
+- Maori  (34 hours, 3.2G)
+- Macedonian  (112 hours, 11G)
+- Malayalam  (47 hours, 4.6G)
+- Mongolian  (71 hours, 6.4G)
+- Marathi  (85 hours, 8.1G)
+- Malay  (83 hours, 7.8G)
+- Maltese  (66 hours, 6.1G)
+- Burmese  (41 hours, 4.0G)
+- Nepali  (72 hours, 7.1G)
+- Dutch  (40 hours, 3.8G)
+- Norwegian Nynorsk  (57 hours, 4.8G)
+- Norwegian  (107 hours, 9.7G)
+- Occitan  (15 hours, 1.5G)
+- Panjabi  (54 hours, 5.2G)
+- Polish  (80 hours, 7.6G)
+- Pushto  (47 hours, 4.5G)
+- Portuguese  (64 hours, 6.1G)
+- Romanian  (65 hours, 6.1G)
+- Russian  (73 hours, 6.9G)
+- Sanskrit  (15 hours, 1.6G)
+- Scots  (3 hours, 269M)
+- Sindhi  (84 hours, 8.3G)
+- Sinhala  (67 hours, 6.4G)
+- Slovak  (40 hours, 3.7G)
+- Slovenian  (121 hours, 12G)
+- Shona  (30 hours, 2.9G)
+- Somali  (103 hours, 9.9G)
+- Albanian  (71 hours, 6.6G)
+- Serbian  (50 hours, 4.7G)
+- Sundanese  (64 hours, 6.2G)
+- Swedish  (34 hours, 3.1G)
+- Swahili  (64 hours, 6.1G)
+- Tamil  (51 hours, 5.0G)
+- Telugu  (77 hours, 7.5G)
+- Tajik  (64 hours, 6.1G)
+- Thai  (61 hours, 5.8G)
+- Turkmen  (85 hours, 8.1G)
+- Tagalog  (93 hours, 8.7G)
+- Turkish  (59 hours, 5.7G)
+- Tatar  (103 hours, 9.6G)
+- Ukrainian  (52 hours, 4.9G)
+- Urdu  (42 hours, 4.1G)
+- Uzbek  (45 hours, 4.3G)
+- Vietnamese  (64 hours, 6.1G)
+- Waray  (11 hours, 1.1G)
+- Yiddish  (46 hours, 4.4G)
+- Yoruba  (94 hours, 9.1G)
+- Mandarin Chinese  (44 hours, 4.1G)
+

--- a/recipes/VoxLingua107/lang_id/README.md
+++ b/recipes/VoxLingua107/lang_id/README.md
@@ -1,4 +1,4 @@
-# Language identification experiments using the VoxLingua107 dataset.
+# Language identification experiments using the VoxLingua107 dataset
 
 This folder contains scripts for running language identification experiments with the VoxLingua107 dataset. 
 These experiments were highly inspired by the language identification experiments on the CommonLanguage dataset,

--- a/recipes/VoxLingua107/lang_id/README.md
+++ b/recipes/VoxLingua107/lang_id/README.md
@@ -1,0 +1,143 @@
+# Language identification experiments using the VoxLingua107 dataset.
+
+This folder contains scripts for running language identification experiments with the VoxLingua107 dataset. 
+These experiments were highly inspired by the language identification experiments on the CommonLanguage dataset,
+as well as speaker recognition experiments with the VoxCeleb dataset. However, due to the large size of
+the VoxLingua107 dataset, it has also significant differences, most prominently in using a WebDataset
+based data loading pipeline.
+
+The VoxLingua107 dataset contains over 2.5 million utterance-like audio files. Training a model on them
+as in the Voxceleb recipe would cause heavy disk loads. Therefore we opted to using WebDataset based training:
+before training, audio files are shuffled and distributed into over 500 so-called shards (tar files). During training,
+the tar files are opened in random order, the audio files in the shards are shuffled again on-the-fly using a moderately large buffer
+and fed to the training process. This reduces the disk load during training by large margin. This is all 
+handled by the WebDataset library.
+
+## Downloading the data
+
+You have three options how to download and prepare the VoxLingua107 dataset for training the model:
+
+  - Download the VoxLingua107 language-specific zips from http://bark.phon.ioc.ee/voxlingua107/ and convert them
+    to WebDataset format. This is the most flexible option, as it allows selecting a subset of VoxLingua107 languages,
+    or adding new languages. It will require around 2.2 TB disk space.
+        
+  - Download the pre-compiled WebDataset shards from http://bark.phon.ioc.ee/voxlingua107/. It will require around 1.4T of disk space.
+  
+  - Train directly on the WebDataset shards hosted on the web (i.e., the shards will be downloaded automatically during training). In this
+    case it is recomended to cache the shards (configurable in the hyperparameter configuration file).
+    
+### 1st option: download the VoxLingua107 zips and create the Webdataset shards
+
+Download the zips:
+  
+```
+# Select a place with around 1 TB of free space
+cd /data/
+mkdir voxlingua107
+cd voxlingua107
+wget http://bark.phon.ioc.ee/voxlingua107/zip_urls.txt
+cat zip_urls.txt | xargs  wget --continue
+wget bark.phon.ioc.ee/voxlingua107/dev.zip
+
+```
+
+Create WebDataset shards:
+
+```
+python create_wds_shards.py /data/voxlingua107/train/ /data/voxlingua107_shards/train
+python create_wds_shards.py /data/voxlingua107/dev/ /data/voxlingua107_shards/dev
+```
+
+### 2nd option: download the pre-compiled WebDataset shards
+
+Download the shards:
+
+```
+# Select a place with around 1 TB of free space
+cd /data/
+mkdir voxlingua107_shards
+cd voxlingua107_shards
+wget  -r -nH --cut-dirs=4 --no-parent --reject="index.html*" http://bark.phon.ioc.ee/lw/korpused/voxlingua107/shards/
+```
+
+## 3rd option:
+
+Just set the `shard_cache_dir` property in `hparams/train_epaca_tdnn_wds.yaml` to something, e.g. `/data/voxlingua107_shards`.
+
+
+## Training
+
+```
+python train.py hparams/train_epaca_tdnn_wds.yaml
+```
+
+Training is run for 30 epochs. One epoch takes one hour and 40 minutes on a NVidia A100 GPU.
+
+
+# Performance
+| Release | hyperparams file | Dev error rate | Model link | GPUs |
+|:-------------:|:---------------------------:| -----:| -----:| --------:| :-----------:|
+| 21-08-24 | train.yaml | 7.3 |https://drive.google.com/drive/folders/1NWIOXpHvC7qUZ16TmNC8oFjfEcjXnKop?usp=sharing | 2xA100 40GB |
+
+
+
+# Inference
+The pre-trained model + easy inference is available on HuggingFace:
+- https://huggingface.co/TalTechNLP/voxlingua107-epaca-tdnn
+
+You can run inference with only few lines of code:
+
+```python
+import torchaudio
+from speechbrain.pretrained import EncoderClassifier
+language_id = EncoderClassifier.from_hparams(source="TalTechNLP/voxlingua107-epaca-tdnn", savedir="tmp")
+# Download Thai language sample from Omniglot
+signal = language_id.load_audio("https://omniglot.com/soundfiles/udhr/udhr_th.mp3")
+prediction =  language_id.classify_batch(signal)
+print(prediction)
+  (tensor([[0.3210, 0.3751, 0.3680, 0.3939, 0.4026, 0.3644, 0.3689, 0.3597, 0.3508,
+           0.3666, 0.3895, 0.3978, 0.3848, 0.3957, 0.3949, 0.3586, 0.4360, 0.3997,
+           0.4106, 0.3886, 0.4177, 0.3870, 0.3764, 0.3763, 0.3672, 0.4000, 0.4256,
+           0.4091, 0.3563, 0.3695, 0.3320, 0.3838, 0.3850, 0.3867, 0.3878, 0.3944,
+           0.3924, 0.4063, 0.3803, 0.3830, 0.2996, 0.4187, 0.3976, 0.3651, 0.3950,
+           0.3744, 0.4295, 0.3807, 0.3613, 0.4710, 0.3530, 0.4156, 0.3651, 0.3777,
+           0.3813, 0.6063, 0.3708, 0.3886, 0.3766, 0.4023, 0.3785, 0.3612, 0.4193,
+           0.3720, 0.4406, 0.3243, 0.3866, 0.3866, 0.4104, 0.4294, 0.4175, 0.3364,
+           0.3595, 0.3443, 0.3565, 0.3776, 0.3985, 0.3778, 0.2382, 0.4115, 0.4017,
+           0.4070, 0.3266, 0.3648, 0.3888, 0.3907, 0.3755, 0.3631, 0.4460, 0.3464,
+           0.3898, 0.3661, 0.3883, 0.3772, 0.9289, 0.3687, 0.4298, 0.4211, 0.3838,
+           0.3521, 0.3515, 0.3465, 0.4772, 0.4043, 0.3844, 0.3973, 0.4343]]), tensor([0.9289]), tensor([94]), ['th'])
+# The scores in the prediction[0] tensor can be interpreted as cosine scores between
+# the languages and the given utterance (i.e., the larger the better)
+# The identified language ISO code is given in prediction[3]
+print(prediction[3])
+  ['th']
+
+# Alternatively, use the utterance embedding extractor:
+emb =  language_id.encode_batch(signal)
+print(emb.shape)
+  torch.Size([1, 1, 256])
+```
+
+
+# **About SpeechBrain**
+- Website: https://speechbrain.github.io/
+- Code: https://github.com/speechbrain/speechbrain/
+- HuggingFace: https://huggingface.co/speechbrain/
+
+
+# **Citing SpeechBrain**
+Please, cite SpeechBrain if you use it for your research or business.
+
+```bibtex
+@misc{speechbrain,
+  title={{SpeechBrain}: A General-Purpose Speech Toolkit},
+  author={Mirco Ravanelli and Titouan Parcollet and Peter Plantinga and Aku Rouhe and Samuele Cornell and Loren Lugosch and Cem Subakan and Nauman Dawalatabad and Abdelwahab Heba and Jianyuan Zhong and Ju-Chieh Chou and Sung-Lin Yeh and Szu-Wei Fu and Chien-Feng Liao and Elena Rastorgueva and François Grondin and William Aris and Hwidong Na and Yan Gao and Renato De Mori and Yoshua Bengio},
+  year={2021},
+  eprint={2106.04624},
+  archivePrefix={arXiv},
+  primaryClass={eess.AS},
+  note={arXiv:2106.04624}
+}
+```
+

--- a/recipes/VoxLingua107/lang_id/README.md
+++ b/recipes/VoxLingua107/lang_id/README.md
@@ -76,7 +76,7 @@ Training is run for 30 epochs. One epoch takes one hour and 40 minutes on a NVid
 
 # Performance
 | Release | hyperparams file | Dev error rate | Model link | GPUs |
-|:-------------:|:---------------------------:| -----:| -----:| --------:| :-----------:|
+|:-------------:|:---------------------------:| -----:| -----:| :-----------:|
 | 21-08-24 | train.yaml | 7.3 |https://drive.google.com/drive/folders/1NWIOXpHvC7qUZ16TmNC8oFjfEcjXnKop?usp=sharing | 2xA100 40GB |
 
 

--- a/recipes/VoxLingua107/lang_id/create_wds_shards.py
+++ b/recipes/VoxLingua107/lang_id/create_wds_shards.py
@@ -1,0 +1,182 @@
+################################################################################
+#
+# Converts the unzipped <LANG_ID>/<VIDEO---0000.000-0000.000.wav> folder
+# structure of VoxLingua107 into a WebDataset format
+#
+# Author(s): Tanel Alumäe, Nik Vaessen
+################################################################################
+
+import json
+import pathlib
+import argparse
+import random
+import re
+from collections import defaultdict
+
+import torch
+import torchaudio
+import webdataset as wds
+
+################################################################################
+# methods for writing the shards
+
+ID_SEPARATOR = "&"
+
+
+def load_audio(audio_file_path: pathlib.Path) -> torch.Tensor:
+    t, sr = torchaudio.load(audio_file_path)
+
+    if sr != 16000:
+        raise ValueError("expected sampling rate of 16 kHz")
+
+    return t
+
+
+def write_shards(
+    voxlingua_folder_path: pathlib.Path,
+    shards_path: pathlib.Path,
+    seed: int,
+    samples_per_shard: int,
+    min_dur: float,
+):
+    """
+    Parameters
+    ----------
+    voxlingua_folder_path: folder where extracted voxceleb data is located
+    shards_path: folder to write shards of data to
+    seed: random seed used to initially shuffle data into shards
+    samples_per_shard: number of data samples to store in each shards.
+    """
+    # make sure output folder exist
+    shards_path.mkdir(parents=True, exist_ok=True)
+
+    # find all audio files
+    audio_files = sorted([f for f in voxlingua_folder_path.rglob("*.wav")])
+
+    # create tuples (unique_sample_id, language_id, path_to_audio_file, duration)
+    data_tuples = []
+
+    # track statistics on data
+    all_language_ids = set()
+    sample_keys_per_language = defaultdict(list)
+
+    for f in audio_files:
+        # path should be
+        # voxlingua107_folder_path/<LANG_ID>/<VIDEO---0000.000-0000.000.wav>
+        m = re.match(
+            r"(.*/((.+)/.+---(\d\d\d\d\.\d\d\d)-(\d\d\d\d\.\d\d\d))\.wav)",
+            f.as_posix(),
+        )
+        if m:
+            loc = m.group(1)
+            key = m.group(2)
+            lang = m.group(3)
+            start = float(m.group(4))
+            end = float(m.group(5))
+            dur = end - start
+            # Period is not allowed in a WebDataset key name
+            key = key.replace(".", "_")
+            if dur > min_dur:
+                # store statistics
+                all_language_ids.add(lang)
+                sample_keys_per_language[lang].append(key)
+                t = (key, lang, loc, dur)
+                data_tuples.append(t)
+        else:
+            raise Exception("Unexpected wav name: " + f)
+
+    all_language_ids = sorted(all_language_ids)
+
+    # write a meta.json file which contains statistics on the data
+    # which will be written to shards
+    meta_dict = {
+        "language_ids": list(all_language_ids),
+        "sample_keys_per_language": sample_keys_per_language,
+        "num_data_samples": len(data_tuples),
+    }
+
+    with (shards_path / "meta.json").open("w") as f:
+        json.dump(meta_dict, f)
+
+    # shuffle the tuples so that each shard has a large variety in languages
+    random.seed(seed)
+    random.shuffle(data_tuples)
+
+    # write shards
+    all_keys = set()
+    shards_path.mkdir(exist_ok=True, parents=True)
+    pattern = str(shards_path / "shard") + "-%06d.tar"
+
+    with wds.ShardWriter(pattern, maxcount=samples_per_shard) as sink:
+        for key, language_id, f, duration in data_tuples:
+
+            # load the audio tensor
+            tensor = load_audio(f)
+
+            # verify key is unique
+            assert key not in all_keys
+            all_keys.add(key)
+
+            # extract language_id, youtube_id and utterance_id from key
+            # language_id = all_language_ids[language_id_idx]
+
+            # create sample to write
+            sample = {
+                "__key__": key,
+                "audio.pth": tensor,
+                "language_id": language_id,
+            }
+
+            # write sample to sink
+            sink.write(sample)
+
+
+################################################################################
+# define CLI
+
+parser = argparse.ArgumentParser(
+    description="Convert VoxLingua107 to WebDataset shards"
+)
+
+parser.add_argument(
+    "voxlingua107_path",
+    type=pathlib.Path,
+    help="directory containing the (unzipped) VoxLingua107 dataset",
+)
+parser.add_argument(
+    "shards_path", type=pathlib.Path, help="directory to write shards to"
+)
+parser.add_argument(
+    "--seed",
+    type=int,
+    default=12345,
+    help="random seed used for shuffling data before writing to shard",
+)
+parser.add_argument(
+    "--samples_per_shard",
+    type=int,
+    default=5000,
+    help="the maximum amount of samples placed in each shard. The last shard "
+    "will most likely contain fewer samples.",
+)
+parser.add_argument(
+    "--min-duration",
+    type=float,
+    default=3.0,
+    help="Minimum duration of the audio",
+)
+
+
+################################################################################
+# execute script
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+
+    write_shards(
+        args.voxlingua107_path,
+        args.shards_path,
+        args.seed,
+        args.samples_per_shard,
+        args.min_duration,
+    )

--- a/recipes/VoxLingua107/lang_id/hparams/train_epaca_tdnn_wds.yaml
+++ b/recipes/VoxLingua107/lang_id/hparams/train_epaca_tdnn_wds.yaml
@@ -21,7 +21,7 @@ train_shards: !ref <shards_url>/train/shard-{000000..000507}.tar
 val_shards: !ref <shards_url>/dev/shard-000000.tar
 
 # Set to directory on a large disk if you are training on Webdataset shards hosted on the web
-shard_cache_dir: 
+shard_cache_dir:
 
 ckpt_interval_minutes: 5
 

--- a/recipes/VoxLingua107/lang_id/hparams/train_epaca_tdnn_wds.yaml
+++ b/recipes/VoxLingua107/lang_id/hparams/train_epaca_tdnn_wds.yaml
@@ -1,0 +1,147 @@
+################################
+# Model: language identification with ECAPA
+# Authors: Tanel Alumäe
+# ################################
+
+# Basic parameters
+seed: 1988
+__set_seed: !apply:torch.manual_seed [!ref <seed>]
+output_folder: !ref results/epaca_tdnn_wds/<seed>
+save_folder: !ref <output_folder>/save
+train_log: !ref <output_folder>/train_log.txt
+data_folder: ./
+
+
+shards_url: /data/voxlingua107_shards
+# Uncomment the following if you want to train on Webdataset shards hosted on the web
+#shards__url: http://bark.phon.ioc.ee/lw/korpused/voxlingua107/shards/
+train_meta: !ref <shards_url>/train/meta.json
+val_meta: !ref <shards_url>/dev/meta.json
+train_shards: !ref <shards_url>/train/shard-{000000..000507}.tar
+val_shards: !ref <shards_url>/dev/shard-000000.tar
+
+# Set to directory on a large disk if you are training on Webdataset shards hosted on the web
+shard_cache_dir: 
+
+ckpt_interval_minutes: 5
+
+# Training parameters
+number_of_epochs: 30
+lr: 0.0001
+lr_final: 0.00001
+base_lr: 0.00000001
+max_lr: !ref <lr>
+step_size: 65000
+sample_rate: 16000
+sentence_len: 3 # seconds
+shuffle: False
+random_chunk: True
+
+# Feature parameters
+n_mels: 60
+left_frames: 0
+right_frames: 0
+deltas: False
+
+# Number of languages
+out_n_neurons: 107
+
+train_dataloader_options:
+    num_workers: 8
+    batch_size: 128
+
+val_dataloader_options:
+    num_workers: 1
+    batch_size: 32
+
+# Functions
+compute_features: !new:speechbrain.lobes.features.Fbank
+    n_mels: !ref <n_mels>
+    left_frames: !ref <left_frames>
+    right_frames: !ref <right_frames>
+    deltas: !ref <deltas>
+
+embedding_model: !new:speechbrain.lobes.models.ECAPA_TDNN.ECAPA_TDNN
+    input_size: !ref <n_mels>
+    channels: [1024, 1024, 1024, 1024, 3072]
+    kernel_sizes: [5, 3, 3, 3, 1]
+    dilations: [1, 2, 3, 4, 1]
+    attention_channels: 128
+    lin_neurons: 256
+
+classifier: !new:speechbrain.lobes.models.ECAPA_TDNN.Classifier
+    input_size: 256
+    out_neurons: !ref <out_n_neurons>
+
+epoch_counter: !new:speechbrain.utils.epoch_loop.EpochCounter
+    limit: !ref <number_of_epochs>
+
+
+augment_speed: !new:speechbrain.lobes.augment.TimeDomainSpecAugment
+    sample_rate: !ref <sample_rate>
+    speeds: [90, 100, 110]
+
+
+add_rev_noise: !new:speechbrain.lobes.augment.EnvCorrupt
+    openrir_folder: !ref <data_folder>
+    openrir_max_noise_len: 3.0  # seconds
+    reverb_prob: 0.5
+    noise_prob: 0.8
+    noise_snr_low: 0
+    noise_snr_high: 15
+    rir_scale_factor: 1.0
+
+# Definition of the augmentation pipeline.
+# If concat_augment = False, the augmentation techniques are applied
+# in sequence. If concat_augment = True, all the augmented signals
+# # are concatenated in a single big batch.
+augment_pipeline: [
+    !ref <augment_speed>,
+    !ref <add_rev_noise>
+]
+
+concat_augment: False
+
+mean_var_norm: !new:speechbrain.processing.features.InputNormalization
+    norm_type: sentence
+    std_norm: False
+
+modules:
+    compute_features: !ref <compute_features>
+    augment_speed: !ref <augment_speed>
+    add_rev_noise: !ref <add_rev_noise>
+    embedding_model: !ref <embedding_model>
+    classifier: !ref <classifier>
+    mean_var_norm: !ref <mean_var_norm>
+
+compute_cost: !new:speechbrain.nnet.losses.LogSoftmaxWrapper
+    loss_fn: !new:speechbrain.nnet.losses.AdditiveAngularMargin
+        margin: 0.2
+        scale: 30
+
+compute_error: !name:speechbrain.nnet.losses.classification_error
+
+opt_class: !name:torch.optim.Adam
+    lr: !ref <lr>
+    weight_decay: 0.000002
+
+lr_annealing: !new:speechbrain.nnet.schedulers.LinearScheduler
+    initial_value: !ref <lr>
+    final_value: !ref <lr_final>
+    epoch_count: !ref <number_of_epochs>
+
+# Logging + checkpoints
+train_logger: !new:speechbrain.utils.train_logger.FileTrainLogger
+    save_file: !ref <train_log>
+
+error_stats: !name:speechbrain.utils.metric_stats.MetricStats
+    metric: !name:speechbrain.nnet.losses.classification_error
+        reduction: batch
+
+checkpointer: !new:speechbrain.utils.checkpoints.Checkpointer
+    checkpoints_dir: !ref <save_folder>
+    recoverables:
+        embedding_model: !ref <embedding_model>
+        classifier: !ref <classifier>
+        normalizer: !ref <mean_var_norm>
+        counter: !ref <epoch_counter>

--- a/recipes/VoxLingua107/lang_id/train.py
+++ b/recipes/VoxLingua107/lang_id/train.py
@@ -1,0 +1,272 @@
+#!/usr/bin/python3
+"""Recipe for training language embeddings using the VoxLingua107 Dataset.
+
+This recipe is heavily inspired by this: https://github.com/nikvaessen/speechbrain/tree/sharded-voxceleb/my-recipes/SpeakerRec
+
+To run this recipe, use the following command:
+> python train_lang_embeddings_wds.py {hyperparameter_file}
+
+Using your own hyperparameter file or one of the following:
+
+    hparams/train_epaca_tdnn_wds.yaml (for the ecapa+tdnn system)
+
+Author
+    * Mirco Ravanelli 2020
+    * Hwidong Na 2020
+    * Nauman Dawalatabad 2020
+    * Tanel Alumäe 2021
+    * @nikvaessen
+"""
+import os
+import sys
+import random
+from typing import Dict
+import json
+from functools import partial
+import webdataset as wds
+import logging
+
+import torch
+import speechbrain as sb
+from hyperpyyaml import load_hyperpyyaml
+from speechbrain.dataio.batch import PaddedBatch
+
+logger = logging.getLogger(__name__)
+
+
+class LanguageBrain(sb.core.Brain):
+    """Class for language ID training"
+    """
+
+    def compute_forward(self, batch, stage):
+        """Computation pipeline based on a encoder + speaker classifier.
+        Data augmentation and environmental corruption are applied to the
+        input speech.
+        """
+        batch = batch.to(self.device)
+        wavs, lens = batch.sig
+
+        if stage == sb.Stage.TRAIN:
+
+            # Applying the augmentation pipeline
+            wavs_aug_tot = []
+            wavs_aug_tot.append(wavs)
+            for count, augment in enumerate(self.hparams.augment_pipeline):
+
+                # Apply augment
+                wavs_aug = augment(wavs, lens)
+
+                # Managing speed change
+                if wavs_aug.shape[1] > wavs.shape[1]:
+                    wavs_aug = wavs_aug[:, 0 : wavs.shape[1]]
+                else:
+                    zero_sig = torch.zeros_like(wavs)
+                    zero_sig[:, 0 : wavs_aug.shape[1]] = wavs_aug
+                    wavs_aug = zero_sig
+
+                if self.hparams.concat_augment:
+                    wavs_aug_tot.append(wavs_aug)
+                else:
+                    wavs = wavs_aug
+                    wavs_aug_tot[0] = wavs
+
+            wavs = torch.cat(wavs_aug_tot, dim=0)
+            self.n_augment = len(wavs_aug_tot)
+            lens = torch.cat([lens] * self.n_augment)
+
+        # Feature extraction and normalization
+        feats = self.modules.compute_features(wavs)
+        feats = self.modules.mean_var_norm(feats, lens)
+
+        # Embeddings + speaker classifier
+        embeddings = self.modules.embedding_model(feats, lens)
+        outputs = self.modules.classifier(embeddings)
+
+        return outputs, lens
+
+    def compute_objectives(self, predictions, batch, stage):
+        """Computes the loss using speaker-id as label.
+        """
+        predictions, lens = predictions
+        uttid = batch.id
+        langid = batch.lang_id_encoded
+
+        # Concatenate labels (due to data augmentation)
+        if stage == sb.Stage.TRAIN:
+            langid = torch.cat([langid] * self.n_augment, dim=0)
+
+        # breakpoint()
+        loss = self.hparams.compute_cost(predictions, langid.unsqueeze(1), lens)
+
+        if hasattr(self.hparams.lr_annealing, "on_batch_end"):
+            self.hparams.lr_annealing.on_batch_end(self.optimizer)
+
+        if stage != sb.Stage.TRAIN:
+            self.error_metrics.append(
+                uttid, predictions, langid.unsqueeze(1), lens
+            )
+
+        return loss
+
+    def on_stage_start(self, stage, epoch=None):
+        """Gets called at the beginning of an epoch."""
+        if stage != sb.Stage.TRAIN:
+            self.error_metrics = self.hparams.error_stats()
+
+    def on_stage_end(self, stage, stage_loss, epoch=None):
+        """Gets called at the end of an epoch."""
+        # Compute/store important stats
+        stage_stats = {"loss": stage_loss}
+        if stage == sb.Stage.TRAIN:
+            self.train_stats = stage_stats
+        else:
+            stage_stats["ErrorRate"] = self.error_metrics.summarize("average")
+
+        # Perform end-of-iteration things, like annealing, logging, etc.
+        if stage == sb.Stage.VALID:
+            old_lr, new_lr = self.hparams.lr_annealing(epoch)
+            sb.nnet.schedulers.update_learning_rate(self.optimizer, new_lr)
+
+            self.hparams.train_logger.log_stats(
+                stats_meta={"epoch": epoch, "lr": old_lr},
+                train_stats=self.train_stats,
+                valid_stats=stage_stats,
+            )
+            self.checkpointer.save_and_keep_only(
+                meta={"ErrorRate": stage_stats["ErrorRate"]},
+                min_keys=["ErrorRate"],
+            )
+
+
+def dataio_prep_shards(hparams):
+
+    # load the meta info json file
+    with wds.gopen.gopen(hparams["train_meta"], "rb") as f:
+        train_meta = json.load(f)
+    with wds.gopen.gopen(hparams["val_meta"], "rb") as f:
+        val_meta = json.load(f)
+
+    # define the mapping functions in the data pipeline
+    snt_len_sample = int(hparams["sample_rate"] * hparams["sentence_len"])
+    label_encoder = sb.dataio.encoder.CategoricalEncoder()
+    lab_enc_file = os.path.join(hparams["save_folder"], "label_encoder.txt")
+    label_encoder.load_or_create(
+        path=lab_enc_file,
+        from_iterables=[train_meta["language_ids"]],
+        output_key="lang_id",
+    )
+    # breakpoint()
+
+    def audio_pipeline(sample_dict: Dict, random_chunk=True):
+        key = sample_dict["__key__"]
+        language_id = sample_dict["language_id"].decode("ascii")
+        audio_tensor = sample_dict["audio.pth"]
+
+        # determine what part of audio sample to use
+        audio_tensor = audio_tensor.squeeze()
+
+        if random_chunk:
+            if len(audio_tensor) - snt_len_sample - 1 <= 0:
+                start = 0
+            else:
+                start = random.randint(
+                    0, len(audio_tensor) - snt_len_sample - 1
+                )
+
+            stop = start + snt_len_sample
+        else:
+            start = 0
+            stop = len(audio_tensor)
+
+        sig = audio_tensor[start:stop]
+
+        # determine the language ID of the sample
+        lang_id_idx = label_encoder.encode_label(language_id)
+
+        return {
+            "sig": sig,
+            "lang_id_encoded": lang_id_idx,
+            "id": key,
+        }
+
+    train_data = (
+        wds.WebDataset(
+            hparams["train_shards"],
+            length=train_meta["num_data_samples"],
+            cache_dir=hparams["shard_cache_dir"],
+        )
+        .repeat()
+        .shuffle(1000)
+        .decode("pil")
+        .map(partial(audio_pipeline, random_chunk=True))
+    )
+    logger.info(
+        f"Training data consist of {train_meta['num_data_samples']} samples"
+    )
+
+    valid_data = (
+        wds.WebDataset(
+            hparams["val_shards"],
+            length=val_meta["num_data_samples"],
+            cache_dir=hparams["shard_cache_dir"],
+        )
+        .decode("pil")
+        .map(partial(audio_pipeline, random_chunk=False))
+    )
+    logger.info(
+        f"Validation data consist of {val_meta['num_data_samples']} samples"
+    )
+
+    return train_data, valid_data
+
+
+if __name__ == "__main__":
+
+    logger.info("Starting training...")
+    # This flag enables the inbuilt cudnn auto-tuner
+    torch.backends.cudnn.benchmark = True
+
+    # CLI:
+    hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
+
+    # Initialize ddp (useful only for multi-GPU DDP training)
+    sb.utils.distributed.ddp_init_group(run_opts)
+
+    # Load hyperparameters file with command-line overrides
+    with open(hparams_file) as fin:
+        hparams = load_hyperpyyaml(fin, overrides)
+
+    train_data, valid_data = dataio_prep_shards(hparams)
+
+    # add collate_fn to dataloader options
+    hparams["train_dataloader_options"]["collate_fn"] = PaddedBatch
+    hparams["val_dataloader_options"]["collate_fn"] = PaddedBatch
+
+    hparams["train_dataloader_options"]["looped_nominal_epoch"] = (
+        len(train_data) // hparams["train_dataloader_options"]["batch_size"]
+    )
+
+    # Create experiment directory
+    sb.core.create_experiment_directory(
+        experiment_directory=hparams["output_folder"],
+        hyperparams_to_save=hparams_file,
+        overrides=overrides,
+    )
+
+    # Brain class initialization
+    language_brain = LanguageBrain(
+        modules=hparams["modules"],
+        opt_class=hparams["opt_class"],
+        hparams=hparams,
+        run_opts=run_opts,
+        checkpointer=hparams["checkpointer"],
+    )
+
+    # Training
+    language_brain.fit(
+        language_brain.hparams.epoch_counter,
+        train_data,
+        valid_data,
+        train_loader_kwargs=hparams["train_dataloader_options"],
+        valid_loader_kwargs=hparams["val_dataloader_options"],
+    )


### PR DESCRIPTION
This PR adds a recipe for training a spoken language identification model using the VoxLingua107 dataset (http://bark.phon.ioc.ee/voxlingua107/). It is fairly similar to CommonLanguage and VoxCeleb recipes, except that it uses a WebDataset based data loading pipeline. A model trained using this recipe is available at https://huggingface.co/TalTechNLP/voxlingua107-epaca-tdnn.