### PR TITLE
Fix documentation generation

### DIFF
--- a/.github/workflows/verify-docs-gen.yml
+++ b/.github/workflows/verify-docs-gen.yml
@@ -1,0 +1,26 @@
+name: Verify docs generation
+
+# Runs on pushes to master and all pull requests
+on:    # yamllint disable-line rule:truthy
+    push:
+        branches: [main, develop]
+    pull_request:
+
+jobs:
+    docs:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Setup Python 3.8
+              uses: actions/setup-python@v2
+              with:
+                  python-version: '3.8'
+            - name: Full dependencies
+              run: |
+                  pip install -r requirements.txt
+                  pip install --editable .
+                  pip install -r docs/docs-requirements.txt
+            - name: Generate docs
+              run: |
+                  cd docs
+                  make html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,9 +68,7 @@ intersphinx_mapping = {
 autodoc_default_options = {}
 
 # Autodoc mock extra dependencies:
-autodoc_mock_imports = [
-    "sklearn",
-]
+autodoc_mock_imports = []
 
 # Order of API items:
 autodoc_member_order = "bysource"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ import os
 import sys
 import hyperpyyaml
 
-sys.path.insert(-1, os.path.abspath("../speechbrain"))
+sys.path.insert(-1, os.path.abspath("../"))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,8 +14,7 @@ import os
 import sys
 import hyperpyyaml
 
-
-sys.path.insert(0, os.path.abspath("../speechbrain"))
+sys.path.insert(-1, os.path.abspath("../speechbrain"))
 
 
 # -- Project information -----------------------------------------------------
@@ -69,7 +68,9 @@ intersphinx_mapping = {
 autodoc_default_options = {}
 
 # Autodoc mock extra dependencies:
-autodoc_mock_imports = ["sklearn"]
+autodoc_mock_imports = [
+    "sklearn",
+]
 
 # Order of API items:
 autodoc_member_order = "bysource"

--- a/docs/docs-requirements.txt
+++ b/docs/docs-requirements.txt
@@ -4,6 +4,7 @@ fairseq
 numba>=0.54.1
 recommonmark>=0.7.1
 six
+sklearn
 sphinx-rtd-theme>=0.4.3
 Sphinx>=3.4.3
 transformers==4.13

--- a/docs/docs-requirements.txt
+++ b/docs/docs-requirements.txt
@@ -1,5 +1,6 @@
 better-apidoc>=0.3.1
 ctc-segmentation>=1.7.0
+fairseq
 numba>=0.54.1
 recommonmark>=0.7.1
 six

--- a/speechbrain/lobes/models/fairseq_wav2vec.py
+++ b/speechbrain/lobes/models/fairseq_wav2vec.py
@@ -18,7 +18,9 @@ from speechbrain.utils.data_utils import download_file
 try:
     import fairseq
 except ImportError:
-    print("Please install Fairseq to use pretrained wav2vec!")
+    MSG = "Please install Fairseq to use pretrained wav2vec\n"
+    MSG += "E.G. run: pip install fairseq"
+    raise ImportError(MSG)
 
 
 class FairseqWav2Vec2(nn.Module):

--- a/speechbrain/lobes/models/huggingface_wav2vec.py
+++ b/speechbrain/lobes/models/huggingface_wav2vec.py
@@ -32,9 +32,7 @@ try:
     )
 
 except ImportError:
-    MSG = (
-        "Please install transformers from HuggingFace to use wav2vec2 / Hubert"
-    )
+    MSG = "Please install transformers from HuggingFace to use wav2vec2 / Hubert\n"
     MSG += "E.G. run: pip install transformers"
     raise ImportError(MSG)
 

--- a/speechbrain/lobes/models/huggingface_wav2vec.py
+++ b/speechbrain/lobes/models/huggingface_wav2vec.py
@@ -32,9 +32,11 @@ try:
     )
 
 except ImportError:
-    print(
-        "Please install transformer from HuggingFace to use wav2vec2/Hubert !"
+    MSG = (
+        "Please install transformers from HuggingFace to use wav2vec2 / Hubert"
     )
+    MSG += "E.G. run: pip install transformers"
+    raise ImportError(MSG)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Docs generation was failing.

The import system was somehow getting confused: when a `transformers` module tried to import their local `tokenizers.py`, it instead resolved to importing the SpeechBrain `tokenizers.py` file.

I wanted to fix the whole thing by mocking the extra dependencies. But it turns out, better-apidoc does not mock the imports in autodoc_mock_imports, it just changes ImportErrors to warnings, which does not work for us. So instead I hacked this so that SpeechBrain is added to the end of the path rather than right at the front.

I also fixed the fairseq and huggingface wav2vec2 ImportErrors to properly raise an error instead of printing a message.