### PR TITLE
Fix the padding issue

### DIFF
--- a/speechbrain/pretrained/interfaces.py
+++ b/speechbrain/pretrained/interfaces.py
@@ -2071,7 +2071,7 @@ class SpectralMaskEnhancement(Pretrained):
     ... )
     >>> noisy, fs = torchaudio.load("samples/audio_samples/example_noisy.wav")
     >>> # Channel dimension is interpreted as batch dimension here
-    >>> enhanced = enhancer.enhance_batch(noisy)
+    >>> enhanced = enhancer.enhance_batch(noisy, lengths=torch.tensor([1.]))
     """
 
     HPARAMS_NEEDED = ["compute_stft", "spectral_magnitude", "resynth"]

--- a/speechbrain/pretrained/interfaces.py
+++ b/speechbrain/pretrained/interfaces.py
@@ -799,11 +799,7 @@ class EncoderWav2vecClassifier(Pretrained):
     >>> prediction =  classifier .classify_batch(signal)
     """
 
-    MODULES_NEEDED = [
-        "wav2vec2",
-        "avg_pool",
-        "output_mlp",
-    ]
+    MODULES_NEEDED = ["wav2vec2", "avg_pool", "output_mlp"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -2093,7 +2089,7 @@ class SpectralMaskEnhancement(Pretrained):
         feats = self.hparams.spectral_magnitude(feats)
         return torch.log1p(feats)
 
-    def enhance_batch(self, noisy, lengths=None):
+    def enhance_batch(self, noisy, lengths):
         """Enhance a batch of noisy waveforms.
 
         Arguments
@@ -2112,10 +2108,7 @@ class SpectralMaskEnhancement(Pretrained):
         noisy_features = self.compute_features(noisy)
 
         # Perform masking-based enhancement, multiplying output with input.
-        if lengths is not None:
-            mask = self.mods.enhance_model(noisy_features, lengths=lengths)
-        else:
-            mask = self.mods.enhance_model(noisy_features)
+        mask = self.mods.enhance_model(noisy_features, lengths=lengths)
         enhanced = torch.mul(mask, noisy_features)
 
         # Return resynthesized waveforms
@@ -2136,7 +2129,10 @@ class SpectralMaskEnhancement(Pretrained):
 
         # Fake a batch:
         batch = noisy.unsqueeze(0)
-        enhanced = self.enhance_batch(batch)
+        rel_length = torch.tensor([1.0])
+
+        # Perform enhancement
+        enhanced = self.enhance_batch(batch, rel_length)
 
         if output_filename is not None:
             torchaudio.save(output_filename, enhanced, channels_first=False)

--- a/speechbrain/processing/multi_mic.py
+++ b/speechbrain/processing/multi_mic.py
@@ -429,7 +429,7 @@ class Mvdr(torch.nn.Module):
         NNs = NNs.to(Xs.device)
         if mics is not None:
             mics = mics.to(Xs.device)
-        
+
         # Convert the tdoas to taus
         if doa_mode:
             taus = doas2taus(doas=localization_tensor, mics=mics, fs=fs, c=c)

--- a/speechbrain/utils/data_utils.py
+++ b/speechbrain/utils/data_utils.py
@@ -398,12 +398,12 @@ def batch_pad_right(tensors: list, mode="constant", value=0):
     # need to remove this when feat extraction is updated to handle multichannel.
     max_shape = []
     for dim in range(tensors[0].ndim):
-        if dim != (tensors[0].ndim - 1):
+        if dim != 0:
             if not all(
                 [x.shape[dim] == tensors[0].shape[dim] for x in tensors[1:]]
             ):
                 raise EnvironmentError(
-                    "Tensors should have same dimensions except for last one"
+                    "Tensors should have same dimensions except for the first one"
                 )
         max_shape.append(max([x.shape[dim] for x in tensors]))
 

--- a/speechbrain/utils/data_utils.py
+++ b/speechbrain/utils/data_utils.py
@@ -394,7 +394,7 @@ def batch_pad_right(tensors: list, mode="constant", value=0):
     ):
         raise IndexError("All tensors must have same number of dimensions")
 
-    # FIXME we limit the support here: we allow padding of only the last dimension
+    # FIXME we limit the support here: we allow padding of only the first dimension
     # need to remove this when feat extraction is updated to handle multichannel.
     max_shape = []
     for dim in range(tensors[0].ndim):


### PR DESCRIPTION
Based on the codes for padding (e.g. `batch_pad_right()` & `pad_right_to()` in `speechbrain.utils.data_utils`), the padding is actually applied to the first dimension, not the last dimension, so I have updated the codes for raising the exception.