### PR TITLE
update setup with torch version 1.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "packaging",
         "scipy",
         "sentencepiece",
-        "torch>=1.8.0,<=1.8.1",
+        "torch>=1.7,<=1.11",
         "torchaudio",
         "tqdm",
         "huggingface_hub",


### PR DESCRIPTION
hi @mravanelli , @TParcollet , @Gastron ,

here is a PR for fixing the issue of installing the latest pytorch version with:
```
pip install speechbrain
```

The problem I saw is that with our pip install, it always install the last version of pytorch.

to reproduce the problem:
```
conda install -n spbrain_1_10 python=3.8
conda activate spbrain_1_10
# with the current `setup.py` it will install pytorch 1.10
pip install speechbrain
python3
import speechbrain
speechbrain.__version__
'0.5.10'
import torch
torch.__version__
'1.10.0+cu102'
``` 


```
conda install -n PR_spbrain_1_10 python=3.8
conda activate PR_spbrain_1_10
# with the new `setup.py` it will install pytorch 1.8.1
pip install git+https://github.com/aheba/speechbrain-aheba-contribs.git@fix-pip-torch-version
python3
>>> import torch
>>> torch.__version__
'1.8.1+cu102'
>>> import speechbrain
>>> speechbrain.__version__
'0.5.10'
```

I will investigate the problem of inference later.

This PR will handle the use of specific pytorch version instead of installing the latest one