### PR TITLE
Torchaudio backed

### DIFF
--- a/recipes/CommonVoice/common_voice_prepare.py
+++ b/recipes/CommonVoice/common_voice_prepare.py
@@ -232,7 +232,7 @@ def create_csv(
         # Setting torchaudio backend to sox-io (needed to read mp3 files)
         if torchaudio.get_audio_backend() != "sox_io":
             logger.warning("This recipe needs the sox-io backend of torchaudio")
-            logger.warning("The torchaudio backed is changed to sox_io")
+            logger.warning("The torchaudio backend is changed to sox_io")
             torchaudio.set_audio_backend("sox_io")
 
         # Reading the signal (to retrieve duration in seconds)

--- a/recipes/CommonVoice/common_voice_prepare.py
+++ b/recipes/CommonVoice/common_voice_prepare.py
@@ -135,7 +135,7 @@ def prepare_common_voice(
     if dev_tsv_file is not None:
 
         create_csv(
-            dev_tsv_file, save_csv_dev, data_folder, accented_letters, language,
+            dev_tsv_file, save_csv_dev, data_folder, accented_letters, language
         )
 
     # Creating csv file for test data
@@ -177,7 +177,7 @@ def skip(save_csv_train, save_csv_dev, save_csv_test):
 
 
 def create_csv(
-    orig_tsv_file, csv_file, data_folder, accented_letters=False, language="en",
+    orig_tsv_file, csv_file, data_folder, accented_letters=False, language="en"
 ):
     """
     Creates the csv file given a list of wav files.
@@ -228,6 +228,12 @@ def create_csv(
         file_name = mp3_path.split(".")[-2].split("/")[-1]
         spk_id = line.split("\t")[0]
         snt_id = file_name
+
+        # Setting torchaudio backend to sox-io (needed to read mp3 files)
+        if torchaudio.get_audio_backend() != "sox_io":
+            logger.warning("This recipe needs the sox-io backend of torchaudio")
+            logger.warning("The torchaudio backed is changed to sox_io")
+            torchaudio.set_audio_backend("sox_io")
 
         # Reading the signal (to retrieve duration in seconds)
         if os.path.isfile(mp3_path):

--- a/recipes/DNS/enhance/spectral_map/train.py
+++ b/recipes/DNS/enhance/spectral_map/train.py
@@ -19,10 +19,9 @@ from speechbrain.utils.metric_stats import MetricStats
 from speechbrain.processing.features import spectral_magnitude
 from speechbrain.nnet.loss.stoi_loss import stoi_loss
 from speechbrain.utils.distributed import run_on_main
-from speechbrain.utils.torch_audio_backend import get_torchaudio_backend
+from speechbrain.utils.torch_audio_backend import check_torchaudio_backend
 
-torchaudio_backend = get_torchaudio_backend()
-torchaudio.set_audio_backend(torchaudio_backend)
+check_torchaudio_backend()
 logger = logging.getLogger(__name__)
 
 try:

--- a/recipes/Fisher-Callhome-Spanish/fisher_callhome_prepare.py
+++ b/recipes/Fisher-Callhome-Spanish/fisher_callhome_prepare.py
@@ -21,7 +21,7 @@ import torchaudio
 
 from tqdm import tqdm
 from speechbrain.utils.data_utils import get_all_files
-from speechbrain.utils.torch_audio_backend import get_torchaudio_backend
+from speechbrain.utils.torch_audio_backend import check_torchaudio_backend
 from speechbrain.processing.speech_augmentation import Resample
 
 try:
@@ -32,8 +32,7 @@ except ImportError:
     raise ImportError(err_msg)
 
 logger = logging.getLogger(__name__)
-torchaudio_backend = get_torchaudio_backend()
-torchaudio.set_audio_backend(torchaudio_backend)
+check_torchaudio_backend()
 
 es_normalizer = MosesPunctNormalizer(lang="es")
 en_normalizer = MosesPunctNormalizer(lang="en")
@@ -77,7 +76,7 @@ class Data:
 
 
 def prepare_fisher_callhome_spanish(
-    data_folder: str, save_folder: str, device: str = "cpu",
+    data_folder: str, save_folder: str, device: str = "cpu"
 ):
 
     """
@@ -396,9 +395,7 @@ def segment_audio(
     data = resampler(data)
     data = torch.unsqueeze(data[channel], 0)
 
-    torchaudio.save(
-        save_path, src=data, sample_rate=sample_rate,
-    )
+    torchaudio.save(save_path, src=data, sample_rate=sample_rate)
 
 
 def get_transcription_files_by_dataset(

--- a/speechbrain/dataio/dataio.py
+++ b/speechbrain/dataio/dataio.py
@@ -20,10 +20,9 @@ import time
 import torchaudio
 import json
 import re
-from speechbrain.utils.torch_audio_backend import get_torchaudio_backend
+from speechbrain.utils.torch_audio_backend import check_torchaudio_backend
 
-torchaudio_backend = get_torchaudio_backend()
-torchaudio.set_audio_backend(torchaudio_backend)
+check_torchaudio_backend()
 logger = logging.getLogger(__name__)
 
 
@@ -752,7 +751,7 @@ def read_kaldi_lab(kaldi_ali, kaldi_lab_opts):
             + kaldi_lab_opts
             + " "
             + kaldi_ali
-            + "/final.mdl ark:- ark:-|",
+            + "/final.mdl ark:- ark:-|"
         )
     }
     return lab

--- a/speechbrain/lobes/augment.py
+++ b/speechbrain/lobes/augment.py
@@ -22,10 +22,9 @@ from speechbrain.processing.speech_augmentation import (
     AddNoise,
     AddReverb,
 )
-from speechbrain.utils.torch_audio_backend import get_torchaudio_backend
+from speechbrain.utils.torch_audio_backend import check_torchaudio_backend
 
-torchaudio_backend = get_torchaudio_backend()
-torchaudio.set_audio_backend(torchaudio_backend)
+check_torchaudio_backend()
 
 OPENRIR_URL = "http://www.openslr.org/resources/28/rirs_noises.zip"
 
@@ -266,7 +265,7 @@ class TimeDomainSpecAugment(torch.nn.Module):
     ):
         super().__init__()
         self.speed_perturb = SpeedPerturb(
-            perturb_prob=perturb_prob, orig_freq=sample_rate, speeds=speeds,
+            perturb_prob=perturb_prob, orig_freq=sample_rate, speeds=speeds
         )
         self.drop_freq = DropFreq(
             drop_prob=drop_freq_prob,

--- a/speechbrain/nnet/loss/stoi_loss.py
+++ b/speechbrain/nnet/loss/stoi_loss.py
@@ -7,10 +7,9 @@
 import torch
 import torchaudio
 import numpy as np
-from speechbrain.utils.torch_audio_backend import get_torchaudio_backend
+from speechbrain.utils.torch_audio_backend import check_torchaudio_backend
 
-torchaudio_backend = get_torchaudio_backend()
-torchaudio.set_audio_backend(torchaudio_backend)
+check_torchaudio_backend()
 smallVal = np.finfo("float").eps  # To avoid divide by zero
 
 

--- a/speechbrain/utils/torch_audio_backend.py
+++ b/speechbrain/utils/torch_audio_backend.py
@@ -1,18 +1,17 @@
 import platform
+import logging
+import torchaudio
+
+logger = logging.getLogger(__name__)
 
 
-def get_torchaudio_backend():
-    """Get the backend for torchaudio between soundfile and sox_io according to the os.
-
-    Allow users to use soundfile or sox_io according to their os.
-
-    Returns
-    -------
-    str
-        The torchaudio backend to use.
+def check_torchaudio_backend():
+    """Checks the torchaudio backend and sets it to soundfile if
+    windows is detected.
     """
     current_system = platform.system()
     if current_system == "Windows":
-        return "soundfile"
-    else:
-        return "sox_io"
+        logger.warn(
+            "The torchaudio backend is switched to 'soundfile'. Note that 'sox_io' is not supported on Windows."
+        )
+        torchaudio.set_audio_backend("soundfile")


### PR DESCRIPTION
As mentioned in a previous discussion (see #1055 by @hbredin), we have to be more "gentle" with the torchaudio backend.  With this PR, I do not force users to use the `sox_io` one. Users can set their torchaudio backend externally and speechbrain will use it. There are only two points where it is mandatory to change the backend:
1. when users are under windows, `soundfile` is the only option
2. when using commonvoice, we need to read mp3 and we have to use `sox_io`.

In these two cases we change the backend and we raise a warning to signal that.

Note that this issue is also part of the problem pointed out in #1086.

closes #1055
closes #1086