### PR TITLE
make ctc-segmentation work with EncoderASR

### DIFF
--- a/speechbrain/alignment/ctc_segmentation.py
+++ b/speechbrain/alignment/ctc_segmentation.py
@@ -229,17 +229,20 @@ class CTCSegmentation:
     ):
         """Initialize the CTCSegmentation module."""
         # Prepare ASR model
-        if (isinstance(asr_model, EncoderDecoderASR) and not (
+        if (
+            isinstance(asr_model, EncoderDecoderASR) and not (
             hasattr(asr_model, "mods")
             and hasattr(asr_model.mods, "decoder")
             and hasattr(asr_model.mods.decoder, "ctc_weight")
-        )) or (isinstance(asr_model, EncoderASR) and not (
+            )
+        ) or (
+            isinstance(asr_model, EncoderASR) and not (
             hasattr(asr_model, "mods")
             and hasattr(asr_model.mods, "encoder")
-            and hasattr(asr_model.mods.decoder, "ctc_lin"))):
-            raise AttributeError(
-                "The given asr_model has no CTC module!"
+            and hasattr(asr_model.mods.decoder, "ctc_lin")
             )
+        ):
+            raise AttributeError("The given asr_model has no CTC module!")
         if not hasattr(asr_model, "tokenizer"):
             raise AttributeError(
                 "The given asr_model has no tokenizer in asr_model.tokenizer!"

--- a/speechbrain/alignment/ctc_segmentation.py
+++ b/speechbrain/alignment/ctc_segmentation.py
@@ -241,7 +241,7 @@ class CTCSegmentation:
             and not (
                 hasattr(asr_model, "mods")
                 and hasattr(asr_model.mods, "encoder")
-                and hasattr(asr_model.mods.decoder, "ctc_lin")
+                and hasattr(asr_model.mods.encoder, "ctc_lin")
             )
         ):
             raise AttributeError("The given asr_model has no CTC module!")
@@ -256,7 +256,7 @@ class CTCSegmentation:
             self._ctc = self.asr_model.mods.decoder.ctc_forward_step
         else:
             # Apply log-softmax to encoder output
-            self._ctc = self.asr_model.hparams.log_softmax()
+            self._ctc = self.asr_model.hparams.log_softmax
         self._tokenizer = self.asr_model.tokenizer
 
         # Apply configuration

--- a/speechbrain/alignment/ctc_segmentation.py
+++ b/speechbrain/alignment/ctc_segmentation.py
@@ -18,7 +18,7 @@ import torch
 from typing import List
 
 # speechbrain interface
-from speechbrain.pretrained.interfaces import EncoderDecoderASR
+from speechbrain.pretrained.interfaces import EncoderASR, EncoderDecoderASR
 
 # imports for CTC segmentation
 try:
@@ -221,7 +221,7 @@ class CTCSegmentation:
 
     def __init__(
         self,
-        asr_model: EncoderDecoderASR,
+        asr_model: Union[EncoderASR, EncoderDecoderASR],
         kaldi_style_text: bool = True,
         text_converter: str = "tokenize",
         time_stamps: str = "auto",
@@ -229,13 +229,16 @@ class CTCSegmentation:
     ):
         """Initialize the CTCSegmentation module."""
         # Prepare ASR model
-        if not (
+        if (isinstance(asr_model, EncoderDecoderASR) and not (
             hasattr(asr_model, "mods")
             and hasattr(asr_model.mods, "decoder")
             and hasattr(asr_model.mods.decoder, "ctc_weight")
-        ):
+        )) or (isinstance(asr_model, EncoderASR) and not (
+            hasattr(asr_model, "mods")
+            and hasattr(asr_model.mods, "encoder")
+            and hasattr(asr_model.mods.decoder, "ctc_lin"))):
             raise AttributeError(
-                "The given asr_model has no CTC decoder in asr_model.mods.decoder!"
+                "The given asr_model has no CTC module!"
             )
         if not hasattr(asr_model, "tokenizer"):
             raise AttributeError(
@@ -243,8 +246,12 @@ class CTCSegmentation:
             )
         self.asr_model = asr_model
         self._encode = self.asr_model.encode_batch
-        # Assumption: log-softmax is already included in ctc_forward_step
-        self._ctc = self.asr_model.mods.decoder.ctc_forward_step
+        if isinstance(asr_model, EncoderDecoderASR):
+            # Assumption: log-softmax is already included in ctc_forward_step
+            self._ctc = self.asr_model.mods.decoder.ctc_forward_step
+        else:
+            # Apply log-softmax to encoder output
+            self._ctc = self.asr_model.hparams.log_softmax()
         self._tokenizer = self.asr_model.tokenizer
 
         # Apply configuration

--- a/speechbrain/alignment/ctc_segmentation.py
+++ b/speechbrain/alignment/ctc_segmentation.py
@@ -230,16 +230,18 @@ class CTCSegmentation:
         """Initialize the CTCSegmentation module."""
         # Prepare ASR model
         if (
-            isinstance(asr_model, EncoderDecoderASR) and not (
-            hasattr(asr_model, "mods")
-            and hasattr(asr_model.mods, "decoder")
-            and hasattr(asr_model.mods.decoder, "ctc_weight")
+            isinstance(asr_model, EncoderDecoderASR)
+            and not (
+                hasattr(asr_model, "mods")
+                and hasattr(asr_model.mods, "decoder")
+                and hasattr(asr_model.mods.decoder, "ctc_weight")
             )
         ) or (
-            isinstance(asr_model, EncoderASR) and not (
-            hasattr(asr_model, "mods")
-            and hasattr(asr_model.mods, "encoder")
-            and hasattr(asr_model.mods.decoder, "ctc_lin")
+            isinstance(asr_model, EncoderASR)
+            and not (
+                hasattr(asr_model, "mods")
+                and hasattr(asr_model.mods, "encoder")
+                and hasattr(asr_model.mods.decoder, "ctc_lin")
             )
         ):
             raise AttributeError("The given asr_model has no CTC module!")


### PR DESCRIPTION
This PR brings the possibility to use an EncoderASR (not just an EncoderDecoderASR) with the ctc-segmentation module.

Sample code:
```python
from speechbrain.pretrained import EncoderASR
from speechbrain.alignment.ctc_segmentation import CTCSegmentation

audio_file = 'audio_path'
asr_model = EncoderASR.from_hparams(source='source_path', hparams_file='hparams_path', savedir='savedir_path')
aligner = CTCSegmentation(asr_model, kaldi_style_text=False) 
segments = aligner(audio_file, text, name="test")
print(segments)
```