### PR TITLE
Fixed voicebank download error

### DIFF
--- a/recipes/Voicebank/voicebank_prepare.py
+++ b/recipes/Voicebank/voicebank_prepare.py
@@ -453,9 +453,8 @@ def download_vctk(destination, tmp_dir=None, device="cpu"):
             # Save downsampled file
             torchaudio.save(
                 os.path.join(dirname_16k, filename[-12:]),
-                downsampled_signal[0].cpu(),
-                sample_rate=16000,
-                channels_first=False,
+                downsampled_signal.cpu(),
+                sample_rate=16000
             )
 
             # Remove old file


### PR DESCRIPTION
`torchaudio.save` does not support 1D tensor anymore (https://github.com/pytorch/audio/issues/1010#issue-737332309)

I also search for all occurrences of `torchaudio.save` and it seems only this recipe still has this bug.