### PR TITLE
fixing model eval on list instead of class attribute

### DIFF
--- a/speechbrain/lobes/models/fairseq_wav2vec.py
+++ b/speechbrain/lobes/models/fairseq_wav2vec.py
@@ -250,7 +250,7 @@ class FairseqWav2Vec1(nn.Module):
         self.model = model
         self.model = self.model[0]
         if self.freeze:
-            model.eval()
+            self.model.eval()
 
         # Randomly initialized layers if pretrain is False
         if not (pretrain):


### PR DESCRIPTION
### The problem
.eval() function is applied on a list object (**model** object)

### Solution
To solve this, similar to the class *FairseqWav2Vec2*, it should be applied to the class attribute *self.model*

It is a very small change but it will fix the usage of the wav2vec model based on the fairseq implementation.