### PR TITLE
JITable sepformer

### DIFF
--- a/recipes/LibriMix/separation/hparams/sepformer-libri2mix.yaml
+++ b/recipes/LibriMix/separation/hparams/sepformer-libri2mix.yaml
@@ -102,7 +102,7 @@ SBtfintra: !new:speechbrain.lobes.models.dual_path.SBTransformerBlock
     d_model: !ref <out_channels>
     nhead: 8
     d_ffn: 1024
-    dropout: 0
+    dropout: 0.0
     use_positional_encoding: True
     norm_before: True
 
@@ -111,7 +111,7 @@ SBtfinter: !new:speechbrain.lobes.models.dual_path.SBTransformerBlock
     d_model: !ref <out_channels>
     nhead: 8
     d_ffn: 1024
-    dropout: 0
+    dropout: 0.0
     use_positional_encoding: True
     norm_before: True
 

--- a/recipes/LibriMix/separation/hparams/sepformer-libri3mix.yaml
+++ b/recipes/LibriMix/separation/hparams/sepformer-libri3mix.yaml
@@ -102,7 +102,7 @@ SBtfintra: !new:speechbrain.lobes.models.dual_path.SBTransformerBlock
     d_model: !ref <out_channels>
     nhead: 8
     d_ffn: 1024
-    dropout: 0
+    dropout: 0.0
     use_positional_encoding: True
     norm_before: True
 
@@ -111,7 +111,7 @@ SBtfinter: !new:speechbrain.lobes.models.dual_path.SBTransformerBlock
     d_model: !ref <out_channels>
     nhead: 8
     d_ffn: 1024
-    dropout: 0
+    dropout: 0.0
     use_positional_encoding: True
     norm_before: True
 

--- a/recipes/WHAMandWHAMR/separation/hparams/sepformer-wham.yaml
+++ b/recipes/WHAMandWHAMR/separation/hparams/sepformer-wham.yaml
@@ -106,7 +106,7 @@ SBtfintra: !new:speechbrain.lobes.models.dual_path.SBTransformerBlock
     d_model: !ref <out_channels>
     nhead: 8
     d_ffn: 1024
-    dropout: 0
+    dropout: 0.0
     use_positional_encoding: True
     norm_before: True
 
@@ -115,7 +115,7 @@ SBtfinter: !new:speechbrain.lobes.models.dual_path.SBTransformerBlock
     d_model: !ref <out_channels>
     nhead: 8
     d_ffn: 1024
-    dropout: 0
+    dropout: 0.0
     use_positional_encoding: True
     norm_before: True
 

--- a/recipes/WHAMandWHAMR/separation/hparams/sepformer-whamr.yaml
+++ b/recipes/WHAMandWHAMR/separation/hparams/sepformer-whamr.yaml
@@ -110,7 +110,7 @@ SBtfintra: !new:speechbrain.lobes.models.dual_path.SBTransformerBlock
     d_model: !ref <out_channels>
     nhead: 8
     d_ffn: 1024
-    dropout: 0
+    dropout: 0.0
     use_positional_encoding: True
     norm_before: True
 
@@ -119,7 +119,7 @@ SBtfinter: !new:speechbrain.lobes.models.dual_path.SBTransformerBlock
     d_model: !ref <out_channels>
     nhead: 8
     d_ffn: 1024
-    dropout: 0
+    dropout: 0.0
     use_positional_encoding: True
     norm_before: True
 

--- a/recipes/WSJ0Mix/separation/hparams/sepformer-customdataset.yaml
+++ b/recipes/WSJ0Mix/separation/hparams/sepformer-customdataset.yaml
@@ -104,7 +104,7 @@ SBtfintra: !new:speechbrain.lobes.models.dual_path.SBTransformerBlock
     d_model: !ref <out_channels>
     nhead: 8
     d_ffn: 1024
-    dropout: 0
+    dropout: 0.0
     use_positional_encoding: True
     norm_before: True
 
@@ -113,7 +113,7 @@ SBtfinter: !new:speechbrain.lobes.models.dual_path.SBTransformerBlock
     d_model: !ref <out_channels>
     nhead: 8
     d_ffn: 1024
-    dropout: 0
+    dropout: 0.0
     use_positional_encoding: True
     norm_before: True
 

--- a/recipes/WSJ0Mix/separation/hparams/sepformer.yaml
+++ b/recipes/WSJ0Mix/separation/hparams/sepformer.yaml
@@ -104,7 +104,7 @@ SBtfintra: !new:speechbrain.lobes.models.dual_path.SBTransformerBlock
     d_model: !ref <out_channels>
     nhead: 8
     d_ffn: 1024
-    dropout: 0
+    dropout: 0.0
     use_positional_encoding: True
     norm_before: True
 
@@ -113,7 +113,7 @@ SBtfinter: !new:speechbrain.lobes.models.dual_path.SBTransformerBlock
     d_model: !ref <out_channels>
     nhead: 8
     d_ffn: 1024
-    dropout: 0
+    dropout: 0.0
     use_positional_encoding: True
     norm_before: True
 

--- a/speechbrain/lobes/models/dual_path.py
+++ b/speechbrain/lobes/models/dual_path.py
@@ -272,24 +272,6 @@ class Decoder(nn.ConvTranspose1d):
             x = torch.squeeze(x)
         return x
 
-
-class IdentityBlock(nn.Module):
-    """This block is used when we want to have identity transformation within the Dual_path block.
-
-    Example
-    -------
-    >>> x = torch.randn(10, 100)
-    >>> IB = IdentityBlock()
-    >>> xhat = IB(x)
-    """
-
-    def _init__(self, **kwargs):
-        pass
-
-    def forward(self, x):
-        return x
-
-
 class FastTransformerBlock(nn.Module):
     """This block is used to implement fast transformer models with efficient attention.
 
@@ -810,8 +792,8 @@ class Dual_Computation_Block(nn.Module):
             self.intra_norm = select_norm(norm, out_channels, 4)
             self.inter_norm = select_norm(norm, out_channels, 4)
 
-        self.intra_linear = IdentityBlock()
-        self.inter_linear = IdentityBlock()
+        self.intra_linear = nn.Identity()
+        self.inter_linear = nn.Identity()
         # Linear
         if self.linear_layer_after_inter_intra:
             if isinstance(intra_mdl, SBRNNBlock):
@@ -959,7 +941,7 @@ class Dual_Path_Model(nn.Module):
         self.conv1d = nn.Conv1d(in_channels, out_channels, 1, bias=False)
         self.use_global_pos_enc = use_global_pos_enc
 
-        self.pos_enc = IdentityBlock()
+        self.pos_enc = nn.Identity()
         if self.use_global_pos_enc:
             self.pos_enc = PositionalEncoding(max_length)
 

--- a/speechbrain/lobes/models/dual_path.py
+++ b/speechbrain/lobes/models/dual_path.py
@@ -263,14 +263,26 @@ class Decoder(nn.ConvTranspose1d):
 
         if x.dim() != 3:
             x = torch.unsqueeze(x, 1)
-        output_padding = self._output_padding(x, None, self.stride, self.padding, self.kernel_size, self.dilation)
-        x = F.conv_transpose1d(x, self.weight, self.bias, self.stride, self.padding, output_padding, self.groups, self.dilation)
+        output_padding = self._output_padding(
+            x, None, self.stride, self.padding, self.kernel_size, self.dilation
+        )
+        x = F.conv_transpose1d(
+            x,
+            self.weight,
+            self.bias,
+            self.stride,
+            self.padding,
+            output_padding,
+            self.groups,
+            self.dilation,
+        )
 
         if torch.squeeze(x).dim() == 1:
             x = torch.squeeze(x, dim=1)
         else:
             x = torch.squeeze(x)
         return x
+
 
 class FastTransformerBlock(nn.Module):
     """This block is used to implement fast transformer models with efficient attention.

--- a/speechbrain/lobes/models/transformer/Transformer.py
+++ b/speechbrain/lobes/models/transformer/Transformer.py
@@ -5,6 +5,8 @@ Authors
 * Samuele Cornell 2021
 """
 import math
+import typing
+
 import torch
 import torch.nn as nn
 import speechbrain as sb
@@ -439,7 +441,7 @@ class TransformerEncoder(nn.Module):
             The mask for the src keys per batch (optional).
         """
         output = src
-        attention_lst = []
+        attention_lst: typing.List[Optional[torch.Tensor]] = []
         for enc_layer in self.layers:
             output, attention = enc_layer(
                 output,

--- a/speechbrain/nnet/attention.py
+++ b/speechbrain/nnet/attention.py
@@ -701,7 +701,7 @@ class MultiheadAttention(nn.Module):
         value,
         attn_mask: Optional[torch.Tensor] = None,
         key_padding_mask: Optional[torch.Tensor] = None,
-        return_attn_weights: Optional[torch.Tensor] = True,
+        need_weights: bool = True,
         pos_embs: Optional[torch.Tensor] = None,
     ):
         """
@@ -759,23 +759,18 @@ class MultiheadAttention(nn.Module):
             else:
                 attn_mask = pos_embs
 
-        output = self.att(
+        output, attention_weights = self.att(
             query,
             key,
             value,
             attn_mask=attn_mask,
             key_padding_mask=key_padding_mask,
-            need_weights=return_attn_weights,
+            need_weights=need_weights,
         )
 
-        if return_attn_weights:
-            output, attention_weights = output
-            # reshape the output back to (batch, time, fea)
-            output = output.permute(1, 0, 2)
-            return output, attention_weights
-        else:
-            output = output.permute(1, 0, 2)
-            return output
+        # reshape the output back to (batch, time, fea)
+        output = output.permute(1, 0, 2)
+        return output, attention_weights
 
 
 class PositionalwiseFeedForward(nn.Module):

--- a/tests/unittests/test_sepformer.py
+++ b/tests/unittests/test_sepformer.py
@@ -1,0 +1,89 @@
+import torch
+
+
+def test_JITability():
+    from speechbrain.pretrained.interfaces import SepformerSeparation
+    from speechbrain.lobes.models.dual_path import (
+        Encoder,
+        Decoder,
+        Dual_Path_Model,
+        SBTransformerBlock,
+    )
+
+    encoder = Encoder(kernel_size=16, out_channels=256)
+    decoder = Decoder(
+        in_channels=256, out_channels=1, kernel_size=16, stride=8, bias=False
+    )
+    intra_model = SBTransformerBlock(
+        num_layers=8,
+        d_model=256,
+        nhead=8,
+        d_ffn=1024,
+        dropout=0.0,
+        use_positional_encoding=True,
+        norm_before=True,
+    )
+    inter_model = SBTransformerBlock(
+        num_layers=8,
+        d_model=256,
+        nhead=8,
+        d_ffn=1024,
+        dropout=0.0,
+        use_positional_encoding=True,
+        norm_before=True,
+    )
+    masknet = Dual_Path_Model(
+        num_spks=2,
+        in_channels=256,
+        out_channels=256,
+        num_layers=2,
+        K=250,
+        intra_model=intra_model,
+        inter_model=inter_model,
+        norm="ln",
+        linear_layer_after_inter_intra=False,
+        skip_around_intra=True,
+    )
+
+    modules = dict(encoder=encoder, decoder=decoder, masknet=masknet)
+    hparams = dict(modules=modules, num_spks=2)
+
+    sepformer = SepformerSeparation(modules=modules, hparams=hparams)
+
+    class JITableSepformer(torch.nn.Module):
+        def __init__(self, encoder, decoder, masknet):
+            super().__init__()
+            self.encoder = encoder
+            self.decoder = decoder
+            self.masknet = masknet
+
+        def forward(self, mix):
+            mix_w = self.encoder(mix)
+            est_mask = self.masknet(mix_w)
+            mix_w = torch.stack([mix_w] * 2)
+            sep_h = mix_w * est_mask
+
+            # Decoding
+            est_source = torch.cat(
+                [self.decoder(sep_h[i]).unsqueeze(-1) for i in range(2)], dim=-1
+            )
+
+            # T changed after conv1d in encoder, fix it here
+            T_origin = mix.size(1)
+            T_est = est_source.size(1)
+            if T_origin > T_est:
+                est_source = torch.nn.functional.pad(
+                    est_source, (0, 0, 0, T_origin - T_est)
+                )
+            else:
+                est_source = est_source[:, :T_origin, :]
+            return est_source
+
+    sepformer_jit = torch.jit.script(
+        JITableSepformer(encoder, decoder, masknet)
+    )
+    input = torch.rand(size=(2, 8000), dtype=torch.float32)
+    with torch.no_grad():
+        assert torch.allclose(
+            sepformer.separate_batch(input), sepformer_jit(input)
+        )


### PR DESCRIPTION
Sepformer is JITable now via torch.jit.script(<object of speechbrain.pretrained.interfaces.SepformerSeparation>)

Repro:

```
import torch
from hyperpyyaml import load_hyperpyyaml
from speechbrain.pretrained.interfaces import SepformerSeparation

hparams = load_hyperpyyaml(
    open(f'{SPEECBRAIN_PATH}/recipes/LibriMix/separation/hparams/sepformer-libri2mix.yaml'),
    overrides='data_folder: wsj0-mix/2speakers'
)

sepformer = SepformerSeparation(modules=hparams['modules'], hparams=dict(hparams))

class JITableSepformer(torch.nn.Module):
    def __init__(self, modules):
        super().__init__()
        self.encoder = modules['encoder']
        self.decoder = modules['decoder']
        self.masknet = modules['masknet']
    
    def forward(self, mix):
        mix_w = self.encoder(mix)
        est_mask = self.masknet(mix_w)
        mix_w = torch.stack([mix_w] * 2)
        sep_h = mix_w * est_mask

        # Decoding
        est_source = torch.cat([self.decoder(sep_h[i]).unsqueeze(-1) for i in range(2)], dim=-1)

        # T changed after conv1d in encoder, fix it here
        T_origin = mix.size(1)
        T_est = est_source.size(1)
        if T_origin > T_est:
            est_source = torch.nn.functional.pad(est_source, (0, 0, 0, T_origin - T_est))
        else:
            est_source = est_source[:, :T_origin, :]
        return est_source

sepformer_jit = torch.jit.script(JITableSepformer(hparams['modules']))
mix = torch.rand(size=(2, 8000), dtype=torch.float32)
with torch.no_grad():
    assert(torch.allclose(sepformer.separate_batch(mix), sepformer_jit(mix)))
```