### PR TITLE
python 3.7 and 3.9 github actions

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -32,8 +32,8 @@ jobs:
         name: Tests
         runs-on: ubuntu-latest
         strategy:
-          matrix:
-            python-version: [3.7, 3.8, 3.9]
+            matrix:
+                python-version: [3.7, 3.8, 3.9]
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -31,15 +31,20 @@ jobs:
     tests:
         name: Tests
         runs-on: ubuntu-latest
+        strategy:
+          matrix:
+            python-version: [3.7, 3.8, 3.9]
         steps:
             - uses: actions/checkout@v2
-            - name: Set up Python 3.8
+            - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v1
               with:
-                  python-version: 3.8
+                  python-version: ${{ matrix.python-version }}
             - name: Install libsndfile
               run: |
                   sudo apt-get install -y libsndfile1
+            - name: Display Python version
+              run: python -c "import sys; print(sys.version)"
             - name: Full dependencies
               run: |
                   pip install -r requirements.txt


### PR DESCRIPTION
If speechbrain setup.py says that speechbrain supports Python >= 3.7, then CI should run speechbrain unittests on python 3.7 - 3.9.

The github actions will not run on this PR unless you give my PR permission to trigger CI. But you can see the CI results here: https://github.com/turian/speechbrain/pull/1