### PR TITLE
Pytest on cuda

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,15 @@
+def pytest_addoption(parser):
+    parser.addoption("--device", action="store", default="cpu")
+
+
+def pytest_generate_tests(metafunc):
+    # This is called for every test. Only get/set command line arguments
+    # if the argument is specified in the list of test "fixturenames".
+    option_value = metafunc.config.option.device
+    if "device" in metafunc.fixturenames and option_value is not None:
+        metafunc.parametrize("device", [option_value])
+
+
 collect_ignore = ["setup.py"]
 try:
     import numba  # noqa: F401

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -45,7 +45,10 @@ Please, run the following script  from the main folder to make sure your install
 ```
 pytest tests
 ```
-You can run doctests as well with:
+
+If you have a GPU, you can run the tests with `pytest tests --device='cuda'`
+
+You can run doctests with:
 
 ```
 tests/.run-doctests.sh

--- a/speechbrain/alignment/aligner.py
+++ b/speechbrain/alignment/aligner.py
@@ -291,9 +291,7 @@ class HMMAligner(torch.nn.Module):
 
         return poss_phns, log_transition_matrix, start_states, final_states
 
-    def use_lexicon(
-        self, words, interword_sils=True, sample_pron=False,
-    ):
+    def use_lexicon(self, words, interword_sils=True, sample_pron=False):
         """Do processing using the lexicon to return a sequence of the possible
         phonemes, the transition/pi probabilities, and the possible final
         states.
@@ -1042,7 +1040,9 @@ class HMMAligner(torch.nn.Module):
         batch_size = len(lens_abs)
         fb_max_length = torch.max(lens_abs)
 
-        flat_start_batch = torch.zeros(batch_size, fb_max_length).long()
+        flat_start_batch = torch.zeros(
+            batch_size, fb_max_length, device=phns.device
+        ).long()
         for i in range(batch_size):
             utter_phns = phns[i]
             utter_phns = utter_phns[: phn_lens_abs[i]]  # crop out zero padding
@@ -1091,7 +1091,9 @@ class HMMAligner(torch.nn.Module):
         batch_size = len(lens_abs)
         fb_max_length = torch.max(lens_abs)
 
-        viterbi_batch = torch.zeros(batch_size, fb_max_length).long()
+        viterbi_batch = torch.zeros(
+            batch_size, fb_max_length, device=lens_abs.device
+        ).long()
         for i in range(batch_size):
             viterbi_preds = self.align_dict[ids[i]]
             viterbi_preds = torch.nn.functional.pad(

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -156,9 +156,7 @@ def parse_arguments(arg_list=None):
     """
     if arg_list is None:
         arg_list = sys.argv[1:]
-    parser = argparse.ArgumentParser(
-        description="Run a SpeechBrain experiment",
-    )
+    parser = argparse.ArgumentParser(description="Run a SpeechBrain experiment")
     parser.add_argument(
         "param_file",
         type=str,
@@ -191,9 +189,7 @@ def parse_arguments(arg_list=None):
         help="A file storing the configuration options for logging",
     )
     # if use_env = False in torch.distributed.lunch then local_rank arg is given
-    parser.add_argument(
-        "--local_rank", type=int, help="Rank on local machine",
-    )
+    parser.add_argument("--local_rank", type=int, help="Rank on local machine")
     parser.add_argument(
         "--device",
         type=str,
@@ -486,7 +482,9 @@ class Brain:
             )
 
         # Switch to the right context
-        if "cuda" in self.device:
+        if self.device == "cuda":
+            torch.cuda.set_device(0)
+        elif "cuda" in self.device:
             torch.cuda.set_device(int(self.device[-1]))
 
         # Put modules on the right device, accessible with dot notation
@@ -630,7 +628,7 @@ class Brain:
         pass
 
     def make_dataloader(
-        self, dataset, stage, ckpt_prefix="dataloader-", **loader_kwargs,
+        self, dataset, stage, ckpt_prefix="dataloader-", **loader_kwargs
     ):
         """Creates DataLoaders for Datasets.
 
@@ -1220,10 +1218,7 @@ class Brain:
 
     @sb.utils.checkpoints.mark_as_saver
     def _save(self, path):
-        save_dict = {
-            "step": self.step,
-            "avg_train_loss": self.avg_train_loss,
-        }
+        save_dict = {"step": self.step, "avg_train_loss": self.avg_train_loss}
         with open(path, "w") as w:
             w.write(yaml.dump(save_dict))
 

--- a/tests/integration/neural_networks/ASR_CTC/example_asr_ctc_experiment.py
+++ b/tests/integration/neural_networks/ASR_CTC/example_asr_ctc_experiment.py
@@ -15,8 +15,9 @@ from hyperpyyaml import load_hyperpyyaml
 class CTCBrain(sb.Brain):
     def compute_forward(self, batch, stage):
         "Given an input batch it computes the output probabilities."
+        batch = batch.to(self.device)
         wavs, lens = batch.sig
-        feats = self.hparams.compute_features(wavs)
+        feats = self.modules.compute_features(wavs)
         feats = self.modules.mean_var_norm(feats, lens)
         x = self.modules.model(feats)
         x = self.modules.lin(x)
@@ -104,7 +105,7 @@ def data_prep(data_folder, hparams):
     return train_data, valid_data
 
 
-def main():
+def main(device="cpu"):
     experiment_dir = pathlib.Path(__file__).resolve().parent
     hparams_file = experiment_dir / "hyperparams.yaml"
     data_folder = "../../../../samples/audio_samples/nn_training_samples"
@@ -118,7 +119,12 @@ def main():
     train_data, valid_data = data_prep(data_folder, hparams)
 
     # Trainer initialization
-    ctc_brain = CTCBrain(hparams["modules"], hparams["opt_class"], hparams)
+    ctc_brain = CTCBrain(
+        hparams["modules"],
+        hparams["opt_class"],
+        hparams,
+        run_opts={"device": device},
+    )
 
     # Training/validation loop
     ctc_brain.fit(
@@ -139,5 +145,5 @@ if __name__ == "__main__":
     main()
 
 
-def test_error():
-    main()
+def test_error(device):
+    main(device)

--- a/tests/integration/neural_networks/ASR_CTC/example_asr_ctc_experiment_complex_net.py
+++ b/tests/integration/neural_networks/ASR_CTC/example_asr_ctc_experiment_complex_net.py
@@ -15,8 +15,9 @@ from hyperpyyaml import load_hyperpyyaml
 class CTCBrain(sb.Brain):
     def compute_forward(self, batch, stage):
         "Given an input batch it computes the output probabilities."
+        batch = batch.to(self.device)
         wavs, lens = batch.sig
-        feats = self.hparams.compute_features(wavs)
+        feats = self.modules.compute_features(wavs)
         feats = self.modules.mean_var_norm(feats, lens)
         x = self.modules.model(feats)
         x = self.modules.lin(x)
@@ -104,7 +105,7 @@ def data_prep(data_folder, hparams):
     return train_data, valid_data
 
 
-def main():
+def main(device="cpu"):
     experiment_dir = pathlib.Path(__file__).resolve().parent
     hparams_file = experiment_dir / "hyperparams_complex_net.yaml"
     data_folder = "../../../../samples/audio_samples/nn_training_samples"
@@ -118,7 +119,12 @@ def main():
     train_data, valid_data = data_prep(data_folder, hparams)
 
     # Trainer initialization
-    ctc_brain = CTCBrain(hparams["modules"], hparams["opt_class"], hparams)
+    ctc_brain = CTCBrain(
+        hparams["modules"],
+        hparams["opt_class"],
+        hparams,
+        run_opts={"device": device},
+    )
 
     # Training/validation loop
     ctc_brain.fit(
@@ -139,5 +145,5 @@ if __name__ == "__main__":
     main()
 
 
-def test_error():
-    main()
+def test_error(device):
+    main(device)

--- a/tests/integration/neural_networks/ASR_CTC/example_asr_ctc_experiment_quaternion_net.py
+++ b/tests/integration/neural_networks/ASR_CTC/example_asr_ctc_experiment_quaternion_net.py
@@ -15,8 +15,9 @@ from hyperpyyaml import load_hyperpyyaml
 class CTCBrain(sb.Brain):
     def compute_forward(self, batch, stage):
         "Given an input batch it computes the output probabilities."
+        batch = batch.to(self.device)
         wavs, lens = batch.sig
-        feats = self.hparams.compute_features(wavs)
+        feats = self.modules.compute_features(wavs)
         feats = self.modules.mean_var_norm(feats, lens)
         x = self.modules.model(feats)
         x = self.modules.lin(x)
@@ -104,7 +105,7 @@ def data_prep(data_folder, hparams):
     return train_data, valid_data
 
 
-def main():
+def main(device="cpu"):
     experiment_dir = pathlib.Path(__file__).resolve().parent
     hparams_file = experiment_dir / "hyperparams_quaternion_net.yaml"
     data_folder = "../../../../samples/audio_samples/nn_training_samples"
@@ -118,7 +119,12 @@ def main():
     train_data, valid_data = data_prep(data_folder, hparams)
 
     # Trainer initialization
-    ctc_brain = CTCBrain(hparams["modules"], hparams["opt_class"], hparams)
+    ctc_brain = CTCBrain(
+        hparams["modules"],
+        hparams["opt_class"],
+        hparams,
+        run_opts={"device": device},
+    )
 
     # Training/validation loop
     ctc_brain.fit(
@@ -139,5 +145,5 @@ if __name__ == "__main__":
     main()
 
 
-def test_error():
-    main()
+def test_error(device):
+    main(device)

--- a/tests/integration/neural_networks/ASR_CTC/hyperparams.yaml
+++ b/tests/integration/neural_networks/ASR_CTC/hyperparams.yaml
@@ -57,6 +57,7 @@ compute_cost: !name:speechbrain.nnet.losses.ctc_loss
     blank_index: !ref <blank_index>
 
 modules:
+    compute_features: !ref <compute_features>
     model: !ref <model>
     lin: !ref <lin>
     mean_var_norm: !ref <mean_var_norm>

--- a/tests/integration/neural_networks/ASR_CTC/hyperparams_complex_net.yaml
+++ b/tests/integration/neural_networks/ASR_CTC/hyperparams_complex_net.yaml
@@ -50,6 +50,7 @@ softmax: !new:speechbrain.nnet.activations.Softmax
     apply_log: True
 
 modules:
+    compute_features: !ref <compute_features>
     model: !ref <model>
     lin: !ref <lin>
     mean_var_norm: !ref <mean_var_norm>

--- a/tests/integration/neural_networks/ASR_CTC/hyperparams_quaternion_net.yaml
+++ b/tests/integration/neural_networks/ASR_CTC/hyperparams_quaternion_net.yaml
@@ -48,6 +48,7 @@ softmax: !new:speechbrain.nnet.activations.Softmax
     apply_log: True
 
 modules:
+    compute_features: !ref <compute_features>
     model: !ref <model>
     lin: !ref <lin>
     mean_var_norm: !ref <mean_var_norm>

--- a/tests/integration/neural_networks/ASR_DNN_HMM/example_asr_dnn_hmm_experiment.py
+++ b/tests/integration/neural_networks/ASR_DNN_HMM/example_asr_dnn_hmm_experiment.py
@@ -14,8 +14,9 @@ from hyperpyyaml import load_hyperpyyaml
 class ASRBrain(sb.Brain):
     def compute_forward(self, batch, stage):
         "Given an input batch it computes the output probabilities."
+        batch = batch.to(self.device)
         wavs, lens = batch.sig
-        feats = self.hparams.compute_features(wavs)
+        feats = self.modules.compute_features(wavs)
         feats = self.modules.mean_var_norm(feats, lens)
 
         x = self.modules.linear1(feats)
@@ -95,7 +96,7 @@ def data_prep(data_folder, hparams):
     return train_data, valid_data
 
 
-def main():
+def main(device="cpu"):
     experiment_dir = pathlib.Path(__file__).resolve().parent
     hparams_file = experiment_dir / "hyperparams.yaml"
     data_folder = "../../../../samples/audio_samples/nn_training_samples"
@@ -109,7 +110,12 @@ def main():
     train_data, valid_data = data_prep(data_folder, hparams)
 
     # Trainer initialization
-    asr_brain = ASRBrain(hparams["modules"], hparams["opt_class"], hparams)
+    asr_brain = ASRBrain(
+        hparams["modules"],
+        hparams["opt_class"],
+        hparams,
+        run_opts={"device": device},
+    )
 
     # Training/validation loop
     asr_brain.fit(
@@ -130,5 +136,5 @@ if __name__ == "__main__":
     main()
 
 
-def test_error():
-    main()
+def test_error(device):
+    main(device)

--- a/tests/integration/neural_networks/ASR_DNN_HMM/hyperparams.yaml
+++ b/tests/integration/neural_networks/ASR_DNN_HMM/hyperparams.yaml
@@ -31,6 +31,7 @@ softmax: !new:speechbrain.nnet.activations.Softmax
     apply_log: True
 
 modules:
+    compute_features: !ref <compute_features>
     linear1: !ref <linear1>
     linear2: !ref <linear2>
     mean_var_norm: !ref <mean_var_norm>

--- a/tests/integration/neural_networks/ASR_alignment_forward/example_asr_alignment_forward_experiment.py
+++ b/tests/integration/neural_networks/ASR_alignment_forward/example_asr_alignment_forward_experiment.py
@@ -14,6 +14,7 @@ from hyperpyyaml import load_hyperpyyaml
 class AlignBrain(sb.Brain):
     def compute_forward(self, batch, stage):
         "Given an input batch it computes the output probabilities."
+        batch = batch.to(self.device)
         wavs, lens = batch.sig
         feats = self.hparams.compute_features(wavs)
         feats = self.modules.mean_var_norm(feats, lens)
@@ -97,7 +98,7 @@ def data_prep(data_folder, hparams):
     return train_data, valid_data
 
 
-def main():
+def main(device="cpu"):
     experiment_dir = pathlib.Path(__file__).resolve().parent
     hparams_file = experiment_dir / "hyperparams.yaml"
     data_folder = "../../../../samples/audio_samples/nn_training_samples"
@@ -111,7 +112,12 @@ def main():
     train_data, valid_data = data_prep(data_folder, hparams)
 
     # Trainer initialization
-    ali_brain = AlignBrain(hparams["modules"], hparams["opt_class"], hparams)
+    ali_brain = AlignBrain(
+        hparams["modules"],
+        hparams["opt_class"],
+        hparams,
+        run_opts={"device": device},
+    )
 
     # Training/validation loop
     ali_brain.fit(
@@ -132,5 +138,5 @@ if __name__ == "__main__":
     main()
 
 
-def test_error():
-    main()
+def test_error(device):
+    main(device)

--- a/tests/integration/neural_networks/ASR_alignment_forward/hyperparams.yaml
+++ b/tests/integration/neural_networks/ASR_alignment_forward/hyperparams.yaml
@@ -46,6 +46,7 @@ lin: !new:speechbrain.nnet.linear.Linear
     bias: False
 
 modules:
+    compute_features: !ref <compute_features>
     model: !ref <model>
     lin: !ref <lin>
     mean_var_norm: !ref <mean_var_norm>

--- a/tests/integration/neural_networks/ASR_alignment_viterbi/example_asr_alignment_viterbi_experiment.py
+++ b/tests/integration/neural_networks/ASR_alignment_viterbi/example_asr_alignment_viterbi_experiment.py
@@ -14,8 +14,9 @@ from hyperpyyaml import load_hyperpyyaml
 class AlignBrain(sb.Brain):
     def compute_forward(self, batch, stage):
         "Given an input batch it computes the output probabilities."
+        batch = batch.to(self.device)
         wavs, lens = batch.sig
-        feats = self.hparams.compute_features(wavs)
+        feats = self.modules.compute_features(wavs)
         feats = self.modules.mean_var_norm(feats, lens)
         x = self.modules.model(feats)
         x = self.modules.lin(x)
@@ -103,7 +104,7 @@ def data_prep(data_folder, hparams):
     return train_data, valid_data
 
 
-def main():
+def main(device="cpu"):
     experiment_dir = pathlib.Path(__file__).resolve().parent
     hparams_file = experiment_dir / "hyperparams.yaml"
     data_folder = "../../../../samples/audio_samples/nn_training_samples"
@@ -117,7 +118,12 @@ def main():
     train_data, valid_data = data_prep(data_folder, hparams)
 
     # Trainer initialization
-    ali_brain = AlignBrain(hparams["modules"], hparams["opt_class"], hparams)
+    ali_brain = AlignBrain(
+        hparams["modules"],
+        hparams["opt_class"],
+        hparams,
+        run_opts={"device": device},
+    )
 
     # Training/validation loop
     ali_brain.fit(
@@ -138,5 +144,5 @@ if __name__ == "__main__":
     main()
 
 
-def test_error():
-    main()
+def test_error(device):
+    main(device)

--- a/tests/integration/neural_networks/ASR_alignment_viterbi/hyperparams.yaml
+++ b/tests/integration/neural_networks/ASR_alignment_viterbi/hyperparams.yaml
@@ -46,6 +46,7 @@ lin: !new:speechbrain.nnet.linear.Linear
     bias: False
 
 modules:
+    compute_features: !ref <compute_features>
     model: !ref <model>
     lin: !ref <lin>
     mean_var_norm: !ref <mean_var_norm>

--- a/tests/integration/neural_networks/ASR_seq2seq/example_asr_seq2seq_experiment.py
+++ b/tests/integration/neural_networks/ASR_seq2seq/example_asr_seq2seq_experiment.py
@@ -14,6 +14,7 @@ from hyperpyyaml import load_hyperpyyaml
 class seq2seqBrain(sb.Brain):
     def compute_forward(self, batch, stage):
         "Given an input batch it computes the output probabilities."
+        batch = batch.to(self.device)
         wavs, wav_lens = batch.sig
         phns_bos, _ = batch.phn_encoded_bos
         feats = self.hparams.compute_features(wavs)
@@ -135,7 +136,7 @@ def data_prep(data_folder, hparams):
     return train_data, valid_data
 
 
-def main():
+def main(device="cpu"):
     experiment_dir = pathlib.Path(__file__).resolve().parent
     hparams_file = experiment_dir / "hyperparams.yaml"
     data_folder = "../../../../samples/audio_samples/nn_training_samples"
@@ -150,7 +151,10 @@ def main():
 
     # Trainer initialization
     seq2seq_brain = seq2seqBrain(
-        hparams["modules"], hparams["opt_class"], hparams
+        hparams["modules"],
+        hparams["opt_class"],
+        hparams,
+        run_opts={"device": device},
     )
 
     # Training/validation loop
@@ -172,5 +176,5 @@ if __name__ == "__main__":
     main()
 
 
-def test_error():
-    main()
+def test_error(device):
+    main(device)

--- a/tests/integration/neural_networks/ASR_seq2seq/hyperparams.yaml
+++ b/tests/integration/neural_networks/ASR_seq2seq/hyperparams.yaml
@@ -65,6 +65,7 @@ softmax: !new:speechbrain.nnet.activations.Softmax
     apply_log: True
 
 modules:
+    compute_features: !ref <compute_features>
     enc: !ref <enc>
     emb: !ref <emb>
     dec: !ref <dec>

--- a/tests/integration/neural_networks/G2P/example_g2p.py
+++ b/tests/integration/neural_networks/G2P/example_g2p.py
@@ -15,10 +15,11 @@ from hyperpyyaml import load_hyperpyyaml
 class seq2seqBrain(sb.Brain):
     def compute_forward(self, batch, stage):
         "Given input chars it computes the phoneme's probabilities"
+        batch = batch.to(self.device)
         chars, char_lens = batch.char_encoded
         phns, phn_lens = batch.phn_encoded_bos
 
-        emb_char = self.hparams.encoder_emb(chars)
+        emb_char = self.modules.encoder_emb(chars)
         x, _ = self.modules.enc(emb_char)
         e_in = self.modules.emb(phns)
 
@@ -126,7 +127,7 @@ def data_prep(data_folder, hparams):
     return train_data, valid_data
 
 
-def main():
+def main(device="cpu"):
     experiment_dir = pathlib.Path(__file__).resolve().parent
     hparams_file = experiment_dir / "hyperparams.yaml"
     data_folder = "../../../../samples/audio_samples/nn_training_samples"
@@ -141,7 +142,10 @@ def main():
 
     # Trainer initialization
     seq2seq_brain = seq2seqBrain(
-        hparams["modules"], hparams["opt_class"], hparams
+        hparams["modules"],
+        hparams["opt_class"],
+        hparams,
+        run_opts={"device": device},
     )
 
     # Training/validation loop
@@ -163,5 +167,5 @@ if __name__ == "__main__":
     main()
 
 
-def test_error():
-    main()
+def test_error(device):
+    main(device)

--- a/tests/integration/neural_networks/G2P/hyperparams.yaml
+++ b/tests/integration/neural_networks/G2P/hyperparams.yaml
@@ -53,6 +53,7 @@ softmax: !new:speechbrain.nnet.activations.Softmax
     apply_log: True
 
 modules:
+    encoder_emb: !ref <encoder_emb>
     enc: !ref <enc>
     emb: !ref <emb>
     dec: !ref <dec>

--- a/tests/integration/neural_networks/LM_RNN/example_lm_rnn_experiment.py
+++ b/tests/integration/neural_networks/LM_RNN/example_lm_rnn_experiment.py
@@ -15,6 +15,7 @@ from hyperpyyaml import load_hyperpyyaml
 class LMBrain(sb.Brain):
     def compute_forward(self, batch, stage):
         "Given an input chars it computes the next-char probability."
+        batch = batch.to(self.device)
         chars, char_lens = batch.char_encoded_bos
         logits = self.modules.model(chars)
         pout = self.hparams.log_softmax(logits)
@@ -83,7 +84,7 @@ def data_prep(data_folder, hparams):
     return train_data, valid_data
 
 
-def main():
+def main(device="cpu"):
     experiment_dir = pathlib.Path(__file__).resolve().parent
     hparams_file = experiment_dir / "hyperparams.yaml"
     data_folder = "../../../../samples/audio_samples/nn_training_samples"
@@ -97,7 +98,12 @@ def main():
     train_data, valid_data = data_prep(data_folder, hparams)
 
     # Trainer initialization
-    lm_brain = LMBrain(hparams["modules"], hparams["opt_class"], hparams)
+    lm_brain = LMBrain(
+        hparams["modules"],
+        hparams["opt_class"],
+        hparams,
+        run_opts={"device": device},
+    )
 
     # Training/validation loop
     lm_brain.fit(
@@ -118,5 +124,5 @@ if __name__ == "__main__":
     main()
 
 
-def test_error():
-    main()
+def test_error(device):
+    main(device)

--- a/tests/integration/neural_networks/VAD/example_vad.py
+++ b/tests/integration/neural_networks/VAD/example_vad.py
@@ -13,6 +13,7 @@ from hyperpyyaml import load_hyperpyyaml
 class VADBrain(sb.Brain):
     def compute_forward(self, batch, stage):
         "Given an input batch it computes the binary probability."
+        batch = batch.to(self.device)
         wavs, lens = batch.sig
         feats = self.hparams.compute_features(wavs)
         feats = self.modules.mean_var_norm(feats, lens)
@@ -110,7 +111,7 @@ def data_prep(data_folder, hparams):
     return train_data, valid_data
 
 
-def main():
+def main(device="cpu"):
 
     experiment_dir = os.path.dirname(os.path.abspath(__file__))
     hparams_file = os.path.join(experiment_dir, "hyperparams.yaml")
@@ -123,7 +124,12 @@ def main():
     train_data, valid_data = data_prep(data_folder, hparams)
 
     # Trainer initialization
-    ctc_brain = VADBrain(hparams["modules"], hparams["opt_class"], hparams)
+    ctc_brain = VADBrain(
+        hparams["modules"],
+        hparams["opt_class"],
+        hparams,
+        run_opts={"device": device},
+    )
 
     # Training/validation loop
     ctc_brain.fit(
@@ -144,5 +150,5 @@ if __name__ == "__main__":
     main()
 
 
-def test_error():
-    main()
+def test_error(device):
+    main(device)

--- a/tests/integration/neural_networks/VAD/hyperparams.yaml
+++ b/tests/integration/neural_networks/VAD/hyperparams.yaml
@@ -41,6 +41,7 @@ lin: !new:speechbrain.nnet.linear.Linear
     bias: False
 
 modules:
+    compute_features: !ref <compute_features>
     rnn: !ref <rnn>
     lin: !ref <lin>
     mean_var_norm: !ref <mean_var_norm>

--- a/tests/integration/neural_networks/autoencoder/example_auto_experiment.py
+++ b/tests/integration/neural_networks/autoencoder/example_auto_experiment.py
@@ -14,6 +14,7 @@ from hyperpyyaml import load_hyperpyyaml
 class AutoBrain(sb.Brain):
     def compute_forward(self, batch, stage):
         "Appling encoder and decoder to the input features"
+        batch = batch.to(self.device)
         wavs, lens = batch.sig
         feats = self.hparams.compute_features(wavs)
         feats = self.modules.mean_var_norm(feats, lens)
@@ -93,7 +94,7 @@ def data_prep(data_folder):
     return train_data, valid_data
 
 
-def main():
+def main(device="cpu"):
     experiment_dir = pathlib.Path(__file__).resolve().parent
     hparams_file = experiment_dir / "hyperparams.yaml"
     data_folder = "../../../../samples/audio_samples/nn_training_samples"
@@ -107,7 +108,12 @@ def main():
     train_data, valid_data = data_prep(data_folder)
 
     # Trainer initialization
-    auto_brain = AutoBrain(hparams["modules"], hparams["opt_class"], hparams)
+    auto_brain = AutoBrain(
+        hparams["modules"],
+        hparams["opt_class"],
+        hparams,
+        run_opts={"device": device},
+    )
 
     # Training/validation loop
     auto_brain.fit(
@@ -128,5 +134,5 @@ if __name__ == "__main__":
     main()
 
 
-def test_error():
-    main()
+def test_error(device):
+    main(device)

--- a/tests/integration/neural_networks/autoencoder/hyperparams.yaml
+++ b/tests/integration/neural_networks/autoencoder/hyperparams.yaml
@@ -32,6 +32,7 @@ linear2: !new:speechbrain.nnet.linear.Linear
     bias: False
 
 modules:
+    compute_features: !ref <compute_features>
     linear1: !ref <linear1>
     linear2: !ref <linear2>
     mean_var_norm: !ref <mean_var_norm>

--- a/tests/integration/neural_networks/separation/example_conv_tasnet.py
+++ b/tests/integration/neural_networks/separation/example_conv_tasnet.py
@@ -15,6 +15,7 @@ from speechbrain.nnet.losses import get_si_snr_with_pitwrapper
 class SepBrain(sb.Brain):
     def compute_forward(self, mixture, stage):
         "Given an input batch it computes the two estimated sources."
+        mixture = mixture.to(self.device)
         mix_w = self.hparams.encoder(mixture)
         est_mask = self.hparams.mask_net(mix_w)
         mix_w = torch.stack([mix_w] * 2)
@@ -122,7 +123,7 @@ def data_prep(data_folder, hparams):
     return train_data, valid_data
 
 
-def main():
+def main(device="cpu"):
     experiment_dir = pathlib.Path(__file__).resolve().parent
     hparams_file = experiment_dir / "hyperparams.yaml"
     data_folder = "../../../../samples/audio_samples/sourcesep_samples"
@@ -136,7 +137,12 @@ def main():
     train_data, valid_data = data_prep(data_folder, hparams)
 
     # Trainer initialization
-    sep_brain = SepBrain(hparams["modules"], hparams["opt_class"], hparams)
+    sep_brain = SepBrain(
+        hparams["modules"],
+        hparams["opt_class"],
+        hparams,
+        run_opts={"device": device},
+    )
 
     # Training/validation loop
     sep_brain.fit(
@@ -157,5 +163,5 @@ if __name__ == "__main__":
     main()
 
 
-def test_error():
-    main()
+def test_error(device):
+    main(device)

--- a/tests/integration/neural_networks/speaker_id/example_xvector_experiment.py
+++ b/tests/integration/neural_networks/speaker_id/example_xvector_experiment.py
@@ -12,6 +12,7 @@ from hyperpyyaml import load_hyperpyyaml
 class XvectorBrain(sb.Brain):
     def compute_forward(self, batch, stage):
         "Given an input batch it computes the speaker probabilities."
+        batch = batch.to(self.device)
         wavs, lens = batch.sig
         feats = self.hparams.compute_features(wavs)
         feats = self.modules.mean_var_norm(feats, lens)
@@ -95,7 +96,7 @@ def data_prep(data_folder, hparams):
     return train_data, valid_data
 
 
-def main():
+def main(device="cpu"):
     experiment_dir = pathlib.Path(__file__).resolve().parent
     hparams_file = experiment_dir / "hyperparams.yaml"
     data_folder = "../../../../samples/audio_samples/nn_training_samples"
@@ -110,7 +111,10 @@ def main():
 
     # Trainer initialization
     xvect_brain = XvectorBrain(
-        hparams["modules"], hparams["opt_class"], hparams
+        hparams["modules"],
+        hparams["opt_class"],
+        hparams,
+        run_opts={"device": device},
     )
 
     # Training/validation loop
@@ -132,5 +136,5 @@ if __name__ == "__main__":
     main()
 
 
-def test_error():
-    main()
+def test_error(device):
+    main(device)

--- a/tests/integration/neural_networks/speaker_id/hyperparams.yaml
+++ b/tests/integration/neural_networks/speaker_id/hyperparams.yaml
@@ -44,6 +44,7 @@ mean_var_norm: !new:speechbrain.processing.features.InputNormalization
     norm_type: global
 
 modules:
+    compute_features: !ref <compute_features>
     xvector_model: !ref <xvector_model>
     classifier: !ref <classifier>
     mean_var_norm: !ref <mean_var_norm>

--- a/tests/unittests/test_CNN.py
+++ b/tests/unittests/test_CNN.py
@@ -2,66 +2,76 @@ import torch
 import torch.nn
 
 
-def test_SincConv():
-
+def test_SincConv(device):
     from speechbrain.nnet.CNN import SincConv
 
-    input = torch.rand([4, 16000])
+    input = torch.rand([4, 16000], device=device)
     convolve = SincConv(
         input_shape=input.shape, out_channels=8, kernel_size=65, padding="same"
-    )
+    ).to(device)
     output = convolve(input)
     assert output.shape[-1] == 8
 
     assert torch.jit.trace(convolve, input)
 
 
-def test_Conv1d():
+def test_Conv1d(device):
 
     from speechbrain.nnet.CNN import Conv1d
 
-    input = torch.tensor([-1, -1, -1, -1]).unsqueeze(0).unsqueeze(2).float()
+    input = (
+        torch.tensor([-1, -1, -1, -1], device=device)
+        .unsqueeze(0)
+        .unsqueeze(2)
+        .float()
+    )
     convolve = Conv1d(
         out_channels=1, kernel_size=1, input_shape=input.shape, padding="same"
-    )
+    ).to(device)
     output = convolve(input)
     assert input.shape == output.shape
 
     convolve.conv.weight = torch.nn.Parameter(
-        torch.tensor([-1]).float().unsqueeze(0).unsqueeze(1)
+        torch.tensor([-1], device=device).float().unsqueeze(0).unsqueeze(1)
     )
-    convolve.conv.bias = torch.nn.Parameter(torch.tensor([0]).float())
+    convolve.conv.bias = torch.nn.Parameter(
+        torch.tensor([0], device=device).float()
+    )
     output = convolve(input)
-    assert torch.all(torch.eq(torch.ones(input.shape), output))
+    assert torch.all(torch.eq(torch.ones(input.shape, device=device), output))
 
     assert torch.jit.trace(convolve, input)
 
 
-def test_Conv2d():
+def test_Conv2d(device):
 
     from speechbrain.nnet.CNN import Conv2d
 
-    input = torch.rand([4, 11, 32, 1])
+    input = torch.rand([4, 11, 32, 1], device=device)
     convolve = Conv2d(
         out_channels=1,
         input_shape=input.shape,
         kernel_size=(1, 1),
         padding="same",
-    )
+    ).to(device)
     output = convolve(input)
     assert output.shape[-1] == 1
 
     convolve.conv.weight = torch.nn.Parameter(
-        torch.zeros(convolve.conv.weight.shape)
+        torch.zeros(convolve.conv.weight.shape, device=device)
     )
-    convolve.conv.bias = torch.nn.Parameter(torch.tensor([0]).float())
+    convolve.conv.bias = torch.nn.Parameter(
+        torch.tensor([0], device=device).float()
+    )
     output = convolve(input)
-    assert torch.all(torch.eq(torch.zeros(input.shape), output))
+    assert torch.all(torch.eq(torch.zeros(input.shape, device=device), output))
 
     convolve.conv.weight = torch.nn.Parameter(
-        torch.ones(convolve.conv.weight.shape)
+        torch.ones(convolve.conv.weight.shape, device=device)
     )
-    convolve.conv.bias = torch.nn.Parameter(torch.tensor([0]).float())
+    convolve.conv.bias = torch.nn.Parameter(
+        torch.tensor([0], device=device).float()
+    )
     output = convolve(input)
     assert torch.all(torch.eq(input, output))
 

--- a/tests/unittests/test_RNN.py
+++ b/tests/unittests/test_RNN.py
@@ -3,25 +3,18 @@ import torch.nn
 from collections import OrderedDict
 
 
-def test_RNN():
+def test_RNN(device):
 
-    from speechbrain.nnet.RNN import (
-        RNN,
-        GRU,
-        LSTM,
-        LiGRU,
-        QuasiRNN,
-        RNNCell,
-    )
+    from speechbrain.nnet.RNN import RNN, GRU, LSTM, LiGRU, QuasiRNN, RNNCell
 
     # Check RNN
-    inputs = torch.randn(4, 2, 7)
+    inputs = torch.randn(4, 2, 7, device=device)
     net = RNN(
         hidden_size=5,
         input_shape=inputs.shape,
         num_layers=2,
         bidirectional=False,
-    )
+    ).to(device)
     output, hn = net(inputs)
     output_l = []
     hn_t = None
@@ -39,13 +32,13 @@ def test_RNN():
     assert torch.jit.trace(net, inputs)
 
     # Check GRU
-    inputs = torch.randn(4, 2, 7)
+    inputs = torch.randn(4, 2, 7, device=device)
     net = GRU(
         hidden_size=5,
         input_shape=inputs.shape,
         num_layers=2,
         bidirectional=False,
-    )
+    ).to(device)
     output, hn = net(inputs)
     output_l = []
     hn_t = None
@@ -63,13 +56,13 @@ def test_RNN():
     assert torch.jit.trace(net, inputs)
 
     # Check LSTM
-    inputs = torch.randn(4, 2, 7)
+    inputs = torch.randn(4, 2, 7, device=device)
     net = LSTM(
         hidden_size=5,
         input_shape=inputs.shape,
         num_layers=2,
         bidirectional=False,
-    )
+    ).to(device)
     output, hn = net(inputs)
     output_l = []
     hn_t = None
@@ -87,14 +80,14 @@ def test_RNN():
     assert torch.jit.trace(net, inputs)
 
     # Check LiGRU
-    inputs = torch.randn(1, 2, 2)
+    inputs = torch.randn(1, 2, 2, device=device)
     net = LiGRU(
         hidden_size=5,
         input_shape=inputs.shape,
         num_layers=2,
         bidirectional=False,
         normalization="layernorm",
-    )
+    ).to(device)
 
     output, hn = net(inputs)
     output_l = []
@@ -113,13 +106,13 @@ def test_RNN():
     ), "LiGRU hidden states mismatch"
 
     # Check QuasiRNN
-    inputs = torch.randn(1, 2, 2)
+    inputs = torch.randn(1, 2, 2, device=device)
     net = QuasiRNN(
         hidden_size=5,
         input_shape=inputs.shape,
         num_layers=2,
         bidirectional=False,
-    )
+    ).to(device)
 
     output, hn = net(inputs)
     output_l = []
@@ -141,8 +134,10 @@ def test_RNN():
     assert torch.jit.trace(net, inputs)
 
     # Check RNNCell
-    inputs = torch.randn(4, 2, 7)
-    net = RNNCell(hidden_size=5, input_size=7, num_layers=2, dropout=0.0,)
+    inputs = torch.randn(4, 2, 7, device=device)
+    net = RNNCell(hidden_size=5, input_size=7, num_layers=2, dropout=0.0).to(
+        device
+    )
     hn_t = None
     output_lst = []
     for t in range(inputs.shape[1]):
@@ -152,7 +147,7 @@ def test_RNN():
     out_steps = torch.stack(output_lst, dim=1)
     rnn = torch.nn.RNN(
         input_size=7, hidden_size=5, num_layers=2, batch_first=True
-    )
+    ).to(device)
 
     # rename the state_dict
     state = net.state_dict()

--- a/tests/unittests/test_activations.py
+++ b/tests/unittests/test_activations.py
@@ -2,11 +2,11 @@ import torch
 import torch.nn
 
 
-def test_softmax():
+def test_softmax(device):
 
     from speechbrain.nnet.activations import Softmax
 
-    inputs = torch.tensor([1, 2, 3]).float()
+    inputs = torch.tensor([1, 2, 3], device=device).float()
     act = Softmax(apply_log=False)
     outputs = act(inputs)
     assert torch.argmax(outputs) == 2

--- a/tests/unittests/test_attention.py
+++ b/tests/unittests/test_attention.py
@@ -1,7 +1,7 @@
 import torch
 
 
-def test_rel_pos_MHA():
+def test_rel_pos_MHA(device):
 
     from speechbrain.nnet.attention import RelPosMHAXL
 
@@ -16,8 +16,12 @@ def test_rel_pos_MHA():
         for ql in q_len:
             for b in bias:
                 for h in head_dim:
-                    relpos = RelPosMHAXL(emb_dim, num_heads=2, vbias=b, vdim=h)
-                    q = torch.rand((bsz, ql, emb_dim))
-                    k = torch.rand((bsz, kl, emb_dim))
-                    pos_embs = torch.rand((1, 2 * kl - 1, emb_dim))
+                    relpos = RelPosMHAXL(
+                        emb_dim, num_heads=2, vbias=b, vdim=h
+                    ).to(device)
+                    q = torch.rand((bsz, ql, emb_dim), device=device)
+                    k = torch.rand((bsz, kl, emb_dim), device=device)
+                    pos_embs = torch.rand(
+                        (1, 2 * kl - 1, emb_dim), device=device
+                    )
                     relpos(q, k, k, pos_embs=pos_embs)

--- a/tests/unittests/test_augment.py
+++ b/tests/unittests/test_augment.py
@@ -3,28 +3,33 @@ import torch
 from speechbrain.dataio.dataio import write_audio
 
 
-def test_add_noise(tmpdir):
+def test_add_noise(tmpdir, device):
     from speechbrain.processing.speech_augmentation import AddNoise
 
     # Test concatenation of batches
-    wav_a = torch.sin(torch.arange(8000.0)).unsqueeze(0)
-    a_len = torch.ones(1)
-    wav_b = torch.cos(torch.arange(10000.0)).unsqueeze(0).repeat(2, 1)
-    b_len = torch.ones(2)
+    wav_a = torch.sin(torch.arange(8000.0, device=device)).unsqueeze(0)
+    a_len = torch.ones(1, device=device)
+    wav_b = (
+        torch.cos(torch.arange(10000.0, device=device))
+        .unsqueeze(0)
+        .repeat(2, 1)
+    )
+    b_len = torch.ones(2, device=device)
     concat, lens = AddNoise._concat_batch(wav_a, a_len, wav_b, b_len)
     assert concat.shape == (3, 10000)
-    assert lens.allclose(torch.Tensor([0.8, 1, 1]))
+    assert lens.allclose(torch.Tensor([0.8, 1, 1]).to(device))
     concat, lens = AddNoise._concat_batch(wav_b, b_len, wav_a, a_len)
     assert concat.shape == (3, 10000)
-    assert lens.allclose(torch.Tensor([1, 1, 0.8]))
+    expected = torch.Tensor([1, 1, 0.8]).to(device)
+    assert lens.allclose(expected)
 
-    test_waveform = torch.sin(torch.arange(16000.0)).unsqueeze(0)
-    test_noise = torch.cos(torch.arange(16000.0)).unsqueeze(0)
-    wav_lens = torch.ones(1)
+    test_waveform = torch.sin(torch.arange(16000.0, device=device)).unsqueeze(0)
+    test_noise = torch.cos(torch.arange(16000.0, device=device)).unsqueeze(0)
+    wav_lens = torch.ones(1, device=device)
 
     # Put noise waveform into temporary file
     noisefile = os.path.join(tmpdir, "noise.wav")
-    write_audio(noisefile, test_noise.transpose(0, 1), 16000)
+    write_audio(noisefile, test_noise.transpose(0, 1).cpu(), 16000)
 
     csv = os.path.join(tmpdir, "noise.csv")
     with open(csv, "w") as w:
@@ -32,7 +37,7 @@ def test_add_noise(tmpdir):
         w.write(f"1, 1.0, {noisefile}, wav,\n")
 
     # Edge cases
-    no_noise = AddNoise(mix_prob=0.0)
+    no_noise = AddNoise(mix_prob=0.0).to(device)
     assert no_noise(test_waveform, wav_lens).allclose(test_waveform)
     no_noise = AddNoise(snr_low=1000, snr_high=1000)
     assert no_noise(test_waveform, wav_lens).allclose(test_waveform)
@@ -40,34 +45,34 @@ def test_add_noise(tmpdir):
     assert all_noise(test_waveform, wav_lens).allclose(test_noise, atol=1e-4)
 
     # Basic 0dB case
-    add_noise = AddNoise(csv_file=csv)
+    add_noise = AddNoise(csv_file=csv).to(device)
     expected = (test_waveform + test_noise) / 2
     assert add_noise(test_waveform, wav_lens).allclose(expected, atol=1e-4)
 
 
-def test_add_reverb(tmpdir):
+def test_add_reverb(tmpdir, device):
     from speechbrain.processing.speech_augmentation import AddReverb
 
-    test_waveform = torch.sin(torch.arange(16000.0)).unsqueeze(0)
-    impulse_response = torch.zeros(1, 8000)
+    test_waveform = torch.sin(torch.arange(16000.0, device=device)).unsqueeze(0)
+    impulse_response = torch.zeros(1, 8000, device=device)
     impulse_response[0, 0] = 1.0
-    wav_lens = torch.ones(1)
+    wav_lens = torch.ones(1, device=device)
 
     # Put ir waveform into temporary file
     ir1 = os.path.join(tmpdir, "ir1.wav")
     ir2 = os.path.join(tmpdir, "ir2.wav")
     ir3 = os.path.join(tmpdir, "ir3.wav")
-    write_audio(ir1, impulse_response.transpose(0, 1), 16000)
+    write_audio(ir1, impulse_response.cpu().transpose(0, 1), 16000)
 
     impulse_response[0, 0] = 0.0
     impulse_response[0, 10] = 0.5
-    write_audio(ir2, impulse_response.transpose(0, 1), 16000)
+    write_audio(ir2, impulse_response.cpu().transpose(0, 1), 16000)
 
     # Check a very simple non-impulse-response case:
     impulse_response[0, 10] = 0.6
     impulse_response[0, 11] = 0.4
     # sf.write(ir3, impulse_response.squeeze(0).numpy(), 16000)
-    write_audio(ir3, impulse_response.transpose(0, 1), 16000)
+    write_audio(ir3, impulse_response.cpu().transpose(0, 1), 16000)
     ir3_result = test_waveform * 0.6 + test_waveform.roll(1, -1) * 0.4
 
     # write ir csv file
@@ -79,7 +84,7 @@ def test_add_reverb(tmpdir):
         w.write(f"3, 0.5, {ir3}, wav,\n")
 
     # Edge case
-    no_reverb = AddReverb(csv, reverb_prob=0.0)
+    no_reverb = AddReverb(csv, reverb_prob=0.0).to(device)
     assert no_reverb(test_waveform, wav_lens).allclose(test_waveform)
 
     # Normal cases
@@ -92,49 +97,52 @@ def test_add_reverb(tmpdir):
     assert reverbed.allclose(ir3_result[:, 0:1000], atol=2e-1)
 
 
-def test_speed_perturb():
+def test_speed_perturb(device):
     from speechbrain.processing.speech_augmentation import SpeedPerturb
 
-    test_waveform = torch.sin(torch.arange(16000.0)).unsqueeze(0)
+    test_waveform = torch.sin(torch.arange(16000.0, device=device)).unsqueeze(0)
 
     # Edge cases
-    no_perturb = SpeedPerturb(16000, perturb_prob=0.0)
+    no_perturb = SpeedPerturb(16000, perturb_prob=0.0).to(device)
     assert no_perturb(test_waveform).allclose(test_waveform)
-    no_perturb = SpeedPerturb(16000, speeds=[100])
+    no_perturb = SpeedPerturb(16000, speeds=[100]).to(device)
     assert no_perturb(test_waveform).allclose(test_waveform)
 
     # Half speed
-    half_speed = SpeedPerturb(16000, speeds=[50])
+    half_speed = SpeedPerturb(16000, speeds=[50]).to(device)
     assert half_speed(test_waveform).allclose(test_waveform[:, ::2], atol=3e-1)
 
 
-def test_babble():
+def test_babble(device):
     from speechbrain.processing.speech_augmentation import AddBabble
 
     test_waveform = torch.stack(
-        (torch.sin(torch.arange(16000.0)), torch.cos(torch.arange(16000.0)),)
+        (
+            torch.sin(torch.arange(16000.0, device=device)),
+            torch.cos(torch.arange(16000.0, device=device)),
+        )
     )
-    lengths = torch.ones(2)
+    lengths = torch.ones(2, device=device)
 
     # Edge cases
-    no_babble = AddBabble(mix_prob=0.0)
+    no_babble = AddBabble(mix_prob=0.0).to(device)
     assert no_babble(test_waveform, lengths).allclose(test_waveform)
     no_babble = AddBabble(speaker_count=1, snr_low=1000, snr_high=1000)
     assert no_babble(test_waveform, lengths).allclose(test_waveform)
 
     # One babbler just averages the two speakers
-    babble = AddBabble(speaker_count=1)
+    babble = AddBabble(speaker_count=1).to(device)
     expected = (test_waveform + test_waveform.roll(1, 0)) / 2
     assert babble(test_waveform, lengths).allclose(expected, atol=1e-4)
 
 
-def test_drop_freq():
+def test_drop_freq(device):
     from speechbrain.processing.speech_augmentation import DropFreq
 
-    test_waveform = torch.sin(torch.arange(16000.0)).unsqueeze(0)
+    test_waveform = torch.sin(torch.arange(16000.0, device=device)).unsqueeze(0)
 
     # Edge cases
-    no_drop = DropFreq(drop_prob=0.0)
+    no_drop = DropFreq(drop_prob=0.0).to(device)
     assert no_drop(test_waveform).allclose(test_waveform)
     no_drop = DropFreq(drop_count_low=0, drop_count_high=0)
     assert no_drop(test_waveform).allclose(test_waveform)
@@ -146,24 +154,24 @@ def test_drop_freq():
     # Check case where frequency range *does* include signal frequency
     drop_same_freq = DropFreq(drop_freq_low=0.28, drop_freq_high=0.28)
     assert drop_same_freq(test_waveform).allclose(
-        torch.zeros(1, 16000), atol=4e-1
+        torch.zeros(1, 16000, device=device), atol=4e-1
     )
 
 
-def test_drop_chunk():
+def test_drop_chunk(device):
     from speechbrain.processing.speech_augmentation import DropChunk
 
-    test_waveform = torch.sin(torch.arange(16000.0)).unsqueeze(0)
-    lengths = torch.ones(1)
+    test_waveform = torch.sin(torch.arange(16000.0, device=device)).unsqueeze(0)
+    lengths = torch.ones(1, device=device)
 
     # Edge cases
-    no_drop = DropChunk(drop_prob=0.0)
+    no_drop = DropChunk(drop_prob=0.0).to(device)
     assert no_drop(test_waveform, lengths).allclose(test_waveform)
-    no_drop = DropChunk(drop_length_low=0, drop_length_high=0)
+    no_drop = DropChunk(drop_length_low=0, drop_length_high=0).to(device)
     assert no_drop(test_waveform, lengths).allclose(test_waveform)
-    no_drop = DropChunk(drop_count_low=0, drop_count_high=0)
+    no_drop = DropChunk(drop_count_low=0, drop_count_high=0).to(device)
     assert no_drop(test_waveform, lengths).allclose(test_waveform)
-    no_drop = DropChunk(drop_start=0, drop_end=0)
+    no_drop = DropChunk(drop_start=0, drop_end=0).to(device)
     assert no_drop(test_waveform, lengths).allclose(test_waveform)
 
     # Specify all parameters to ensure it is deterministic
@@ -175,31 +183,31 @@ def test_drop_chunk():
         drop_start=100,
         drop_end=200,
         noise_factor=0.0,
-    )
+    ).to(device)
     expected_waveform = test_waveform.clone()
     expected_waveform[:, 100:200] = 0.0
 
     assert dropper(test_waveform, lengths).allclose(expected_waveform)
 
     # Make sure amplitude is similar before and after
-    dropper = DropChunk(noise_factor=1.0)
+    dropper = DropChunk(noise_factor=1.0).to(device)
     drop_amplitude = dropper(test_waveform, lengths).abs().mean()
     orig_amplitude = test_waveform.abs().mean()
     assert drop_amplitude.allclose(orig_amplitude, atol=1e-2)
 
 
-def test_clip():
+def test_clip(device):
     from speechbrain.processing.speech_augmentation import DoClip
 
-    test_waveform = torch.sin(torch.arange(16000.0)).unsqueeze(0)
+    test_waveform = torch.sin(torch.arange(16000.0, device=device)).unsqueeze(0)
 
     # Edge cases
-    no_clip = DoClip(clip_prob=0.0)
+    no_clip = DoClip(clip_prob=0.0).to(device)
     assert no_clip(test_waveform).allclose(test_waveform)
-    no_clip = DoClip(clip_low=1, clip_high=1)
+    no_clip = DoClip(clip_low=1, clip_high=1).to(device)
     assert no_clip(test_waveform).allclose(test_waveform)
 
     # Sort of a reimplementation of clipping, but its one function call.
     expected = test_waveform.clamp(min=-0.5, max=0.5)
-    half_clip = DoClip(clip_low=0.5, clip_high=0.5)
+    half_clip = DoClip(clip_low=0.5, clip_high=0.5).to(device)
     assert half_clip(test_waveform).allclose(expected)

--- a/tests/unittests/test_batching.py
+++ b/tests/unittests/test_batching.py
@@ -3,7 +3,7 @@ import torch
 import numpy as np
 
 
-def test_batch_pad_right_to():
+def test_batch_pad_right_to(device):
     from speechbrain.utils.data_utils import batch_pad_right
     import random
 
@@ -12,7 +12,10 @@ def test_batch_pad_right_to():
 
     for b in batch_lens:
         rand_lens = [random.randint(10, 53) for x in range(b)]
-        tensors = [torch.ones((rand_lens[x], n_channels)) for x in range(b)]
+        tensors = [
+            torch.ones((rand_lens[x], n_channels), device=device)
+            for x in range(b)
+        ]
         batched, lens = batch_pad_right(tensors)
         assert batched.shape[0] == b
         np.testing.assert_almost_equal(
@@ -21,7 +24,7 @@ def test_batch_pad_right_to():
 
     for b in batch_lens:
         rand_lens = [random.randint(10, 53) for x in range(b)]
-        tensors = [torch.ones(rand_lens[x],) for x in range(b)]
+        tensors = [torch.ones(rand_lens[x], device=device) for x in range(b)]
         batched, lens = batch_pad_right(tensors)
         assert batched.shape[0] == b
         np.testing.assert_almost_equal(
@@ -29,20 +32,20 @@ def test_batch_pad_right_to():
         )
 
 
-def test_paddedbatch():
+def test_paddedbatch(device):
     from speechbrain.dataio.batch import PaddedBatch
 
     batch = PaddedBatch(
         [
             {
                 "id": "ex1",
-                "foo": torch.Tensor([1.0]),
-                "bar": torch.Tensor([1.0, 2.0, 3.0]),
+                "foo": torch.Tensor([1.0]).to(device),
+                "bar": torch.Tensor([1.0, 2.0, 3.0]).to(device),
             },
             {
                 "id": "ex2",
-                "foo": torch.Tensor([2.0, 1.0]),
-                "bar": torch.Tensor([2.0]),
+                "foo": torch.Tensor([2.0, 1.0]).to(device),
+                "bar": torch.Tensor([2.0]).to(device),
             },
         ]
     )

--- a/tests/unittests/test_categorical_encoder.py
+++ b/tests/unittests/test_categorical_encoder.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-def test_categorical_encoder():
+def test_categorical_encoder(device):
     from speechbrain.dataio.encoder import CategoricalEncoder
 
     encoder = CategoricalEncoder()
@@ -25,7 +25,7 @@ def test_categorical_encoder():
     encoder = CategoricalEncoder()
     encoder.update_from_iterable("abcd")
     result = encoder.decode_torch(
-        torch.tensor([[0, 0], [1, 1], [2, 2], [3, 3]])
+        torch.tensor([[0, 0], [1, 1], [2, 2], [3, 3]], device=device)
     )
     assert result == [["a", "a"], ["b", "b"], ["c", "c"], ["d", "d"]]
     result = encoder.decode_ndim([[0, 0], [1, 1], [2, 2], [3, 3]])
@@ -35,7 +35,7 @@ def test_categorical_encoder():
     result = encoder.decode_ndim([[[[[0, 0], [1, 1], [2, 2], [3, 3]]]]])
     assert result == [[[[["a", "a"], ["b", "b"], ["c", "c"], ["d", "d"]]]]]
     result = encoder.decode_torch(
-        torch.tensor([[[[[0, 0], [1, 1], [2, 2], [3, 3]]]]])
+        torch.tensor([[[[[0, 0], [1, 1], [2, 2], [3, 3]]]]], device=device)
     )
     assert result == [[[[["a", "a"], ["b", "b"], ["c", "c"], ["d", "d"]]]]]
     result = encoder.decode_ndim([[0, 0], [1], [2, 2, 2], []])

--- a/tests/unittests/test_checkpoints.py
+++ b/tests/unittests/test_checkpoints.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-def test_checkpointer(tmpdir):
+def test_checkpointer(tmpdir, device):
     from speechbrain.utils.checkpoints import Checkpointer
     import torch
 
@@ -16,12 +16,12 @@ def test_checkpointer(tmpdir):
     recoverable = Recoverable(2.0)
     recoverables = {"recoverable": recoverable}
     recoverer = Checkpointer(tmpdir, recoverables)
-    recoverable.param.data = torch.tensor([1.0])
+    recoverable.param.data = torch.tensor([1.0], device=device)
     # Should not be possible since no checkpoint saved yet:
     assert not recoverer.recover_if_possible()
     result = recoverable(10.0)
     # Check that parameter has not been loaded from original value:
-    assert recoverable.param.data == torch.tensor([1.0])
+    assert recoverable.param.data == torch.tensor([1.0], device=device)
 
     ckpt = recoverer.save_checkpoint()
     # Check that the name recoverable has a save file:
@@ -30,10 +30,10 @@ def test_checkpointer(tmpdir):
     # Check that saved checkpoint is found, and location correct:
     assert recoverer.list_checkpoints()[0] == ckpt
     assert recoverer.list_checkpoints()[0].path.parent == tmpdir
-    recoverable.param.data = torch.tensor([2.0])
+    recoverable.param.data = torch.tensor([2.0], device=device)
     recoverer.recover_if_possible()
     # Check that parameter has been loaded immediately:
-    assert recoverable.param.data == torch.tensor([1.0])
+    assert recoverable.param.data == torch.tensor([1.0], device=device)
     result = recoverable(10.0)
     # And result correct
     assert result == 10.0
@@ -48,14 +48,14 @@ def test_checkpointer(tmpdir):
     assert (new_ckpt.path / "recoverable.ckpt").exists()
     assert (new_ckpt.path / "other.ckpt").exists()
     assert new_ckpt in recoverer.list_checkpoints()
-    recoverable.param.data = torch.tensor([2.0])
-    other.param.data = torch.tensor([10.0])
+    recoverable.param.data = torch.tensor([2.0], device=device)
+    other.param.data = torch.tensor([10.0], device=device)
     chosen_ckpt = recoverer.recover_if_possible()
     # Should choose newest by default:
     assert chosen_ckpt == new_ckpt
     # Check again that parameters have been loaded immediately:
-    assert recoverable.param.data == torch.tensor([1.0])
-    assert other.param.data == torch.tensor([2.0])
+    assert recoverable.param.data == torch.tensor([1.0], device=device)
+    assert other.param.data == torch.tensor([2.0], device=device)
     other_result = other(10.0)
     # And again we should have the correct computations:
     assert other_result == 20.0
@@ -69,8 +69,8 @@ def test_checkpointer(tmpdir):
         )
     # However this operation may have loaded the first object
     # so let's set the values manually:
-    recoverable.param.data = torch.tensor([2.0])
-    other.param.data = torch.tensor([10.0])
+    recoverable.param.data = torch.tensor([2.0], device=device)
+    other.param.data = torch.tensor([10.0], device=device)
     recoverer.allow_partial_load = True
     chosen_ckpt = recoverer.recover_if_possible(
         importance_key=lambda x: -x.meta["unixtime"]
@@ -78,23 +78,23 @@ def test_checkpointer(tmpdir):
     # Should have chosen the original:
     assert chosen_ckpt == ckpt
     # And should recover recoverable:
-    assert recoverable.param.data == torch.tensor([1.0])
+    assert recoverable.param.data == torch.tensor([1.0], device=device)
     # But not other:
     other_result = other(10.0)
-    assert other.param.data == torch.tensor([10.0])
+    assert other.param.data == torch.tensor([10.0], device=device)
     assert other_result == 100.0
 
     # Test saving names checkpoints with meta info, and custom filter
     epoch_ckpt = recoverer.save_checkpoint(name="ep1", meta={"loss": 2.0})
     assert "ep1" in epoch_ckpt.path.name
-    other.param.data = torch.tensor([2.0])
+    other.param.data = torch.tensor([2.0], device=device)
     recoverer.save_checkpoint(meta={"loss": 3.0})
     chosen_ckpt = recoverer.recover_if_possible(
         ckpt_predicate=lambda ckpt: "loss" in ckpt.meta,
         importance_key=lambda ckpt: -ckpt.meta["loss"],
     )
     assert chosen_ckpt == epoch_ckpt
-    assert other.param.data == torch.tensor([10.0])
+    assert other.param.data == torch.tensor([10.0], device=device)
 
     # Make sure checkpoints can't be name saved by the same name
     with pytest.raises(FileExistsError):
@@ -140,14 +140,16 @@ def test_recovery_custom_io(tmpdir):
     assert custom_recoverable.param == 1
 
 
-def test_checkpoint_deletion(tmpdir):
+def test_checkpoint_deletion(tmpdir, device):
     from speechbrain.utils.checkpoints import Checkpointer
     import torch
 
     class Recoverable(torch.nn.Module):
         def __init__(self, param):
             super().__init__()
-            self.param = torch.nn.Parameter(torch.tensor([param]))
+            self.param = torch.nn.Parameter(
+                torch.tensor([param], device=device)
+            )
 
         def forward(self, x):
             return x * self.param
@@ -252,14 +254,16 @@ def test_multiple_ckpts_and_criteria(tmpdir):
     assert found_ckpts == [fifth_ckpt, fourth_ckpt]
 
 
-def test_torch_meta(tmpdir):
+def test_torch_meta(tmpdir, device):
     from speechbrain.utils.checkpoints import Checkpointer
     import torch
 
     class Recoverable(torch.nn.Module):
         def __init__(self, param):
             super().__init__()
-            self.param = torch.nn.Parameter(torch.tensor([param]))
+            self.param = torch.nn.Parameter(
+                torch.tensor([param], device=device)
+            )
 
         def forward(self, x):
             return x * self.param
@@ -268,7 +272,7 @@ def test_torch_meta(tmpdir):
     recoverables = {"recoverable": recoverable}
     recoverer = Checkpointer(tmpdir, recoverables)
     saved = recoverer.save_checkpoint(
-        meta={"loss": torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0])}
+        meta={"loss": torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device=device)}
     )
     loaded = recoverer.recover_if_possible()
     assert saved.meta["loss"].allclose(loaded.meta["loss"])
@@ -338,11 +342,11 @@ def test_checkpoint_hook_register(tmpdir):
                     self.param = int(fi.read())
 
 
-def test_torch_defaults(tmpdir):
+def test_torch_defaults(tmpdir, device):
     from speechbrain.utils.checkpoints import Checkpointer
     import torch
 
-    module = torch.nn.Linear(10, 10)
+    module = torch.nn.Linear(10, 10).to(device)
     optimizer = torch.optim.Adam(module.parameters())
     lr_scheduler = torch.optim.lr_scheduler.CyclicLR(
         optimizer, 0.1, 1.0, cycle_momentum=False
@@ -360,11 +364,11 @@ def test_torch_defaults(tmpdir):
     )
     ckpt = checkpointer.save_checkpoint()
     # test the module:
-    inp = torch.randn((3, 10))
+    inp = torch.randn((3, 10), device=device)
     prev_output = module(inp)
 
     # Re-initialize everything
-    module = torch.nn.Linear(10, 10)
+    module = torch.nn.Linear(10, 10, device=device)
     optimizer = torch.optim.Adam(module.parameters())
     lr_scheduler = torch.optim.lr_scheduler.CyclicLR(
         optimizer, 0.1, 1.0, cycle_momentum=False

--- a/tests/unittests/test_core.py
+++ b/tests/unittests/test_core.py
@@ -9,12 +9,12 @@ def test_parse_arguments():
     assert overrides == "seed: 3\ndata_folder: TIMIT"
 
 
-def test_brain():
+def test_brain(device):
     import torch
     from speechbrain.core import Brain, Stage
     from torch.optim import SGD
 
-    model = torch.nn.Linear(in_features=10, out_features=10)
+    model = torch.nn.Linear(in_features=10, out_features=10, device=device)
 
     class SimpleBrain(Brain):
         def compute_forward(self, batch, stage):
@@ -23,10 +23,12 @@ def test_brain():
         def compute_objectives(self, predictions, batch, stage):
             return torch.nn.functional.l1_loss(predictions, batch[1])
 
-    brain = SimpleBrain({"model": model}, lambda x: SGD(x, 0.1))
+    brain = SimpleBrain(
+        {"model": model}, lambda x: SGD(x, 0.1), run_opts={"device": device}
+    )
 
-    inputs = torch.rand(10, 10)
-    targets = torch.rand(10, 10)
+    inputs = torch.rand(10, 10, device=device)
+    targets = torch.rand(10, 10, device=device)
     train_set = ([inputs, targets],)
     valid_set = ([inputs, targets],)
 

--- a/tests/unittests/test_data_io.py
+++ b/tests/unittests/test_data_io.py
@@ -2,59 +2,59 @@ import torch
 import os
 
 
-def test_read_audio(tmpdir):
+def test_read_audio(tmpdir, device):
     from speechbrain.dataio.dataio import read_audio, write_audio
 
-    test_waveform = torch.rand(16000)
+    test_waveform = torch.rand(16000, device=device)
     wavfile = os.path.join(tmpdir, "wave.wav")
-    write_audio(wavfile, test_waveform, 16000)
+    write_audio(wavfile, test_waveform.cpu(), 16000)
 
     # dummy annotation
     for i in range(3):
-        start = torch.randint(0, 8000, (1,)).item()
-        stop = start + torch.randint(500, 1000, (1,)).item()
+        start = torch.randint(0, 8000, (1,), device=device).item()
+        stop = start + torch.randint(500, 1000, (1,), device=device).item()
         wav_obj = {"wav": {"file": wavfile, "start": start, "stop": stop}}
-        loaded = read_audio(wav_obj["wav"])
+        loaded = read_audio(wav_obj["wav"]).to(device)
         assert loaded.allclose(test_waveform[start:stop], atol=1e-4)
         # set to equal when switching to the sox_io backend
         # assert torch.all(torch.eq(loaded, test_waveform[0, start:stop]))
 
 
-def test_read_audio_multichannel(tmpdir):
+def test_read_audio_multichannel(tmpdir, device):
     from speechbrain.dataio.dataio import read_audio_multichannel, write_audio
 
-    test_waveform = torch.rand(16000, 2)
+    test_waveform = torch.rand(16000, 2, device=device)
     wavfile = os.path.join(tmpdir, "wave.wav")
     # sf.write(wavfile, test_waveform, 16000, subtype="float")
-    write_audio(wavfile, test_waveform, 16000)
+    write_audio(wavfile, test_waveform.cpu(), 16000)
 
     # dummy annotation we save and load one multichannel file
     for i in range(2):
-        start = torch.randint(0, 8000, (1,)).item()
-        stop = start + torch.randint(500, 1000, (1,)).item()
+        start = torch.randint(0, 8000, (1,), device=device).item()
+        stop = start + torch.randint(500, 1000, (1,), device=device).item()
 
         wav_obj = {"wav": {"files": [wavfile], "start": start, "stop": stop}}
 
-        loaded = read_audio_multichannel(wav_obj["wav"])
+        loaded = read_audio_multichannel(wav_obj["wav"]).to(device)
         assert loaded.allclose(test_waveform[start:stop, :], atol=1e-4)
         # set to equal when switching to the sox_io backend
         # assert torch.all(torch.eq(loaded, test_waveform[:,start:stop]))
 
     # we test now multiple files loading
-    test_waveform_2 = torch.rand(16000, 2)
+    test_waveform_2 = torch.rand(16000, 2, device=device)
     wavfile_2 = os.path.join(tmpdir, "wave_2.wav")
-    write_audio(wavfile_2, test_waveform_2, 16000)
+    write_audio(wavfile_2, test_waveform_2.cpu(), 16000)
     # sf.write(wavfile_2, test_waveform_2, 16000, subtype="float")
 
     for i in range(2):
-        start = torch.randint(0, 8000, (1,)).item()
-        stop = start + torch.randint(500, 1000, (1,)).item()
+        start = torch.randint(0, 8000, (1,), device=device).item()
+        stop = start + torch.randint(500, 1000, (1,), device=device).item()
 
         wav_obj = {
             "wav": {"files": [wavfile, wavfile_2], "start": start, "stop": stop}
         }
 
-        loaded = read_audio_multichannel(wav_obj["wav"])
+        loaded = read_audio_multichannel(wav_obj["wav"]).to(device)
         test_waveform3 = torch.cat(
             (test_waveform[start:stop, :], test_waveform_2[start:stop, :]), 1
         )

--- a/tests/unittests/test_dataloader.py
+++ b/tests/unittests/test_dataloader.py
@@ -2,11 +2,11 @@ import torch
 import pytest
 
 
-def test_saveable_dataloader(tmpdir):
+def test_saveable_dataloader(tmpdir, device):
     from speechbrain.dataio.dataloader import SaveableDataLoader
 
     save_file = tmpdir + "/dataloader.ckpt"
-    dataset = torch.randn(10, 1)
+    dataset = torch.randn(10, 1, device=device)
     dataloader = SaveableDataLoader(dataset, collate_fn=None)
     data_iterator = iter(dataloader)
     first_item = next(data_iterator)

--- a/tests/unittests/test_dropout.py
+++ b/tests/unittests/test_dropout.py
@@ -2,17 +2,19 @@ import torch
 import torch.nn
 
 
-def test_dropout():
+def test_dropout(device):
 
     from speechbrain.nnet.dropout import Dropout2d
 
-    inputs = torch.rand([4, 10, 32])
-    drop = Dropout2d(drop_rate=0.0)
+    inputs = torch.rand([4, 10, 32], device=device)
+    drop = Dropout2d(drop_rate=0.0).to(device)
     outputs = drop(inputs)
     assert torch.all(torch.eq(inputs, outputs))
 
-    drop = Dropout2d(drop_rate=1.0)
+    drop = Dropout2d(drop_rate=1.0).to(device)
     outputs = drop(inputs)
-    assert torch.all(torch.eq(torch.zeros(inputs.shape), outputs))
+    assert torch.all(
+        torch.eq(torch.zeros(inputs.shape, device=device), outputs)
+    )
 
     assert torch.jit.trace(drop, inputs)

--- a/tests/unittests/test_embedding.py
+++ b/tests/unittests/test_embedding.py
@@ -1,7 +1,7 @@
 import torch
 
 
-def test_embedding():
+def test_embedding(device):
 
     from speechbrain.nnet.embedding import Embedding
 
@@ -10,16 +10,18 @@ def test_embedding():
     blank_id = 39
     size_dict = 40
     emb = Embedding(
-        num_embeddings=size_dict, consider_as_one_hot=True, blank_id=blank_id,
-    )
-    inputs = torch.Tensor([10, 5, 2, 0, 39]).long()
+        num_embeddings=size_dict, consider_as_one_hot=True, blank_id=blank_id
+    ).to(device)
+    inputs = torch.Tensor([10, 5, 2, 0, 39]).to(device).long()
     output = emb(inputs)
     assert output.shape == (5, 39)
 
     # use standard embedding layer
     embedding_dim = 128
-    emb = Embedding(num_embeddings=size_dict, embedding_dim=embedding_dim)
-    inputs = torch.randint(0, 40, (5, 10))
+    emb = Embedding(num_embeddings=size_dict, embedding_dim=embedding_dim).to(
+        device
+    )
+    inputs = torch.randint(0, 40, (5, 10), device=device)
     output = emb(inputs)
     assert output.shape == (5, 10, 128)
 

--- a/tests/unittests/test_features.py
+++ b/tests/unittests/test_features.py
@@ -1,45 +1,54 @@
 import torch
 
 
-def test_deltas():
+def test_deltas(device):
 
     from speechbrain.processing.features import Deltas
 
-    size = torch.Size([10, 101, 20])
-    inp = torch.ones(size)
-    compute_deltas = Deltas(input_size=20)
-    out = torch.zeros(size)
+    size = torch.Size([10, 101, 20], device=device)
+    inp = torch.ones(size, device=device)
+    compute_deltas = Deltas(input_size=20).to(device)
+    out = torch.zeros(size, device=device)
     assert torch.sum(compute_deltas(inp) == out) == out.numel()
 
     assert torch.jit.trace(compute_deltas, inp)
 
 
-def test_context_window():
+def test_context_window(device):
 
     from speechbrain.processing.features import ContextWindow
 
-    inp = torch.tensor([1, 2, 3]).unsqueeze(0).unsqueeze(-1).float()
-    compute_cw = ContextWindow(left_frames=1, right_frames=1)
-    out = torch.tensor([[0, 1, 2], [1, 2, 3], [2, 3, 0]]).unsqueeze(0).float()
+    inp = (
+        torch.tensor([1, 2, 3], device=device)
+        .unsqueeze(0)
+        .unsqueeze(-1)
+        .float()
+    )
+    compute_cw = ContextWindow(left_frames=1, right_frames=1).to(device)
+    out = (
+        torch.tensor([[0, 1, 2], [1, 2, 3], [2, 3, 0]], device=device)
+        .unsqueeze(0)
+        .float()
+    )
     assert torch.sum(compute_cw(inp) == out) == 9
 
-    inp = torch.rand([2, 10, 5])
-    compute_cw = ContextWindow(left_frames=0, right_frames=0)
+    inp = torch.rand([2, 10, 5], device=device)
+    compute_cw = ContextWindow(left_frames=0, right_frames=0).to(device)
     assert torch.sum(compute_cw(inp) == inp) == inp.numel()
 
     assert torch.jit.trace(compute_cw, inp)
 
 
-def test_istft():
+def test_istft(device):
     from speechbrain.processing.features import STFT
     from speechbrain.processing.features import ISTFT
 
     fs = 16000
-    inp = torch.randn([10, 16000])
+    inp = torch.randn([10, 16000], device=device)
     inp = torch.stack(3 * [inp], -1)
 
-    compute_stft = STFT(sample_rate=fs)
-    compute_istft = ISTFT(sample_rate=fs)
+    compute_stft = STFT(sample_rate=fs).to(device)
+    compute_istft = ISTFT(sample_rate=fs).to(device)
     out = compute_istft(compute_stft(inp), sig_length=16000)
 
     assert torch.sum(torch.abs(inp - out) < 5e-5) >= inp.numel() - 5
@@ -48,29 +57,29 @@ def test_istft():
     assert torch.jit.trace(compute_istft, compute_stft(inp))
 
 
-def test_filterbank():
+def test_filterbank(device):
 
     from speechbrain.processing.features import Filterbank
 
-    compute_fbanks = Filterbank()
-    inputs = torch.ones([10, 101, 201])
+    compute_fbanks = Filterbank().to(device)
+    inputs = torch.ones([10, 101, 201], device=device)
     assert torch.jit.trace(compute_fbanks, inputs)
 
     # Check amin (-100 dB)
-    inputs = torch.zeros([10, 101, 201])
+    inputs = torch.zeros([10, 101, 201], device=device)
     fbanks = compute_fbanks(inputs)
     assert torch.equal(fbanks, torch.ones_like(fbanks) * -100)
 
     # Check top_db
-    fbanks = torch.zeros([1, 1, 1])
-    expected = torch.Tensor([[[-100]]])
+    fbanks = torch.zeros([1, 1, 1], device=device)
+    expected = torch.Tensor([[[-100]]]).to(device)
     fbanks_db = compute_fbanks._amplitude_to_DB(fbanks)
     assert torch.equal(fbanks_db, expected)
 
     # Making sure independent computation gives same results
     # as the batch computation
-    input1 = torch.rand([1, 101, 201]) * 10
-    input2 = torch.rand([1, 101, 201])
+    input1 = torch.rand([1, 101, 201], device=device) * 10
+    input2 = torch.rand([1, 101, 201], device=device)
     input3 = torch.cat([input1, input2], dim=0)
     fbank1 = compute_fbanks(input1)
     fbank2 = compute_fbanks(input2)
@@ -79,38 +88,43 @@ def test_filterbank():
     assert torch.sum(torch.abs(fbank2[0] - fbank3[1])) < 8e-05
 
 
-def test_dtc():
+def test_dtc(device):
 
     from speechbrain.processing.features import DCT
 
     compute_dct = DCT(input_size=40)
-    inputs = torch.randn([10, 101, 40])
+    inputs = torch.randn([10, 101, 40], device=device)
     assert torch.jit.trace(compute_dct, inputs)
 
 
-def test_input_normalization():
+def test_input_normalization(device):
 
     from speechbrain.processing.features import InputNormalization
 
-    norm = InputNormalization()
-    inputs = torch.randn([10, 101, 20])
-    inp_len = torch.ones([10])
+    norm = InputNormalization().to(device)
+    inputs = torch.randn([10, 101, 20], device=device)
+    inp_len = torch.ones([10], device=device)
     assert torch.jit.trace(norm, (inputs, inp_len))
 
-    norm = InputNormalization()
-    inputs = torch.FloatTensor([1, 2, 3, 0, 0, 0]).unsqueeze(0).unsqueeze(2)
-    inp_len = torch.FloatTensor([0.5])
+    norm = InputNormalization().to(device)
+    inputs = (
+        torch.FloatTensor([1, 2, 3, 0, 0, 0])
+        .to(device)
+        .unsqueeze(0)
+        .unsqueeze(2)
+    )
+    inp_len = torch.FloatTensor([0.5]).to(device)
     out_norm = norm(inputs, inp_len).squeeze()
-    target = torch.FloatTensor([-1, 0, 1, -2, -2, -2])
+    target = torch.FloatTensor([-1, 0, 1, -2, -2, -2]).to(device)
     assert torch.equal(out_norm, target)
 
 
-def test_features_multimic():
+def test_features_multimic(device):
 
     from speechbrain.processing.features import Filterbank
 
-    compute_fbanks = Filterbank()
-    inputs = torch.rand([10, 101, 201])
+    compute_fbanks = Filterbank().to(device)
+    inputs = torch.rand([10, 101, 201], device=device)
     output = compute_fbanks(inputs)
     inputs_ch2 = torch.stack((inputs, inputs), -1)
     output_ch2 = compute_fbanks(inputs_ch2)

--- a/tests/unittests/test_linear.py
+++ b/tests/unittests/test_linear.py
@@ -2,13 +2,15 @@ import torch
 import torch.nn
 
 
-def test_linear():
+def test_linear(device):
 
     from speechbrain.nnet.linear import Linear
 
-    inputs = torch.rand(1, 2, 4)
+    inputs = torch.rand(1, 2, 4, device=device)
     lin_t = Linear(n_neurons=4, input_size=inputs.shape[-1], bias=False)
-    lin_t.w.weight = torch.nn.Parameter(torch.eye(inputs.shape[-1]))
+    lin_t.w.weight = torch.nn.Parameter(
+        torch.eye(inputs.shape[-1], device=device)
+    )
     outputs = lin_t(inputs)
     assert torch.all(torch.eq(inputs, outputs))
 

--- a/tests/unittests/test_losses.py
+++ b/tests/unittests/test_losses.py
@@ -2,83 +2,89 @@ import torch
 import pytest
 
 
-def test_nll():
+def test_nll(device):
     from speechbrain.nnet.losses import nll_loss
 
-    predictions = torch.zeros(4, 10, 8)
-    targets = torch.zeros(4, 10)
-    lengths = torch.ones(4)
+    predictions = torch.zeros(4, 10, 8, device=device)
+    targets = torch.zeros(4, 10, device=device)
+    lengths = torch.ones(4, device=device)
     out_cost = nll_loss(predictions, targets, lengths)
     assert torch.all(torch.eq(out_cost, 0))
 
 
-def test_mse():
+def test_mse(device):
     from speechbrain.nnet.losses import mse_loss
 
-    predictions = torch.ones(4, 10, 8)
-    targets = torch.ones(4, 10, 8)
-    lengths = torch.ones(4)
+    predictions = torch.ones(4, 10, 8, device=device)
+    targets = torch.ones(4, 10, 8, device=device)
+    lengths = torch.ones(4, device=device)
     out_cost = mse_loss(predictions, targets, lengths)
     assert torch.all(torch.eq(out_cost, 0))
 
-    predictions = torch.zeros(4, 10, 8)
+    predictions = torch.zeros(4, 10, 8, device=device)
     out_cost = mse_loss(predictions, targets, lengths)
     assert torch.all(torch.eq(out_cost, 1))
 
 
-def test_l1():
+def test_l1(device):
     from speechbrain.nnet.losses import l1_loss
 
-    predictions = torch.ones(4, 10, 8)
-    targets = torch.ones(4, 10, 8)
-    lengths = torch.ones(4)
+    predictions = torch.ones(4, 10, 8, device=device)
+    targets = torch.ones(4, 10, 8, device=device)
+    lengths = torch.ones(4, device=device)
     out_cost = l1_loss(predictions, targets, lengths)
     assert torch.all(torch.eq(out_cost, 0))
 
 
-def test_bce_loss():
+def test_bce_loss(device):
     from speechbrain.nnet.losses import bce_loss
 
     # Ensure this works both with and without singleton dimension
-    predictions_singleton = torch.zeros(4, 10, 1)
-    predictions_match = torch.zeros(4, 10)
-    targets = torch.ones(4, 10)
-    lengths = torch.ones(4)
+    predictions_singleton = torch.zeros(4, 10, 1, device=device)
+    predictions_match = torch.zeros(4, 10, device=device)
+    targets = torch.ones(4, 10, device=device)
+    lengths = torch.ones(4, device=device)
     out_cost_singleton = bce_loss(predictions_singleton, targets, lengths)
     out_cost_match = bce_loss(predictions_match, targets, lengths)
-    assert torch.allclose(torch.exp(out_cost_singleton), torch.tensor(2.0))
-    assert torch.allclose(torch.exp(out_cost_match), torch.tensor(2.0))
+    assert torch.allclose(
+        torch.exp(out_cost_singleton), torch.tensor(2.0, device=device)
+    )
+    assert torch.allclose(
+        torch.exp(out_cost_match), torch.tensor(2.0, device=device)
+    )
 
     # How about one dimensional inputs
-    predictions = torch.zeros(5, 1)
-    targets = torch.ones(5)
+    predictions = torch.zeros(5, 1, device=device)
+    targets = torch.ones(5, device=device)
     out_cost = bce_loss(predictions, targets)
-    assert torch.allclose(torch.exp(out_cost), torch.tensor(2.0))
+    assert torch.allclose(torch.exp(out_cost), torch.tensor(2.0, device=device))
 
     # Can't pass lengths in 1D case
     with pytest.raises(ValueError):
-        bce_loss(predictions, targets, length=torch.ones(5))
+        bce_loss(predictions, targets, length=torch.ones(5, device=device))
 
 
-def test_classification_error():
+def test_classification_error(device):
     from speechbrain.nnet.losses import classification_error
 
-    predictions = torch.zeros(4, 10, 8)
+    predictions = torch.zeros(4, 10, 8, device=device)
     predictions[:, :, 0] += 1.0
-    targets = torch.zeros(4, 10)
-    lengths = torch.ones(4)
+    targets = torch.zeros(4, 10, device=device)
+    lengths = torch.ones(4, device=device)
     out_cost = classification_error(predictions, targets, lengths)
     assert torch.all(torch.eq(out_cost, 0))
 
 
-def test_pitwrapper():
+def test_pitwrapper(device):
     from speechbrain.nnet.losses import PitWrapper
     import torch
     from torch import nn
 
     base_loss = nn.MSELoss(reduction="none")
     pit = PitWrapper(base_loss)
-    predictions = torch.rand((2, 32, 4))  # batch, frames, sources
+    predictions = torch.rand(
+        (2, 32, 4), device=device
+    )  # batch, frames, sources
     p = (3, 0, 2, 1)
     # same but we invert the ordering to check if permutation invariant
     targets = predictions[..., p]
@@ -87,7 +93,9 @@ def test_pitwrapper():
     predictions = pit.reorder_tensor(predictions, opt_p)
     assert torch.all(torch.eq(base_loss(predictions, targets), 0))
 
-    predictions = torch.rand((3, 32, 32, 32, 5))  # batch, ..., sources
+    predictions = torch.rand(
+        (3, 32, 32, 32, 5), device=device
+    )  # batch, ..., sources
     p = (3, 0, 2, 1, 4)
     targets = predictions[
         ..., p
@@ -98,7 +106,7 @@ def test_pitwrapper():
     assert torch.all(torch.eq(base_loss(predictions, targets), 0))
 
 
-def test_transducer_loss():
+def test_transducer_loss(device):
     # Make this its own test since it can only be run
     # if numba is installed and a GPU is available
     pytest.importorskip("numba")
@@ -139,12 +147,12 @@ def test_transducer_loss():
     assert out_cost.item() == 2.247833251953125
 
 
-def test_guided_attention_loss_mask():
+def test_guided_attention_loss_mask(device):
     from speechbrain.nnet.loss.guidedattn_loss import GuidedAttentionLoss
 
-    loss = GuidedAttentionLoss()
-    input_lengths = torch.tensor([3, 2, 6])
-    output_lengths = torch.tensor([4, 3, 5])
+    loss = GuidedAttentionLoss().to(device)
+    input_lengths = torch.tensor([3, 2, 6], device=device)
+    output_lengths = torch.tensor([4, 3, 5], device=device)
     soft_mask = loss.guided_attentions(input_lengths, output_lengths)
     ref_soft_mask = torch.tensor(
         [
@@ -172,17 +180,18 @@ def test_guided_attention_loss_mask():
                 [0.9961341, 0.93427145, 0.5888877, 0.05404053, 0.1992626],
                 [0.9998301, 0.993355, 0.90436554, 0.49366438, 0.01379288],
             ],
-        ]
+        ],
+        device=device,
     )
     assert torch.allclose(soft_mask, ref_soft_mask)
 
 
-def test_guided_attention_loss_value():
+def test_guided_attention_loss_value(device):
     from speechbrain.nnet.loss.guidedattn_loss import GuidedAttentionLoss
 
-    loss = GuidedAttentionLoss()
-    input_lengths = torch.tensor([2, 3])
-    target_lengths = torch.tensor([3, 4])
+    loss = GuidedAttentionLoss().to(device)
+    input_lengths = torch.tensor([2, 3], device=device)
+    target_lengths = torch.tensor([3, 4], device=device)
     alignments = torch.tensor(
         [
             [
@@ -197,19 +206,20 @@ def test_guided_attention_loss_value():
                 [0.3, 0.4, 0.3],
                 [0.2, 0.3, 0.5],
             ],
-        ]
+        ],
+        device=device,
     )
     loss_value = loss(alignments, input_lengths, target_lengths)
     ref_loss_value = torch.tensor(0.1142)
     assert torch.isclose(loss_value, ref_loss_value, 0.0001, 0.0001).item()
 
 
-def test_guided_attention_loss_shapes():
+def test_guided_attention_loss_shapes(device):
     from speechbrain.nnet.loss.guidedattn_loss import GuidedAttentionLoss
 
-    loss = GuidedAttentionLoss()
-    input_lengths = torch.tensor([3, 2, 6])
-    output_lengths = torch.tensor([4, 3, 5])
+    loss = GuidedAttentionLoss().to(device)
+    input_lengths = torch.tensor([3, 2, 6], device=device)
+    output_lengths = torch.tensor([4, 3, 5], device=device)
     soft_mask = loss.guided_attentions(input_lengths, output_lengths)
     assert soft_mask.shape == (3, 6, 5)
     soft_mask = loss.guided_attentions(

--- a/tests/unittests/test_multi_mic.py
+++ b/tests/unittests/test_multi_mic.py
@@ -1,7 +1,7 @@
 import torch
 
 
-def test_gccphat():
+def test_gccphat(device):
 
     from speechbrain.processing.features import STFT
     from speechbrain.processing.multi_mic import Covariance, GccPhat
@@ -11,19 +11,21 @@ def test_gccphat():
 
     delay = 60
 
-    sig = torch.randn([10, fs])
-    sig_delayed = torch.cat((torch.zeros([10, delay]), sig[:, 0:-delay]), 1)
+    sig = torch.randn([10, fs], device=device)
+    sig_delayed = torch.cat(
+        (torch.zeros([10, delay], device=device), sig[:, 0:-delay]), 1
+    )
 
     xs = torch.stack((sig_delayed, sig), -1)
 
-    stft = STFT(sample_rate=fs)
+    stft = STFT(sample_rate=fs).to(device)
     Xs = stft(xs)
 
     # Computing the covariance matrix for GCC-PHAT
-    cov = Covariance()
-    gccphat = GccPhat()
+    cov = Covariance().to(device)
+    gccphat = GccPhat().to(device)
 
-    XXs = cov(Xs)
+    XXs = cov(Xs).to(device)
     tdoas = torch.abs(gccphat(XXs))
 
     n_valid_tdoas = torch.sum(torch.abs(tdoas[..., 1] - delay) < 1e-3)

--- a/tests/unittests/test_normalization.py
+++ b/tests/unittests/test_normalization.py
@@ -2,12 +2,12 @@ import torch
 import torch.nn
 
 
-def test_BatchNorm1d():
+def test_BatchNorm1d(device):
 
     from speechbrain.nnet.normalization import BatchNorm1d
 
-    input = torch.randn(100, 10) + 2.0
-    norm = BatchNorm1d(input_shape=input.shape)
+    input = torch.randn(100, 10, device=device) + 2.0
+    norm = BatchNorm1d(input_shape=input.shape).to(device)
     output = norm(input)
     assert input.shape == output.shape
 
@@ -17,7 +17,7 @@ def test_BatchNorm1d():
     current_std = output.std(dim=0).mean()
     assert torch.abs(1.0 - current_std) < 0.01
 
-    input = torch.randn(100, 20, 10) + 2.0
+    input = torch.randn(100, 20, 10, device=device) + 2.0
     output = norm(input)
     assert input.shape == output.shape
 
@@ -28,8 +28,10 @@ def test_BatchNorm1d():
     assert torch.abs(1.0 - current_std) < 0.01
 
     # Test with combined dimensions
-    input = torch.randn(100, 10, 20) + 2.0
-    norm = BatchNorm1d(input_shape=input.shape, combine_batch_time=True)
+    input = torch.randn(100, 10, 20, device=device) + 2.0
+    norm = BatchNorm1d(input_shape=input.shape, combine_batch_time=True).to(
+        device
+    )
     output = norm(input)
     assert input.shape == output.shape
 
@@ -39,8 +41,10 @@ def test_BatchNorm1d():
     current_std = output.std(dim=0).mean()
     assert torch.abs(1.0 - current_std) < 0.01
 
-    input = torch.randn(100, 40, 20, 30) + 2.0
-    norm = BatchNorm1d(input_shape=input.shape, combine_batch_time=True)
+    input = torch.randn(100, 40, 20, 30, device=device) + 2.0
+    norm = BatchNorm1d(input_shape=input.shape, combine_batch_time=True).to(
+        device
+    )
     output = norm(input)
     assert input.shape == output.shape
 
@@ -53,12 +57,12 @@ def test_BatchNorm1d():
     assert torch.jit.trace(norm, input)
 
 
-def test_BatchNorm2d():
+def test_BatchNorm2d(device):
 
     from speechbrain.nnet.normalization import BatchNorm2d
 
-    input = torch.randn(100, 10, 4, 20) + 2.0
-    norm = BatchNorm2d(input_shape=input.shape)
+    input = torch.randn(100, 10, 4, 20, device=device) + 2.0
+    norm = BatchNorm2d(input_shape=input.shape).to(device)
     output = norm(input)
     assert input.shape == output.shape
 
@@ -71,12 +75,12 @@ def test_BatchNorm2d():
     assert torch.jit.trace(norm, input)
 
 
-def test_LayerNorm():
+def test_LayerNorm(device):
 
     from speechbrain.nnet.normalization import LayerNorm
 
-    input = torch.randn(4, 101, 256) + 2.0
-    norm = LayerNorm(input_shape=input.shape)
+    input = torch.randn(4, 101, 256, device=device) + 2.0
+    norm = LayerNorm(input_shape=input.shape).to(device)
     output = norm(input)
     assert input.shape == output.shape
 
@@ -86,8 +90,8 @@ def test_LayerNorm():
     current_std = output.std(dim=2).mean()
     assert torch.abs(1.0 - current_std) < 0.01
 
-    input = torch.randn(100, 101, 16, 32) + 2.0
-    norm = LayerNorm(input_shape=input.shape)
+    input = torch.randn(100, 101, 16, 32, device=device) + 2.0
+    norm = LayerNorm(input_shape=input.shape).to(device)
     output = norm(input)
     assert input.shape == output.shape
 
@@ -100,12 +104,12 @@ def test_LayerNorm():
     assert torch.jit.trace(norm, input)
 
 
-def test_InstanceNorm1d():
+def test_InstanceNorm1d(device):
 
     from speechbrain.nnet.normalization import InstanceNorm1d
 
-    input = torch.randn(100, 10, 128) + 2.0
-    norm = InstanceNorm1d(input_shape=input.shape)
+    input = torch.randn(100, 10, 128, device=device) + 2.0
+    norm = InstanceNorm1d(input_shape=input.shape).to(device)
     output = norm(input)
     assert input.shape == output.shape
 
@@ -118,12 +122,12 @@ def test_InstanceNorm1d():
     assert torch.jit.trace(norm, input)
 
 
-def test_InstanceNorm2d():
+def test_InstanceNorm2d(device):
 
     from speechbrain.nnet.normalization import InstanceNorm2d
 
-    input = torch.randn(100, 10, 20, 2) + 2.0
-    norm = InstanceNorm2d(input_shape=input.shape)
+    input = torch.randn(100, 10, 20, 2, device=device) + 2.0
+    norm = InstanceNorm2d(input_shape=input.shape).to(device)
     output = norm(input)
     assert input.shape == output.shape
 

--- a/tests/unittests/test_pooling.py
+++ b/tests/unittests/test_pooling.py
@@ -2,44 +2,57 @@ import torch
 import torch.nn
 
 
-def test_pooling1d():
+def test_pooling1d(device):
 
     from speechbrain.nnet.pooling import Pooling1d
 
-    input = torch.tensor([1, 3, 2]).unsqueeze(0).unsqueeze(-1).float()
-    pool = Pooling1d("max", 3)
+    input = (
+        torch.tensor([1, 3, 2], device=device)
+        .unsqueeze(0)
+        .unsqueeze(-1)
+        .float()
+    )
+    pool = Pooling1d("max", 3).to(device)
     output = pool(input)
     assert output == 3
 
-    pool = Pooling1d("avg", 3)
+    pool = Pooling1d("avg", 3).to(device)
     output = pool(input)
     assert output == 2
 
     assert torch.jit.trace(pool, input)
 
 
-def test_pooling2d():
+def test_pooling2d(device):
 
     from speechbrain.nnet.pooling import Pooling2d
 
-    input = torch.tensor([[1, 3, 2], [4, 6, 5]]).float().unsqueeze(0)
-    pool = Pooling2d("max", (2, 3))
+    input = (
+        torch.tensor([[1, 3, 2], [4, 6, 5]], device=device).float().unsqueeze(0)
+    )
+    pool = Pooling2d("max", (2, 3)).to(device)
     output = pool(input)
     assert output == 6
 
-    input = torch.tensor([[1, 3, 2], [4, 6, 5]]).float().unsqueeze(0)
-    pool = Pooling2d("max", (1, 3))
+    input = (
+        torch.tensor([[1, 3, 2], [4, 6, 5]], device=device).float().unsqueeze(0)
+    )
+    pool = Pooling2d("max", (1, 3)).to(device)
     output = pool(input)
     assert output[0][0] == 3
     assert output[0][1] == 6
 
-    input = torch.tensor([[1, 3, 2], [4, 6, 5]]).float().unsqueeze(0)
-    pool = Pooling2d("avg", (2, 3))
+    input = (
+        torch.tensor([[1, 3, 2], [4, 6, 5]], device=device).float().unsqueeze(0)
+    )
+    pool = Pooling2d("avg", (2, 3)).to(device)
     output = pool(input)
     assert output == 3.5
 
-    input = torch.tensor([[1, 3, 2], [4, 6, 5]]).float().unsqueeze(0)
-    pool = Pooling2d("avg", (1, 3))
+    input = (
+        torch.tensor([[1, 3, 2], [4, 6, 5]], device=device).float().unsqueeze(0)
+    )
+    pool = Pooling2d("avg", (1, 3)).to(device)
     output = pool(input)
     assert output[0][0] == 2
     assert output[0][1] == 5

--- a/tests/unittests/test_pretrainer.py
+++ b/tests/unittests/test_pretrainer.py
@@ -1,16 +1,16 @@
-def test_pretrainer(tmpdir):
+def test_pretrainer(tmpdir, device):
     import torch
     from torch.nn import Linear
 
     # save a model in tmpdir/original/model.ckpt
-    first_model = Linear(32, 32)
+    first_model = Linear(32, 32).to(device)
     pretrained_dir = tmpdir / "original"
     pretrained_dir.mkdir()
     with open(pretrained_dir / "model.ckpt", "wb") as fo:
         torch.save(first_model.state_dict(), fo)
 
     # Make a new model and Pretrainer
-    pretrained_model = Linear(32, 32)
+    pretrained_model = Linear(32, 32).to(device)
     assert not torch.all(torch.eq(pretrained_model.weight, first_model.weight))
     from speechbrain.utils.parameter_transfer import Pretrainer
 

--- a/tests/unittests/test_samplers.py
+++ b/tests/unittests/test_samplers.py
@@ -1,7 +1,7 @@
 import torch
 
 
-def test_ConcatDatasetBatchSampler():
+def test_ConcatDatasetBatchSampler(device):
     from torch.utils.data import TensorDataset, ConcatDataset, DataLoader
     from speechbrain.dataio.sampler import (
         ReproducibleRandomSampler,
@@ -12,14 +12,18 @@ def test_ConcatDatasetBatchSampler():
     datasets = []
     for i in range(3):
         if i == 0:
-            datasets.append(TensorDataset(torch.arange(i * 10, (i + 1) * 10)))
+            datasets.append(
+                TensorDataset(torch.arange(i * 10, (i + 1) * 10, device=device))
+            )
         else:
-            datasets.append(TensorDataset(torch.arange(i * 6, (i + 1) * 6)))
+            datasets.append(
+                TensorDataset(torch.arange(i * 6, (i + 1) * 6, device=device))
+            )
 
     samplers = [ReproducibleRandomSampler(x) for x in datasets]
     dataset = ConcatDataset(datasets)
     loader = DataLoader(
-        dataset, batch_sampler=ConcatDatasetBatchSampler(samplers, [1, 1, 1]),
+        dataset, batch_sampler=ConcatDatasetBatchSampler(samplers, [1, 1, 1])
     )
 
     concat_data = []
@@ -31,7 +35,7 @@ def test_ConcatDatasetBatchSampler():
     non_cat_data = []
     for i in range(len(samplers)):
         c_data = []
-        loader = DataLoader(dataset.datasets[i], sampler=samplers[i],)
+        loader = DataLoader(dataset.datasets[i], sampler=samplers[i])
 
         for data in loader:
             c_data.append(data[0].item())

--- a/tests/unittests/test_signal_processing.py
+++ b/tests/unittests/test_signal_processing.py
@@ -1,7 +1,7 @@
 import torch
 
 
-def test_normalize():
+def test_normalize(device):
 
     from speechbrain.processing.signal_processing import compute_amplitude
     from speechbrain.processing.signal_processing import rescale
@@ -11,9 +11,9 @@ def test_normalize():
     for scale in ["dB", "linear"]:
         for amp_type in ["peak", "avg"]:
             for test_vec in [
-                torch.zeros((100)),
-                torch.rand((10, 100)),
-                torch.rand((10, 100, 5)),
+                torch.zeros((100), device=device),
+                torch.rand((10, 100), device=device),
+                torch.rand((10, 100, 5), device=device),
             ]:
 
                 lengths = (
@@ -23,8 +23,8 @@ def test_normalize():
                 )
                 amp = compute_amplitude(test_vec, lengths, amp_type, scale)
                 scaled_back = rescale(
-                    random.random() * test_vec, lengths, amp, amp_type, scale,
+                    random.random() * test_vec, lengths, amp, amp_type, scale
                 )
                 np.testing.assert_array_almost_equal(
-                    scaled_back.numpy(), test_vec.numpy()
+                    scaled_back.cpu().numpy(), test_vec.cpu().numpy()
                 )


### PR DESCRIPTION
This PR allows users to run `pytests` (unit/integration tests) on the GPU as well. This can be done by running:

`pytest --device='cuda'`

By default, without this flag, we run everything on the cpu as usual.  With the current CI, we cannot run the tests on the GPU. However, we can periodically check that everything is fine on the GPU as well in our local machines. This makes that extremely simple.

This PR also fixes the device-mismatch errors  that emerged from the tests on the gpus.