### PR TITLE
VAD: fix edge cases, starting speech at end frames

### DIFF
--- a/speechbrain/pretrained/interfaces.py
+++ b/speechbrain/pretrained/interfaces.py
@@ -1286,12 +1286,12 @@ class VAD(Pretrained):
         prob_th[:, 0, :] = (prob_th[:, 0, :] >= 1).int()
         prob_th[:, -1, :] = (prob_th[:, -1, :] >= 1).int()
 
-        # Fix edge cases (when a new sentence starts in the last frame)
-        if prob_th[:, -1, :] == 1 and prob_th[:, -2, :] == 1:
-            prob_th[:, -2, :] = 2
-
-        if prob_th[:, -1, :] == 1 and prob_th[:, -2, :] == 0:
-            prob_th[:, -2, :] = 1
+        # Fix edge cases (when a speech starts in the last frames)
+        if (prob_th == 1).nonzero().shape[0] % 2 == 1:
+            prob_th = torch.cat(
+                (prob_th, torch.Tensor([1.0]).unsqueeze(0).unsqueeze(2)), 
+                dim=1
+                )
 
         # Where prob_th is 1 there is a change
         indexes = (prob_th == 1).nonzero()[:, 1].reshape(-1, 2)

--- a/speechbrain/pretrained/interfaces.py
+++ b/speechbrain/pretrained/interfaces.py
@@ -1289,9 +1289,8 @@ class VAD(Pretrained):
         # Fix edge cases (when a speech starts in the last frames)
         if (prob_th == 1).nonzero().shape[0] % 2 == 1:
             prob_th = torch.cat(
-                (prob_th, torch.Tensor([1.0]).unsqueeze(0).unsqueeze(2)), 
-                dim=1
-                )
+                (prob_th, torch.Tensor([1.0]).unsqueeze(0).unsqueeze(2)), dim=1
+            )
 
         # Where prob_th is 1 there is a change
         indexes = (prob_th == 1).nonzero()[:, 1].reshape(-1, 2)


### PR DESCRIPTION
I faced some problems while using VAD interface to get speech segments. In fact, the problem was already detected [here](#1108). Cases, when speech starts in final frames, are not well managed. The **get_boundaries** method returns an even number of bounds, so if speech starts in final frames (start bound) the code was not able to give an end bound. For more details go to issue #1108. The next images show an example that used to break the execution:

Output probability:
![image](https://user-images.githubusercontent.com/58975068/159241618-899b0102-2c4a-4abd-8751-7e6b5a5f9ed5.png)
Threshold-based decision:
![image](https://user-images.githubusercontent.com/58975068/159242849-27ad68ce-2a54-49ee-9aa3-55034a0b699a.png)


With this PR, the following lines no longer break the execution.

```python
import torch
from speechbrain.pretrained import VAD

vad = VAD.from_hparams(
    source="speechbrain/vad-crdnn-libriparty",
    savedir="data/vad",
)
torch.manual_seed(2022)

for i in range(100):
    probs_th = (torch.randn(1, 100, 1) > 0.5).int()
    vad.get_boundaries(probs_th)
```

close #1108 