### PR TITLE
adding conditioned support to multichannel SincConv

### DIFF
--- a/speechbrain/nnet/CNN.py
+++ b/speechbrain/nnet/CNN.py
@@ -83,6 +83,7 @@ class SincConv(nn.Module):
         min_band_hz=50,
     ):
         super().__init__()
+        self.in_channels = in_channels
         self.out_channels = out_channels
         self.kernel_size = kernel_size
         self.stride = stride
@@ -98,7 +99,12 @@ class SincConv(nn.Module):
             raise ValueError("Must provide one of input_shape or in_channels")
 
         if in_channels is None:
-            in_channels = self._check_input_shape(input_shape)
+            self.in_channels = self._check_input_shape(input_shape)
+
+        if self.out_channels % self.in_channels != 0:
+            raise ValueError(
+                "Number of output channels must be divisible by in_channels"
+            )
 
         # Initialize Sinc filters
         self._init_sinc_conv()
@@ -145,6 +151,7 @@ class SincConv(nn.Module):
             stride=self.stride,
             padding=0,
             dilation=self.dilation,
+            groups=self.in_channels
         )
 
         if unsqueeze:
@@ -161,7 +168,7 @@ class SincConv(nn.Module):
         if len(shape) == 2:
             in_channels = 1
         elif len(shape) == 3:
-            in_channels = 1
+            in_channels = shape[-1]
         else:
             raise ValueError(
                 "sincconv expects 2d or 3d inputs. Got " + str(len(shape))

--- a/tests/unittests/test_CNN.py
+++ b/tests/unittests/test_CNN.py
@@ -14,6 +14,16 @@ def test_SincConv(device):
 
     assert torch.jit.trace(convolve, input)
 
+    # Multichannel case
+    input = torch.rand([10, 16000, 8], device=device)
+    convolve = SincConv(
+        input_shape=input.shape, out_channels=16, kernel_size=11, padding="same"
+    ).to(device)
+    output = convolve(input)
+    assert output.shape[-1] == 16
+
+    assert torch.jit.trace(convolve, input)
+
 
 def test_Conv1d(device):
 


### PR DESCRIPTION
As discussed in (Issue 774)[https://github.com/speechbrain/speechbrain/issues/774], I'm trying to batch the channels for multichannel support on the SincConv operation.
This modification is heavily inspired by the [espnet2](https://github.com/espnet/espnet/blob/master/espnet2/layers/sinc_conv.py) repo.