### PR TITLE
Remove torch.no_grad in feature lobes

### DIFF
--- a/speechbrain/lobes/features.py
+++ b/speechbrain/lobes/features.py
@@ -131,20 +131,15 @@ class Fbank(torch.nn.Module):
         wav : tensor
             A batch of audio signals to transform to features.
         """
-        with torch.no_grad():
-
-            STFT = self.compute_STFT(wav)
-            mag = spectral_magnitude(STFT)
-            fbanks = self.compute_fbanks(mag)
-
-            if self.deltas:
-                delta1 = self.compute_deltas(fbanks)
-                delta2 = self.compute_deltas(delta1)
-                fbanks = torch.cat([fbanks, delta1, delta2], dim=2)
-
-            if self.context:
-                fbanks = self.context_window(fbanks)
-
+        STFT = self.compute_STFT(wav)
+        mag = spectral_magnitude(STFT)
+        fbanks = self.compute_fbanks(mag)
+        if self.deltas:
+            delta1 = self.compute_deltas(fbanks)
+            delta2 = self.compute_deltas(delta1)
+            fbanks = torch.cat([fbanks, delta1, delta2], dim=2)
+        if self.context:
+            fbanks = self.context_window(fbanks)
         return fbanks
 
 
@@ -269,18 +264,14 @@ class MFCC(torch.nn.Module):
         wav : tensor
             A batch of audio signals to transform to features.
         """
-        with torch.no_grad():
-            STFT = self.compute_STFT(wav)
-            mag = spectral_magnitude(STFT)
-            fbanks = self.compute_fbanks(mag)
-            mfccs = self.compute_dct(fbanks)
-
-            if self.deltas:
-                delta1 = self.compute_deltas(mfccs)
-                delta2 = self.compute_deltas(delta1)
-                mfccs = torch.cat([mfccs, delta1, delta2], dim=2)
-
-            if self.context:
-                mfccs = self.context_window(mfccs)
-
+        STFT = self.compute_STFT(wav)
+        mag = spectral_magnitude(STFT)
+        fbanks = self.compute_fbanks(mag)
+        mfccs = self.compute_dct(fbanks)
+        if self.deltas:
+            delta1 = self.compute_deltas(mfccs)
+            delta2 = self.compute_deltas(delta1)
+            mfccs = torch.cat([mfccs, delta1, delta2], dim=2)
+        if self.context:
+            mfccs = self.context_window(mfccs)
         return mfccs


### PR DESCRIPTION
See discussion in [https://speechbrain.discourse.group/t/use-pretrained-speechbrain-model-as-loss/493/8](https://speechbrain.discourse.group/t/use-pretrained-speechbrain-model-as-loss/493/8). Also discussed this offline with Mirco and Titouan.

This change should theoretically be small, but in practice it affects a huge number of recipes, etc. Should maybe do some timing tests as well as run some basic recipe just to make sure there's no regression.