### PR TITLE
Typo in index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ Referencing SpeechBrain
       eprint={2106.04624},
       archivePrefix={arXiv},
       primaryClass={eess.AS}
-}
+  }
 
 
 .. toctree::


### PR DESCRIPTION
A closing curly brace was outside of a code block. Moved it back.