### PR TITLE
Use the parameter layers to determine the number of RNN layers in templates/speech_recognition/LM/custom_model.py

### DIFF
--- a/templates/speech_recognition/LM/custom_model.py
+++ b/templates/speech_recognition/LM/custom_model.py
@@ -57,7 +57,7 @@ class CustomModel(torch.nn.Module):
             input_size=embedding_dim,
             hidden_size=rnn_size,
             bidirectional=False,
-            num_layers=layers
+            num_layers=layers,
         )
 
         # Final output transformation + softmax


### PR DESCRIPTION
By now the parameter **layers** is unused, so it will be nice to use it in the CustomModel to determine the number of RNN layers.