### PR TITLE
fix imprecise .int() conversion

### DIFF
--- a/speechbrain/nnet/losses.py
+++ b/speechbrain/nnet/losses.py
@@ -46,8 +46,8 @@ def transducer_loss(
     """
     from speechbrain.nnet.loss.transducer_loss import Transducer
 
-    input_lens = (input_lens * log_probs.shape[1]).int()
-    target_lens = (target_lens * targets.shape[1]).int()
+    input_lens = (input_lens * log_probs.shape[1]).round().int()
+    target_lens = (target_lens * targets.shape[1]).round().int()
     return Transducer.apply(
         log_probs, targets, input_lens, target_lens, blank_index, reduction
     )
@@ -233,8 +233,8 @@ def ctc_loss(
         See pytorch for 'mean', 'sum', 'none'. The 'batch' option returns
         one loss per item in the batch, 'batchmean' returns sum / batch size.
     """
-    input_lens = (input_lens * log_probs.shape[1]).int()
-    target_lens = (target_lens * targets.shape[1]).int()
+    input_lens = (input_lens * log_probs.shape[1]).round().int()
+    target_lens = (target_lens * targets.shape[1]).round().int()
     log_probs = log_probs.transpose(0, 1)
 
     if reduction == "batchmean":
@@ -995,7 +995,7 @@ def ctc_loss_kd(log_probs, targets, input_lens, blank_index, device):
         # Getting current predictions
         current_pred = predictions[j]
 
-        actual_size = (input_lens[j] * log_probs.shape[1]).int()
+        actual_size = (input_lens[j] * log_probs.shape[1]).round().int()
         current_pred = current_pred[0:actual_size]
         current_pred = filter_ctc_output(
             list(current_pred.cpu().numpy()), blank_id=blank_index
@@ -1017,7 +1017,7 @@ def ctc_loss_kd(log_probs, targets, input_lens, blank_index, device):
     fake_lab_lengths = torch.from_numpy(np.array(pred_len_list)).int()
     fake_lab_lengths.to(device)
 
-    input_lens = (input_lens * log_probs.shape[1]).int()
+    input_lens = (input_lens * log_probs.shape[1]).round().int()
     log_probs = log_probs.transpose(0, 1)
     return torch.nn.functional.ctc_loss(
         log_probs,

--- a/speechbrain/pretrained/interfaces.py
+++ b/speechbrain/pretrained/interfaces.py
@@ -1349,7 +1349,7 @@ class VAD(Pretrained):
 
         # From indexes to samples
         seconds = (indexes * self.time_resolution).float()
-        samples = (self.sample_rate * seconds).int()
+        samples = (self.sample_rate * seconds).round().int()
 
         if output_value == "seconds":
             boundaries = seconds

--- a/speechbrain/tokenizers/SentencePiece.py
+++ b/speechbrain/tokenizers/SentencePiece.py
@@ -407,7 +407,7 @@ class SentencePiece:
             # Convert list of words/chars to bpe ids
             bpe = []
             max_bpe_len = 0
-            batch_lens = (batch_lens * batch.shape[1]).int()
+            batch_lens = (batch_lens * batch.shape[1]).round().int()
             for i, utt_seq in enumerate(batch):
                 tokens = [
                     ind2lab[int(index)] for index in utt_seq[: batch_lens[i]]
@@ -439,7 +439,7 @@ class SentencePiece:
         elif task == "decode":
             # From a batch tensor and a length tensor
             # find the absolute batch lengths and do decoding
-            batch_lens = (batch_lens * batch.shape[1]).int()
+            batch_lens = (batch_lens * batch.shape[1]).round().int()
             return [
                 self.sp.decode_ids(
                     utt_seq[: batch_lens[i]].int().tolist()

--- a/speechbrain/utils/metric_stats.py
+++ b/speechbrain/utils/metric_stats.py
@@ -155,7 +155,7 @@ class MetricStats:
 def multiprocess_evaluation(metric, predict, target, lengths=None, n_jobs=8):
     """Runs metric evaluation if parallel over multiple jobs."""
     if lengths is not None:
-        lengths = (lengths * predict.size(1)).int().cpu()
+        lengths = (lengths * predict.size(1)).round().int().cpu()
         predict = [p[:length].cpu() for p, length in zip(predict, lengths)]
         target = [t[:length].cpu() for t, length in zip(target, lengths)]
 
@@ -175,7 +175,7 @@ def multiprocess_evaluation(metric, predict, target, lengths=None, n_jobs=8):
 def sequence_evaluation(metric, predict, target, lengths=None):
     """Runs metric evaluation sequentially over the inputs."""
     if lengths is not None:
-        lengths = (lengths * predict.size(1)).int().cpu()
+        lengths = (lengths * predict.size(1)).round().int().cpu()
         predict = [p[:length].cpu() for p, length in zip(predict, lengths)]
         target = [t[:length].cpu() for t, length in zip(target, lengths)]
 

--- a/tests/unittests/test_tokenizer.py
+++ b/tests/unittests/test_tokenizer.py
@@ -28,7 +28,7 @@ def test_tokenizer():
         dict_int2lab,
         task="encode",
     )
-    lens = (encoded_seq_pieces * encoded_seq_ids.shape[1]).int()
+    lens = (encoded_seq_pieces * encoded_seq_ids.shape[1]).round().int()
     # decode from torch tensors (batch, batch_lens)
     words_seq = spm(encoded_seq_ids, encoded_seq_pieces, task="decode")
     assert words_seq == gt, "output not the same"
@@ -131,7 +131,7 @@ def test_tokenizer():
         dict_int2lab,
         task="encode",
     )
-    lens = (encoded_seq_pieces * encoded_seq_ids.shape[1]).int()
+    lens = (encoded_seq_pieces * encoded_seq_ids.shape[1]).round().int()
     # decode from torch tensors (batch, batch_lens)
     words_seq = spm(encoded_seq_ids, encoded_seq_pieces, task="decode")
     assert words_seq == gt, "output not the same"


### PR DESCRIPTION
This PR fixes the issue pointed out in #1129.
In some rare cases, the conversion to int done when converting relative lengths to absolute lengths is not precise due to the limited precision in float32. Using `.round().int()` solves this issue. Thank you @gebauertnt for reporting it. 