### PR TITLE
Document hparams overriding of run_opts and automatically load argv[1:] if not specified.

### DIFF
--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -390,6 +390,11 @@ class Brain:
         ckpt_interval_minutes (float)
             Amount of time between saving intra-epoch checkpoints,
             in minutes, default: ``15.0``. If non-positive, these are not saved.
+
+        Typically in a script this comes from ``speechbrain.parse_args``, which
+        has different defaults than Brain. If an option is not defined here
+        (keep in mind that parse_args will inject some options by default),
+        then the option is also searched for in hparams (by key).
     checkpointer : speechbrain.Checkpointer
         By default, this will be used to load checkpoints, and will have the
         optimizer added to continue training if interrupted.

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -125,13 +125,14 @@ def _logging_excepthook(exc_type, exc_value, exc_traceback):
     logger.error("Exception:", exc_info=(exc_type, exc_value, exc_traceback))
 
 
-def parse_arguments(arg_list):
+def parse_arguments(arg_list=None):
     r"""Parse command-line arguments to the experiment.
 
     Arguments
     ---------
-    arg_list : list
-        A list of arguments to parse, most often from `sys.argv[1:]`.
+    arg_list : list, None
+        A list of arguments to parse.  If not given, this is read from
+        `sys.argv[1:]`
 
     Returns
     -------
@@ -153,6 +154,8 @@ def parse_arguments(arg_list):
     >>> overrides
     'seed: 10'
     """
+    if arg_list is None:
+        arg_list = sys.argv[1:]
     parser = argparse.ArgumentParser(
         description="Run a SpeechBrain experiment",
     )
@@ -369,10 +372,8 @@ class Brain:
             If a non-positive number is passed, all epochs are run.
         jit_module_keys (list of str)
             List of keys in ``modules`` that should be jit compiled.
-        distributed_count (int)
-            Number of devices to run on.
         distributed_backend (str)
-            One of ``ddp_nccl``, ``ddp_gloo``, ``ddp_mpi``, ``data_parallel``.
+            One of ``nccl``, ``gloo``, ``mpi``.
         device (str)
             The location for performing computations.
         auto_mix_prec (bool)


### PR DESCRIPTION
Related to issue #1133, see the discussion there.