### PR TITLE
Add ctc-segmentation to mocked deps

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ intersphinx_mapping = {
 autodoc_default_options = {}
 
 # Autodoc mock extra dependencies:
-autodoc_mock_imports = ["numba", "sklearn"]
+autodoc_mock_imports = ["numba", "sklearn", "ctc_segmentation"]
 
 # Order of API items:
 autodoc_member_order = "bysource"


### PR DESCRIPTION
Add ctc-segmentation package
(https://github.com/lumaku/ctc-segmentation) to be mocked while
generating API docs using sphinx autodoc. 
Fixes #1119.