### PR TITLE
Pin `click` version

### DIFF
--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,4 +1,5 @@
 black==19.10b0
+click >= 6.6, <= 8.0.4
 flake8==3.7.9
 pycodestyle==2.5.0
 pytest==5.4.1


### PR DESCRIPTION
An update to `click` causes `black` to fail with
`ImportError: cannot import name '_unicodefun' from 'click' (/Users/jimhays/.cache/pre-commit/repoef_0ghls/py_env-python3/lib/python3.10/site-packages/click/__init__.py)`

This pins `click` at a working version.

For more information, see:
https://github.com/dask/distributed/issues/6013