### PR TITLE
in diarization, handle two-segment case gracefully

### DIFF
--- a/speechbrain/processing/diarization.py
+++ b/speechbrain/processing/diarization.py
@@ -738,23 +738,23 @@ class Spec_Clust_unorm:
      [0.904 0.982 0.928 1.    0.976]
      [0.966 0.997 0.972 0.976 1.   ]]
     >>> # Prunning
-    >>> prunned_sim_mat = clust.p_pruning(sim_mat, 0.3)
-    >>> print (np.around(prunned_sim_mat[5:,5:], decimals=3))
+    >>> pruned_sim_mat = clust.p_pruning(sim_mat, 0.3)
+    >>> print (np.around(pruned_sim_mat[5:,5:], decimals=3))
     [[1.    0.    0.    0.    0.   ]
      [0.    1.    0.    0.982 0.997]
      [0.    0.977 1.    0.    0.972]
      [0.    0.982 0.    1.    0.976]
      [0.    0.997 0.    0.976 1.   ]]
     >>> # Symmetrization
-    >>> sym_prund_sim_mat = 0.5 * (prunned_sim_mat + prunned_sim_mat.T)
-    >>> print (np.around(sym_prund_sim_mat[5:,5:], decimals=3))
+    >>> sym_pruned_sim_mat = 0.5 * (pruned_sim_mat + pruned_sim_mat.T)
+    >>> print (np.around(sym_pruned_sim_mat[5:,5:], decimals=3))
     [[1.    0.    0.    0.    0.   ]
      [0.    1.    0.489 0.982 0.997]
      [0.    0.489 1.    0.    0.486]
      [0.    0.982 0.    1.    0.976]
      [0.    0.997 0.486 0.976 1.   ]]
     >>> # Laplacian
-    >>> laplacian = clust.get_laplacian(sym_prund_sim_mat)
+    >>> laplacian = clust.get_laplacian(sym_pruned_sim_mat)
     >>> print (np.around(laplacian[5:,5:], decimals=3))
     [[ 1.999  0.     0.     0.     0.   ]
      [ 0.     2.468 -0.489 -0.982 -0.997]
@@ -796,13 +796,13 @@ class Spec_Clust_unorm:
         sim_mat = self.get_sim_mat(X)
 
         # Refining similarity matrix with p_val
-        prunned_sim_mat = self.p_pruning(sim_mat, p_val)
+        pruned_sim_mat = self.p_pruning(sim_mat, p_val)
 
         # Symmetrization
-        sym_prund_sim_mat = 0.5 * (prunned_sim_mat + prunned_sim_mat.T)
+        sym_pruned_sim_mat = 0.5 * (pruned_sim_mat + pruned_sim_mat.T)
 
         # Laplacian calculation
-        laplacian = self.get_laplacian(sym_prund_sim_mat)
+        laplacian = self.get_laplacian(sym_pruned_sim_mat)
 
         # Get Spectral Embeddings
         emb, num_of_spk = self.get_spec_embs(laplacian, k_oracle)
@@ -845,7 +845,7 @@ class Spec_Clust_unorm:
         -------
         A : array
             (n_samples, n_samples).
-            Prunned affinity matrix based on p_val.
+            pruned affinity matrix based on p_val.
         """
 
         n_elems = int((1 - pval) * A.shape[0])
@@ -917,8 +917,9 @@ class Spec_Clust_unorm:
                         : min(self.max_num_spkrs, len(lambda_gap_list))
                     ]
                 )
-                + 2
-            )
+                if lambda_gap_list
+                else 0
+            ) + 2
 
             if num_of_spk < self.min_num_spkrs:
                 num_of_spk = self.min_num_spkrs
@@ -1074,16 +1075,16 @@ def do_kmeans_clustering(
 
         # Get sim matrix
         sim_mat = clust_obj.get_sim_mat(diary_obj.stat1)
-        prunned_sim_mat = clust_obj.p_pruning(sim_mat, p_val)
+        pruned_sim_mat = clust_obj.p_pruning(sim_mat, p_val)
 
         # Symmetrization
-        sym_prund_sim_mat = 0.5 * (prunned_sim_mat + prunned_sim_mat.T)
+        sym_pruned_sim_mat = 0.5 * (pruned_sim_mat + pruned_sim_mat.T)
 
         # Laplacian calculation
-        laplacian = clust_obj.get_laplacian(sym_prund_sim_mat)
+        laplacian = clust_obj.get_laplacian(sym_pruned_sim_mat)
 
         # Get Spectral Embeddings
-        emb, num_of_spk = clust_obj.get_spec_embs(laplacian, k_oracle)
+        _, num_of_spk = clust_obj.get_spec_embs(laplacian, k_oracle)
 
     # Perform kmeans directly on deep embeddings
     _, labels, _ = k_means(diary_obj.stat1, num_of_spk)


### PR DESCRIPTION
I'm seeing some failures for spectral clustering for spectral clustering with two samples with corresponding embeddings. This PR is a proposed fix for the issue and typographical changes for `pruned` similarity matrices (instead of `prunned`).

If we check inline if the `lambda_gap_list` (See https://github.com/speechbrain/speechbrain/blob/ed0027fbd4a53ca37e24fbf4d66df0cd920442f0/speechbrain/processing/diarization.py#L912) is empty, then we can circumvent this error. It looks like this will occur whenever only two samples are fed into `Spec_Clust_unorm` instantiations. Below, find a more extended description of the error in my particular case.

-----
Specifically, I see a ValueError from numpy's argmax function

```.../site-packages/speechbrain/processing/diarization.py in get_spec_embs(self, L, k_oracle)
    913 
    914             num_of_spk = (
--> 915                 np.argmax(
    916                     lambda_gap_list[
    917                         : min(self.max_num_spkrs, len(lambda_gap_list))

<__array_function__ internals> in argmax(*args, **kwargs)

.../site-packages/numpy/core/fromnumeric.py in argmax(a, axis, out)
   1193 
   1194     """
-> 1195     return _wrapfunc(a, 'argmax', axis=axis, out=out)
   1196 
   1197 

.../site-packages/numpy/core/fromnumeric.py in _wrapfunc(obj, method, *args, **kwds)
     52     bound = getattr(obj, method, None)
     53     if bound is None:
---> 54         return _wrapit(obj, method, *args, **kwds)
     55 
     56     try:

.../site-packages/numpy/core/fromnumeric.py in _wrapit(obj, method, *args, **kwds)
     41     except AttributeError:
     42         wrap = None
---> 43     result = getattr(asarray(obj), method)(*args, **kwds)
     44     if wrap:
     45         if not isinstance(result, mu.ndarray):

ValueError: attempt to get argmax of an empty sequence
```

For my data, the similarity matrix is functionally orthogonal
```
In [46]: sim_mat
Out[46]: 
array([[0.9999998, 0.       ],
       [0.       , 0.9999997]], dtype=float32)
```

and the Laplacian used for spectral clustering is a 2x2 matrix of zeros, resulting in eigenvalues of 0, and I have an empty list for `lambda_gap_list` and a failure in the numpy.argmax invocation in https://github.com/speechbrain/speechbrain/blob/ed0027fbd4a53ca37e24fbf4d66df0cd920442f0/speechbrain/processing/diarization.py#L915-L919
Even if the Laplacian weren't all zeroes, it looks like the `lambda_gap_list` would still be an empty array when only receiving two input embeddings from how `getEigenGaps` behaves.
