### PR TITLE
Fixed freezing wav2vec at LibriSpeech CTC recipe

### DIFF
--- a/recipes/LibriSpeech/ASR/ctc/train_with_wav2vec.py
+++ b/recipes/LibriSpeech/ASR/ctc/train_with_wav2vec.py
@@ -52,7 +52,7 @@ class ASR(sb.Brain):
 
         # Forward pass
         feats = self.modules.wav2vec2(wavs)
-        x = self.modules.enc(feats.detach())
+        x = self.modules.enc(feats)
 
         # Compute outputs
         p_tokens = None


### PR DESCRIPTION
A fix of #1077