### PR TITLE
fix bug: negative_scores calculation in BinaryMetricStats

### DIFF
--- a/speechbrain/utils/metric_stats.py
+++ b/speechbrain/utils/metric_stats.py
@@ -402,7 +402,7 @@ class BinaryMetricStats(MetricStats):
                             for i in range(
                                 0,
                                 len(positive_scores),
-                                int(len(positive_scores) / max_samples)
+                                int(len(positive_scores) / max_samples),
                             )
                         ]
                     ]
@@ -414,7 +414,7 @@ class BinaryMetricStats(MetricStats):
                             for i in range(
                                 0,
                                 len(negative_scores),
-                                int(len(negative_scores) / max_samples)
+                                int(len(negative_scores) / max_samples),
                             )
                         ]
                     ]

--- a/speechbrain/utils/metric_stats.py
+++ b/speechbrain/utils/metric_stats.py
@@ -380,10 +380,8 @@ class BinaryMetricStats(MetricStats):
             self.labels = torch.stack(self.labels)
 
         if threshold is None:
-            positive_scores = self.scores[self.labels.nonzero(as_tuple=True)]
-            negative_scores = self.scores[
-                self.labels[self.labels == 0].nonzero(as_tuple=True)
-            ]
+            positive_scores = self.scores[(self.labels==1).nonzero(as_tuple=True)]
+            negative_scores = self.scores[(self.labels==0).nonzero(as_tuple=True)]
 
             eer, threshold = EER(positive_scores, negative_scores)
 

--- a/speechbrain/utils/metric_stats.py
+++ b/speechbrain/utils/metric_stats.py
@@ -396,6 +396,7 @@ class BinaryMetricStats(MetricStats):
         self.summary["FAR"] = FP / (FP + TN + eps)
         self.summary["FRR"] = FN / (TP + FN + eps)
         self.summary["DER"] = (FP + FN) / (TP + TN + eps)
+        self.summary["threshold"] = threshold
 
         self.summary["precision"] = TP / (TP + FP + eps)
         self.summary["recall"] = TP / (TP + FN + eps)

--- a/speechbrain/utils/metric_stats.py
+++ b/speechbrain/utils/metric_stats.py
@@ -345,7 +345,7 @@ class BinaryMetricStats(MetricStats):
         self.labels.extend(labels.detach())
 
     def summarize(
-      self, field=None, threshold=None, max_samples=None, beta=1, eps=1e-8
+        self, field=None, threshold=None, max_samples=None, beta=1, eps=1e-8
     ):
         """Compute statistics using a full set of scores.
 
@@ -400,9 +400,9 @@ class BinaryMetricStats(MetricStats):
                         [
                             i
                             for i in range(
-                            0,
-                            len(positive_scores),
-                            int(len(positive_scores) / max_samples)
+                                0,
+                                len(positive_scores),
+                                int(len(positive_scores) / max_samples)
                             )
                         ]
                     ]
@@ -412,9 +412,9 @@ class BinaryMetricStats(MetricStats):
                         [
                             i
                             for i in range(
-                            0,
-                            len(negative_scores),
-                            int(len(negative_scores) / max_samples)
+                                0,
+                                len(negative_scores),
+                                int(len(negative_scores) / max_samples)
                             )
                         ]
                     ]

--- a/speechbrain/utils/metric_stats.py
+++ b/speechbrain/utils/metric_stats.py
@@ -344,7 +344,9 @@ class BinaryMetricStats(MetricStats):
         self.scores.extend(scores.detach())
         self.labels.extend(labels.detach())
 
-    def summarize(self, field=None, threshold=None, max_samples=None, beta=1, eps=1e-8):
+    def summarize(
+      self, field=None, threshold=None, max_samples=None, beta=1, eps=1e-8
+    ):
         """Compute statistics using a full set of scores.
 
         Full set of fields:
@@ -385,15 +387,37 @@ class BinaryMetricStats(MetricStats):
             self.labels = torch.stack(self.labels)
 
         if threshold is None:
-            positive_scores = self.scores[(self.labels == 1).nonzero(as_tuple=True)]
-            negative_scores = self.scores[(self.labels == 0).nonzero(as_tuple=True)]
+            positive_scores = self.scores[
+                (self.labels == 1).nonzero(as_tuple=True)
+            ]
+            negative_scores = self.scores[
+                (self.labels == 0).nonzero(as_tuple=True)
+            ]
             if max_samples is not None:
                 if len(positive_scores) > max_samples:
                     positive_scores, _ = torch.sort(positive_scores)
-                    positive_scores = positive_scores[[i for i in range(0, len(positive_scores), int(len(positive_scores) / max_samples))]]
+                    positive_scores = positive_scores[
+                        [
+                            i
+                            for i in range(
+                            0,
+                            len(positive_scores),
+                            int(len(positive_scores) / max_samples)
+                            )
+                        ]
+                    ]
                 if len(negative_scores) > max_samples:
                     negative_scores, _ = torch.sort(negative_scores)
-                    negative_scores = negative_scores[[i for i in range(0, len(negative_scores), int(len(negative_scores) / max_samples))]]
+                    negative_scores = negative_scores[
+                        [
+                            i
+                            for i in range(
+                            0,
+                            len(negative_scores),
+                            int(len(negative_scores) / max_samples)
+                            )
+                        ]
+                    ]
 
             eer, threshold = EER(positive_scores, negative_scores)
 

--- a/tests/unittests/test_metrics.py
+++ b/tests/unittests/test_metrics.py
@@ -64,7 +64,7 @@ def test_binary_metrics(device):
     assert summary["FN"] == 2
 
     summary = binary_stats.summarize(threshold=None)
-    assert summary["threshold"] > 0.3 and summary["threshold"] < 0.4
+    assert summary["threshold"] >= 0.3 and summary["threshold"] < 0.4
 
 
 def test_EER(device):

--- a/tests/unittests/test_metrics.py
+++ b/tests/unittests/test_metrics.py
@@ -66,6 +66,9 @@ def test_binary_metrics(device):
     summary = binary_stats.summarize(threshold=None)
     assert summary["threshold"] >= 0.3 and summary["threshold"] < 0.4
 
+    summary = binary_stats.summarize(threshold=None, max_samples=1)
+    assert summary["threshold"] >= 0.1 and summary["threshold"] < 0.2
+
 
 def test_EER(device):
     from speechbrain.utils.metric_stats import EER

--- a/tests/unittests/test_metrics.py
+++ b/tests/unittests/test_metrics.py
@@ -63,7 +63,8 @@ def test_binary_metrics(device):
     assert summary["FP"] == 1
     assert summary["FN"] == 2
 
-    summary = binary_stats.summarize()
+    summary = binary_stats.summarize(threshold=None)
+    assert summary["threshold"] > 0.3 and summary["threshold"] < 0.4
 
 
 def test_EER(device):


### PR DESCRIPTION
Hi, I have created an issue mentioning a possible bug in utils/metric_stats.py

If it is indeed a bug or typo, I have fixed it in the PR. Hope you can merge it.

Many thanks!