### PR TITLE
fix blake8 - click lib error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: black
         types: [python]
-
+        additional_dependencies: ['click==8.0.4']
   - repo: https://gitlab.com/pycqa/flake8.git
     rev: 3.7.9
     hooks:

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,4 +1,5 @@
 black==19.10b0
+click==8.0.4
 flake8==3.7.9
 pycodestyle==2.5.0
 pytest==5.4.1

--- a/tests/.run-doctests.sh
+++ b/tests/.run-doctests.sh
@@ -5,5 +5,5 @@ set -e -u -o pipefail
 # > pytest --doctest-modules speechbrain/
 # However, we take this more complex approach to avoid testing files not
 # tracked by git. We filter out tests that require optional dependencies.
-avoid="transducer_loss.py\|fairseq_wav2vec.py\|huggingface_wav2vec.py\|bleu.py|ctc_segmentation.py"
+avoid="transducer_loss.py\|fairseq_wav2vec.py\|huggingface_wav2vec.py\|bleu.py\|ctc_segmentation.py"
 git ls-files speechbrain | grep -e "\.py$" | grep -v $avoid | xargs pytest --doctest-modules

--- a/tests/.run-doctests.sh
+++ b/tests/.run-doctests.sh
@@ -5,5 +5,5 @@ set -e -u -o pipefail
 # > pytest --doctest-modules speechbrain/
 # However, we take this more complex approach to avoid testing files not
 # tracked by git. We filter out tests that require optional dependencies.
-avoid="transducer_loss.py\|fairseq_wav2vec.py\|huggingface_wav2vec.py\|bleu.py"
+avoid="transducer_loss.py\|fairseq_wav2vec.py\|huggingface_wav2vec.py\|bleu.py|ctc_segmentation.py"
 git ls-files speechbrain | grep -e "\.py$" | grep -v $avoid | xargs pytest --doctest-modules


### PR DESCRIPTION
Hello, 
as discussed offline, I just saw that the click lib gave errors with pre-commit, see:
```
(spbrain) ovh@job-3d94d6d0-44eb-41ba-8972-c33856dbaa9c:~/speechbrain-aheba-contribs/recipes/TIMIT/ASR/transducer$ git commit -m "fix RNN-T loss bug - use logits instead of log_probs"
[WARNING] Unstaged files detected.
[INFO] Stashing unstaged files to /workspace/.cache/pre-commit/patch1649596825-52794.
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Fix requirements.txt.................................(no files to check)Skipped
Mixed line ending........................................................Passed
Check for added large files..............................................Passed
black....................................................................Failed
- hook id: black
- exit code: 1

Traceback (most recent call last):
  File "/workspace/.cache/pre-commit/repo41p2_ikj/py_env-python3/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/workspace/.cache/pre-commit/repo41p2_ikj/py_env-python3/lib/python3.8/site-packages/black.py", line 4134, in patched_main
    patch_click()
  File "/workspace/.cache/pre-commit/repo41p2_ikj/py_env-python3/lib/python3.8/site-packages/black.py", line 4123, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/workspace/.cache/pre-commit/repo41p2_ikj/py_env-python3/lib/python3.8/site-packages/click/__init__.py)

flake8...................................................................Passed
yamllint.............................................(no files to check)Skipped
[INFO] Restored changes from /workspace/.cache/pre-commit/patch1649596825-52794.
```

I do an update on `linter-requirement` which solve the issue 