### PR TITLE
Add default checkpoint hooks for Torch Schedulers

### DIFF
--- a/speechbrain/utils/checkpoints.py
+++ b/speechbrain/utils/checkpoints.py
@@ -160,10 +160,14 @@ def torch_parameter_transfer(obj, path, device):
 DEFAULT_LOAD_HOOKS = {
     torch.nn.Module: torch_recovery,
     torch.optim.Optimizer: torch_recovery,
+    torch.optim.lr_scheduler._LRScheduler: torch_recovery,
+    torch.optim.lr_scheduler.ReduceLROnPlateau: torch_recovery,
 }
 DEFAULT_SAVE_HOOKS = {
     torch.nn.Module: torch_save,
     torch.optim.Optimizer: torch_save,
+    torch.optim.lr_scheduler._LRScheduler: torch_save,
+    torch.optim.lr_scheduler.ReduceLROnPlateau: torch_save,
 }
 DEFAULT_TRANSFER_HOOKS = {
     torch.nn.Module: torch_parameter_transfer,


### PR DESCRIPTION
Torch schedulers have their own class structure so they need separate default hooks.