### PR TITLE
Skip CTC-segmentation test if module not available

### DIFF
--- a/tests/unittests/test_ctc_segmentation.py
+++ b/tests/unittests/test_ctc_segmentation.py
@@ -1,6 +1,16 @@
 from speechbrain.pretrained import EncoderDecoderASR
 import pytest
 
+try:
+    import speechbrain.alignment.ctc_segmentation  # noqa F401
+
+    CTC_SEG_AVAIL = True
+except ImportError:
+    pytest.skip(
+        "These tests require the ctc_segmentation library",
+        allow_module_level=True,
+    )
+
 
 @pytest.fixture()
 def asr_model():

--- a/tests/unittests/test_ctc_segmentation.py
+++ b/tests/unittests/test_ctc_segmentation.py
@@ -1,15 +1,10 @@
 from speechbrain.pretrained import EncoderDecoderASR
 import pytest
 
-try:
-    import speechbrain.alignment.ctc_segmentation  # noqa F401
-
-    CTC_SEG_AVAIL = True
-except ImportError:
-    pytest.skip(
-        "These tests require the ctc_segmentation library",
-        allow_module_level=True,
-    )
+pytest.importorskip(
+    "speechbrain.alignment.ctc_segmentation",
+    reason="These tests require the ctc_segmentation library",
+)
 
 
 @pytest.fixture()


### PR DESCRIPTION
This simply skips the tests if the extra dependency is not installed.