### PR TITLE
Auto mix prec + noprogressbar override via hyperparams

### DIFF
--- a/recipes/LibriMix/separation/train.py
+++ b/recipes/LibriMix/separation/train.py
@@ -120,7 +120,7 @@ class Separation(sb.Brain):
         if self.hparams.num_spks == 3:
             targets.append(batch.s3_sig)
 
-        if self.hparams.auto_mix_prec:
+        if self.auto_mix_prec:
             with autocast():
                 predictions, targets = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN, noise
@@ -553,7 +553,6 @@ if __name__ == "__main__":
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
     with open(hparams_file) as fin:
         hparams = load_hyperpyyaml(fin, overrides)
-    run_opts["auto_mix_prec"] = hparams["auto_mix_prec"]
 
     # Initialize ddp (useful only for multi-GPU DDP training)
     sb.utils.distributed.ddp_init_group(run_opts)

--- a/recipes/REAL-M/sisnr-estimation/train.py
+++ b/recipes/REAL-M/sisnr-estimation/train.py
@@ -174,7 +174,7 @@ class Separation(sb.Brain):
         if self.hparams.num_spks == 3:
             targets.append(batch.s3_sig)
 
-        if self.hparams.auto_mix_prec:
+        if self.auto_mix_prec:
             with autocast():
                 predictions, snrhat, snr, snr_compressed = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN, noise
@@ -563,7 +563,6 @@ if __name__ == "__main__":
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
     with open(hparams_file) as fin:
         hparams = load_hyperpyyaml(fin, overrides)
-    run_opts["auto_mix_prec"] = hparams["auto_mix_prec"]
 
     # Initialize ddp (useful only for multi-GPU DDP training)
     sb.utils.distributed.ddp_init_group(run_opts)

--- a/recipes/WHAMandWHAMR/separation/train.py
+++ b/recipes/WHAMandWHAMR/separation/train.py
@@ -118,7 +118,7 @@ class Separation(sb.Brain):
         targets = [batch.s1_sig, batch.s2_sig]
         noise = batch.noise_sig[0]
 
-        if self.hparams.auto_mix_prec:
+        if self.auto_mix_prec:
             with autocast():
                 predictions, targets = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN, noise
@@ -530,7 +530,6 @@ if __name__ == "__main__":
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
     with open(hparams_file) as fin:
         hparams = load_hyperpyyaml(fin, overrides)
-    run_opts["auto_mix_prec"] = hparams["auto_mix_prec"]
 
     # Initialize ddp (useful only for multi-GPU DDP training)
     sb.utils.distributed.ddp_init_group(run_opts)

--- a/recipes/WSJ0Mix/separation/train.py
+++ b/recipes/WSJ0Mix/separation/train.py
@@ -104,7 +104,7 @@ class Separation(sb.Brain):
         if self.hparams.num_spks == 3:
             targets.append(batch.s3_sig)
 
-        if self.hparams.auto_mix_prec:
+        if self.auto_mix_prec:
             with autocast():
                 predictions, targets = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN
@@ -514,7 +514,6 @@ if __name__ == "__main__":
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
     with open(hparams_file) as fin:
         hparams = load_hyperpyyaml(fin, overrides)
-    run_opts["auto_mix_prec"] = hparams["auto_mix_prec"]
 
     # Initialize ddp (useful only for multi-GPU DDP training)
     sb.utils.distributed.ddp_init_group(run_opts)

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -233,7 +233,7 @@ def parse_arguments(arg_list=None):
     )
     parser.add_argument(
         "--auto_mix_prec",
-        default=False,
+        default=None,
         action="store_true",
         help="This flag enables training with automatic mixed-precision.",
     )
@@ -250,7 +250,7 @@ def parse_arguments(arg_list=None):
     )
     parser.add_argument(
         "--noprogressbar",
-        default=False,
+        default=None,
         action="store_true",
         help="This flag disables the data loop progressbars.",
     )


### PR DESCRIPTION
Auto mixed precision can be controlled via hyperparams.yaml if it has no default in the argument parsing (implementation clarification: `None` values get deleted). Also allow the same for noprogressbar; that seems to do no harm I think.

I noticed a few recipes actually implemented (hacked) this feature already, so it seemed to make sense to change it.

See issue #1133 