### PR TITLE
Fix backwards compatibility for Brain CKPTs

### DIFF
--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -18,6 +18,7 @@ import inspect
 import pathlib
 import argparse
 import tempfile
+import warnings
 import speechbrain as sb
 from datetime import date
 from enum import Enum, auto
@@ -1273,4 +1274,12 @@ class Brain:
             save_dict = yaml.safe_load(f)
         self.step = save_dict["step"]
         self.avg_train_loss = save_dict["avg_train_loss"]
-        self.optimizer_step = save_dict["optimizer_step"]
+        # Ensure compatibility with checkpoints from before optimizer_step:
+        if "optimizer_step" not in save_dict:
+            clsname = self.__class__.__name__
+            MSG = f"'optimizer_step' not found in {clsname} checkpoint."
+            MSG += " Using the saved 'step' value (BACKWARDS COMPATIBILITY)"
+            warnings.warn(MSG)
+            self.optimizer_step = self.step
+        else:
+            self.optimizer_step = save_dict["optimizer_step"]


### PR DESCRIPTION
We have a lot of Brain CKPTs uploaded which became incompatible with the new recovery after PR #1251.  Though workarounds like this might not in general be good for long term health of the codebase, here we have a meaningful value as fallback and we can issue a warning just in case.

Fixes issue #1321 