### PR TITLE
Implemented GroupNorm in nnet.normalization

### DIFF
--- a/speechbrain/nnet/normalization.py
+++ b/speechbrain/nnet/normalization.py
@@ -412,10 +412,7 @@ class GroupNorm(nn.Module):
             input_size = input_shape[-1]
 
         self.norm = torch.nn.GroupNorm(
-            num_groups,
-            input_size,
-            eps=self.eps,
-            affine=self.affine,
+            num_groups, input_size, eps=self.eps, affine=self.affine,
         )
 
     def forward(self, x):

--- a/speechbrain/nnet/normalization.py
+++ b/speechbrain/nnet/normalization.py
@@ -2,6 +2,7 @@
 
 Authors
  * Mirco Ravanelli 2020
+ * Guillermo Cámbara 2021
 """
 import torch
 import torch.nn as nn
@@ -355,6 +356,75 @@ class InstanceNorm2d(nn.Module):
         ---------
         x : torch.Tensor (batch, time, channel1, channel2)
             input to normalize. 4d tensors are expected.
+        """
+        x = x.transpose(-1, 1)
+        x_n = self.norm(x)
+        x_n = x_n.transpose(1, -1)
+
+        return x_n
+
+
+class GroupNorm(nn.Module):
+    """Applies group normalization to the input tensor.
+
+    Arguments
+    ---------
+    input_shape : tuple
+        The expected shape of the input. Alternatively, use ``input_size``.
+    input_size : int
+        The expected size of the input. Alternatively, use ``input_shape``.
+    num_groups : int
+        Number of groups to separate the channels into.
+    eps : float
+        This value is added to std deviation estimation to improve the numerical
+        stability.
+    affine : bool
+         A boolean value that when set to True, this module has learnable per-channel
+         affine parameters initialized to ones (for weights) and zeros (for biases).
+    Example
+    -------
+    >>> input = torch.randn(100, 101, 128)
+    >>> norm = GroupNorm(input_size=128, num_groups=128)
+    >>> output = norm(input)
+    >>> output.shape
+    torch.Size([100, 101, 128])
+    """
+
+    def __init__(
+        self,
+        input_shape=None,
+        input_size=None,
+        num_groups=None,
+        eps=1e-05,
+        affine=True,
+    ):
+        super().__init__()
+        self.eps = eps
+        self.affine = affine
+
+        if input_shape is None and input_size is None:
+            raise ValueError("Expected input_shape or input_size as input")
+
+        if num_groups is None:
+            raise ValueError("Expected num_groups as input")
+
+        if input_shape is not None:
+            input_size = input_shape[-1]
+
+        self.norm = torch.nn.GroupNorm(
+            num_groups,
+            input_size,
+            eps=self.eps,
+            affine=self.affine,
+        )
+
+    def forward(self, x):
+        """Returns the normalized input tensor.
+
+        Arguments
+        ---------
+        x : torch.Tensor (batch, time, channels)
+            input to normalize. 3d or 4d tensors are expected.
         """
         x = x.transpose(-1, 1)
         x_n = self.norm(x)

--- a/tests/unittests/test_normalization.py
+++ b/tests/unittests/test_normalization.py
@@ -138,3 +138,53 @@ def test_InstanceNorm2d(device):
     assert torch.abs(1.0 - current_std) < 0.01
 
     assert torch.jit.trace(norm, input)
+
+def test_GroupNorm(device):
+
+    from speechbrain.nnet.normalization import GroupNorm
+
+    input = torch.randn(4, 101, 256, device=device) + 2.0
+    norm = GroupNorm(input_shape=input.shape, num_groups=256).to(device)
+    output = norm(input)
+    assert input.shape == output.shape
+
+    current_mean = output.mean(dim=2).mean()
+    assert torch.abs(current_mean) < 1e-06
+
+    current_std = output.std(dim=2).mean()
+    assert torch.abs(1.0 - current_std) < 0.01
+
+    input = torch.randn(4, 101, 256, device=device) + 2.0
+    norm = GroupNorm(input_shape=input.shape, num_groups=128).to(device)
+    output = norm(input)
+    assert input.shape == output.shape
+
+    current_mean = output.mean(dim=2).mean()
+    assert torch.abs(current_mean) < 1e-06
+
+    current_std = output.std(dim=2).mean()
+    assert torch.abs(1.0 - current_std) < 0.01
+
+    input = torch.randn(100, 101, 16, 32, device=device) + 2.0
+    norm = GroupNorm(input_shape=input.shape, num_groups=32).to(device)
+    output = norm(input)
+    assert input.shape == output.shape
+
+    current_mean = output.mean(dim=3).mean()
+    assert torch.abs(current_mean) < 1e-06
+
+    current_std = output.std(dim=3).mean()
+    assert torch.abs(1.0 - current_std) < 0.01
+
+    input = torch.randn(100, 101, 16, 32, device=device) + 2.0
+    norm = GroupNorm(input_shape=input.shape, num_groups=8).to(device)
+    output = norm(input)
+    assert input.shape == output.shape
+
+    current_mean = output.mean(dim=3).mean()
+    assert torch.abs(current_mean) < 1e-06
+
+    current_std = output.std(dim=3).mean()
+    assert torch.abs(1.0 - current_std) < 0.01
+
+    assert torch.jit.trace(norm, input)

--- a/tests/unittests/test_normalization.py
+++ b/tests/unittests/test_normalization.py
@@ -139,6 +139,7 @@ def test_InstanceNorm2d(device):
 
     assert torch.jit.trace(norm, input)
 
+
 def test_GroupNorm(device):
 
     from speechbrain.nnet.normalization import GroupNorm


### PR DESCRIPTION
I have implemented GroupNorm since I thought it could be useful for writing models using such, like wav2vec2.0 Base LibriSpeech model, for instance. Furthermore, it is one of the norms implemented in the PyTorch library, along with other popular ones like LayerNorm or BatchNorm.
