### PR TITLE
Fixing numeric inconsistency in losses.py

### DIFF
--- a/speechbrain/nnet/losses.py
+++ b/speechbrain/nnet/losses.py
@@ -923,6 +923,7 @@ class AdditiveAngularMargin(AngularMargin):
         predictions : torch.Tensor
         """
         cosine = outputs.float()
+        cosine = torch.clamp(cosine, -1+1e-7, 1-1e-7)
         sine = torch.sqrt(1.0 - torch.pow(cosine, 2))
         phi = cosine * self.cos_m - sine * self.sin_m  # cos(theta + m)
         if self.easy_margin:


### PR DESCRIPTION
https://github.com/speechbrain/speechbrain/blob/9d56d50809d8745cc7dafa930aec554145be4028/speechbrain/nnet/losses.py#L925

A numerical error occurs if the Cosine value slightly crosses 1.0 and results in "nan" in further calculations.

Error:
```
ValueError: Loss is not finite and patience is exhausted. To debug, wrap 'fit()' with autograd's detect_anomaly()', e.g.
with torch.autograd.detec_anomaly():
     brain.fit(...)
```
Related issues reported: https://github.com/speechbrain/speechbrain/issues/1020#issue-1011886114

This can be prevented by adding a line of code:

line: 926  `cosine = torch.clamp(cosine, -1+1e-7, 1-1e-7) #You can modify the eps value according to your preference`