### PR TITLE
Numerical Stability: Update energy_VAD function to prevent NaNs

### DIFF
--- a/speechbrain/pretrained/interfaces.py
+++ b/speechbrain/pretrained/interfaces.py
@@ -1526,7 +1526,8 @@ class VAD(Pretrained):
             )
 
             # Energy computation within each chunk
-            energy_chunks = segment_chunks.abs().sum(-1).log()
+            energy_chunks = segment_chunks.abs().sum(-1) + 1e-6
+            energy_chunks = energy_chunks.log()
 
             # Energy normalization
             energy_chunks = (

--- a/speechbrain/pretrained/interfaces.py
+++ b/speechbrain/pretrained/interfaces.py
@@ -1464,7 +1464,12 @@ class VAD(Pretrained):
             f.close()
 
     def energy_VAD(
-        self, audio_file, boundaries, activation_th=0.5, deactivation_th=0.0
+        self,
+        audio_file,
+        boundaries,
+        activation_th=0.5,
+        deactivation_th=0.0,
+        eps=1e-6,
     ):
         """Applies energy-based VAD within the detected speech segments.The neural
         network VAD often creates longer segments and tends to merge segments that
@@ -1489,6 +1494,8 @@ class VAD(Pretrained):
             A new speech segment is started it the energy is above activation_th.
         deactivation_th: float
             The segment is considered ended when the energy is <= deactivation_th.
+        eps: float
+            Small constant for numerical stability.
 
 
         Returns
@@ -1526,7 +1533,7 @@ class VAD(Pretrained):
             )
 
             # Energy computation within each chunk
-            energy_chunks = segment_chunks.abs().sum(-1) + 1e-6
+            energy_chunks = segment_chunks.abs().sum(-1) + eps
             energy_chunks = energy_chunks.log()
 
             # Energy normalization


### PR DESCRIPTION
Adding an epsilon value of 1e-6 to prevent numerical instability during energy computation for VAD. I encountered this problem with the pretrained VAD model. 

For energy-based computation we compute the energy before energy normalization. The logarithm however, is not numerically stable. Sometimes we might encounter 0.0 values in the segment chunks, and applying `.log()` will lead to `-inf` values. Moreover there is no error raised or any checks for this part, and the model would just label this segment as non-speech since the energy is not a valid value.

As a solution, I propose changing: 

https://github.com/speechbrain/speechbrain/blob/c7039d837345e56d34d159cf95675c8d4b933c20/speechbrain/pretrained/interfaces.py#L1529

To:

```python
            energy_chunks = segment_chunks.abs().sum(-1) + 1e-6
            energy_chunks = energy_chunks.log()
```
This epsilon would guarantee that there are no `-inf` or `nan` values.

I am not sure if there are any similar cases for other models, we might need to check for similar cases as well. 