### PR TITLE
Small bug fix in ECAPA-TDNN classifier

### DIFF
--- a/speechbrain/lobes/models/ECAPA_TDNN.py
+++ b/speechbrain/lobes/models/ECAPA_TDNN.py
@@ -523,7 +523,7 @@ class Classifier(torch.nn.Module):
         for block_index in range(lin_blocks):
             self.blocks.extend(
                 [
-                    _BatchNorm1d(input_size),
+                    _BatchNorm1d(input_size=input_size),
                     Linear(input_size=input_size, n_neurons=lin_neurons),
                 ]
             )


### PR DESCRIPTION
Fixes the following error that occurs only when constructing the ECAPA-TDNN classifier with `lin_neurons > 0`
```
>>> from speechbrain.lobes.models.ECAPA_TDNN import Classifier                                                                                                                                                                                                                            
>>> classify = Classifier(input_size=2, lin_neurons=2, out_neurons=2)                                                                                                                                                                                                                     
>>> classify = Classifier(input_size=256, lin_neurons=2, lin_blocks=2, out_neurons=2)                                                                                                                                                                                                     
Traceback (most recent call last):                                                                                                           
  File "<stdin>", line 1, in <module>                                                                                                                                                                                                                                                     
  File "/ceph/home/tanel.alumae/tools/speechbrain/speechbrain/lobes/models/ECAPA_TDNN.py", line 526, in __init__                                                                                                                                                                          
    _BatchNorm1d(input_size),                                                                                                                                                                                                                                                             
  File "/ceph/home/tanel.alumae/tools/speechbrain/speechbrain/nnet/normalization.py", line 60, in __init__                                   
    input_size = input_shape[-1]                                                                                                                                                                                                                                                          
TypeError: 'int' object is not subscriptable
```
