### PR TITLE
fix RNN-T loss bug - use logits instead of log_probs

### DIFF
--- a/recipes/CommonVoice/ASR/transducer/train.py
+++ b/recipes/CommonVoice/ASR/transducer/train.py
@@ -71,8 +71,7 @@ class ASR(sb.Brain):
         joint = self.modules.Tjoint(x.unsqueeze(2), h.unsqueeze(1))
 
         # Output layer for transducer log-probabilities
-        logits = self.modules.transducer_lin(joint)
-        p_transducer = self.hparams.log_softmax(logits)
+        logits_transducer = self.modules.transducer_lin(joint)
 
         # Compute outputs
         if stage == sb.Stage.TRAIN:
@@ -96,17 +95,17 @@ class ASR(sb.Brain):
                 p_ce = self.modules.dec_lin(h)
                 p_ce = self.hparams.log_softmax(p_ce)
             if return_CE and return_CTC:
-                return p_ctc, p_ce, p_transducer, wav_lens
+                return p_ctc, p_ce, logits_transducer, wav_lens
             elif return_CTC:
-                return p_ctc, p_transducer, wav_lens
+                return p_ctc, logits_transducer, wav_lens
             elif return_CE:
-                return p_ce, p_transducer, wav_lens
+                return p_ce, logits_transducer, wav_lens
             else:
-                return p_transducer, wav_lens
+                return logits_transducer, wav_lens
 
         elif stage == sb.Stage.VALID:
             best_hyps, scores, _, _ = self.hparams.beam_searcher(x)
-            return p_transducer, wav_lens, best_hyps
+            return logits_transducer, wav_lens, best_hyps
         else:
             (
                 best_hyps,
@@ -114,7 +113,7 @@ class ASR(sb.Brain):
                 nbest_hyps,
                 nbest_scores,
             ) = self.hparams.beam_searcher(x)
-            return p_transducer, wav_lens, best_hyps
+            return logits_transducer, wav_lens, best_hyps
 
     def compute_objectives(self, predictions, batch, stage):
         """Computes the loss (Transducer+(CTC+NLL)) given predictions and targets."""
@@ -126,7 +125,7 @@ class ASR(sb.Brain):
 
         if stage == sb.Stage.TRAIN:
             if len(predictions) == 4:
-                p_ctc, p_ce, p_transducer, wav_lens = predictions
+                p_ctc, p_ce, logits_transducer, wav_lens = predictions
                 CTC_loss = self.hparams.ctc_cost(
                     p_ctc, tokens, wav_lens, token_lens
                 )
@@ -134,7 +133,7 @@ class ASR(sb.Brain):
                     p_ce, tokens_eos, length=token_eos_lens
                 )
                 loss_transducer = self.hparams.transducer_cost(
-                    p_transducer, tokens, wav_lens, token_lens
+                    logits_transducer, tokens, wav_lens, token_lens
                 )
                 loss = (
                     self.hparams.ctc_weight * CTC_loss
@@ -151,7 +150,7 @@ class ASR(sb.Brain):
                         p_ctc, tokens, wav_lens, token_lens
                     )
                     loss_transducer = self.hparams.transducer_cost(
-                        p_transducer, tokens, wav_lens, token_lens
+                        logits_transducer, tokens, wav_lens, token_lens
                     )
                     loss = (
                         self.hparams.ctc_weight * CTC_loss
@@ -159,26 +158,29 @@ class ASR(sb.Brain):
                     )
                 # CE for decoder alive
                 else:
-                    p_ce, p_transducer, wav_lens = predictions
+                    p_ce, logits_transducer, wav_lens = predictions
                     CE_loss = self.hparams.ce_cost(
                         p_ce, tokens_eos, length=token_eos_lens
                     )
+                    # Transducer loss use logits from RNN-T model.
                     loss_transducer = self.hparams.transducer_cost(
-                        p_transducer, tokens, wav_lens, token_lens
+                        logits_transducer, tokens, wav_lens, token_lens
                     )
                     loss = (
                         self.hparams.ce_weight * CE_loss
                         + (1 - self.hparams.ctc_weight) * loss_transducer
                     )
             else:
-                p_transducer, wav_lens = predictions
+                logits_transducer, wav_lens = predictions
+                # Transducer loss use logits from RNN-T model.
                 loss = self.hparams.transducer_cost(
-                    p_transducer, tokens, wav_lens, token_lens
+                    logits_transducer, tokens, wav_lens, token_lens
                 )
         else:
-            p_transducer, wav_lens, predicted_tokens = predictions
+            logits_transducer, wav_lens, predicted_tokens = predictions
+            # Transducer loss use logits from RNN-T model.
             loss = self.hparams.transducer_cost(
-                p_transducer, tokens, wav_lens, token_lens
+                logits_transducer, tokens, wav_lens, token_lens
             )
 
         if stage != sb.Stage.TRAIN:

--- a/recipes/LibriSpeech/ASR/transducer/train.py
+++ b/recipes/LibriSpeech/ASR/transducer/train.py
@@ -81,8 +81,7 @@ class ASR(sb.Brain):
         joint = self.modules.Tjoint(x.unsqueeze(2), h.unsqueeze(1))
 
         # Output layer for transducer log-probabilities
-        logits = self.modules.transducer_lin(joint)
-        p_transducer = self.hparams.log_softmax(logits)
+        logits_transducer = self.modules.transducer_lin(joint)
 
         # Compute outputs
         if stage == sb.Stage.TRAIN:
@@ -106,17 +105,17 @@ class ASR(sb.Brain):
                 p_ce = self.modules.dec_lin(h)
                 p_ce = self.hparams.log_softmax(p_ce)
             if return_CE and return_CTC:
-                return p_ctc, p_ce, p_transducer, wav_lens
+                return p_ctc, p_ce, logits_transducer, wav_lens
             elif return_CTC:
-                return p_ctc, p_transducer, wav_lens
+                return p_ctc, logits_transducer, wav_lens
             elif return_CE:
-                return p_ce, p_transducer, wav_lens
+                return p_ce, logits_transducer, wav_lens
             else:
-                return p_transducer, wav_lens
+                return logits_transducer, wav_lens
 
         elif stage == sb.Stage.VALID:
             best_hyps, scores, _, _ = self.hparams.Greedysearcher(x)
-            return p_transducer, wav_lens, best_hyps
+            return logits_transducer, wav_lens, best_hyps
         else:
             (
                 best_hyps,
@@ -124,7 +123,7 @@ class ASR(sb.Brain):
                 nbest_hyps,
                 nbest_scores,
             ) = self.hparams.Beamsearcher(x)
-            return p_transducer, wav_lens, best_hyps
+            return logits_transducer, wav_lens, best_hyps
 
     def compute_objectives(self, predictions, batch, stage):
         """Computes the loss (Transducer+(CTC+NLL)) given predictions and targets."""
@@ -141,7 +140,7 @@ class ASR(sb.Brain):
 
         if stage == sb.Stage.TRAIN:
             if len(predictions) == 4:
-                p_ctc, p_ce, p_transducer, wav_lens = predictions
+                p_ctc, p_ce, logits_transducer, wav_lens = predictions
                 CTC_loss = self.hparams.ctc_cost(
                     p_ctc, tokens, wav_lens, token_lens
                 )
@@ -149,7 +148,7 @@ class ASR(sb.Brain):
                     p_ce, tokens_eos, length=token_eos_lens
                 )
                 loss_transducer = self.hparams.transducer_cost(
-                    p_transducer, tokens, wav_lens, token_lens
+                    logits_transducer, tokens, wav_lens, token_lens
                 )
                 loss = (
                     self.hparams.ctc_weight * CTC_loss
@@ -161,12 +160,12 @@ class ASR(sb.Brain):
                 # one of the 2 heads (CTC or CE) is still computed
                 # CTC alive
                 if current_epoch <= self.hparams.number_of_ctc_epochs:
-                    p_ctc, p_transducer, wav_lens = predictions
+                    p_ctc, logits_transducer, wav_lens = predictions
                     CTC_loss = self.hparams.ctc_cost(
                         p_ctc, tokens, wav_lens, token_lens
                     )
                     loss_transducer = self.hparams.transducer_cost(
-                        p_transducer, tokens, wav_lens, token_lens
+                        logits_transducer, tokens, wav_lens, token_lens
                     )
                     loss = (
                         self.hparams.ctc_weight * CTC_loss
@@ -174,26 +173,26 @@ class ASR(sb.Brain):
                     )
                 # CE for decoder alive
                 else:
-                    p_ce, p_transducer, wav_lens = predictions
+                    p_ce, logits_transducer, wav_lens = predictions
                     CE_loss = self.hparams.ce_cost(
                         p_ce, tokens_eos, length=token_eos_lens
                     )
                     loss_transducer = self.hparams.transducer_cost(
-                        p_transducer, tokens, wav_lens, token_lens
+                        logits_transducer, tokens, wav_lens, token_lens
                     )
                     loss = (
                         self.hparams.ce_weight * CE_loss
                         + (1 - self.hparams.ctc_weight) * loss_transducer
                     )
             else:
-                p_transducer, wav_lens = predictions
+                logits_transducer, wav_lens = predictions
                 loss = self.hparams.transducer_cost(
-                    p_transducer, tokens, wav_lens, token_lens
+                    logits_transducer, tokens, wav_lens, token_lens
                 )
         else:
-            p_transducer, wav_lens, predicted_tokens = predictions
+            logits_transducer, wav_lens, predicted_tokens = predictions
             loss = self.hparams.transducer_cost(
-                p_transducer, tokens, wav_lens, token_lens
+                logits_transducer, tokens, wav_lens, token_lens
             )
 
         if stage != sb.Stage.TRAIN:

--- a/recipes/TIMIT/ASR/transducer/train.py
+++ b/recipes/TIMIT/ASR/transducer/train.py
@@ -64,11 +64,10 @@ class ASR_Brain(sb.Brain):
 
         # output layer for seq2seq log-probabilities
         logits = self.modules.output(joint)
-        p_transducer = self.hparams.log_softmax(logits)
 
         if stage == sb.Stage.VALID:
             hyps, scores, _, _ = self.hparams.Greedysearcher(x)
-            return p_transducer, hyps
+            return logits, hyps
 
         elif stage == sb.Stage.TEST:
             (
@@ -77,8 +76,8 @@ class ASR_Brain(sb.Brain):
                 nbest_hyps,
                 nbest_scores,
             ) = self.hparams.Beamsearcher(x)
-            return p_transducer, best_hyps
-        return p_transducer
+            return logits, best_hyps
+        return logits
 
     def compute_objectives(self, predictions, batch, stage):
         "Given the network predictions and targets computed the loss."
@@ -88,6 +87,7 @@ class ASR_Brain(sb.Brain):
         if stage != sb.Stage.TRAIN:
             predictions, hyps = predictions
 
+        # Transducer loss use logits from RNN-T model.
         loss = self.hparams.compute_cost(predictions, phns, wav_lens, phn_lens)
         self.transducer_metrics.append(
             ids, predictions, phns, wav_lens, phn_lens

--- a/recipes/TIMIT/ASR/transducer/train_wav2vec.py
+++ b/recipes/TIMIT/ASR/transducer/train_wav2vec.py
@@ -55,11 +55,10 @@ class ASR_Brain(sb.Brain):
 
         # output layer for seq2seq log-probabilities
         logits = self.modules.output(joint)
-        p_transducer = self.hparams.log_softmax(logits)
 
         if stage == sb.Stage.VALID:
             hyps, scores, _, _ = self.hparams.Greedysearcher(x)
-            return p_transducer, hyps
+            return logits, hyps
 
         elif stage == sb.Stage.TEST:
             (
@@ -68,8 +67,8 @@ class ASR_Brain(sb.Brain):
                 nbest_hyps,
                 nbest_scores,
             ) = self.hparams.Beamsearcher(x)
-            return p_transducer, best_hyps
-        return p_transducer
+            return logits, best_hyps
+        return logits
 
     def compute_objectives(self, predictions, batch, stage):
         "Given the network predictions and targets computed the loss."
@@ -79,6 +78,7 @@ class ASR_Brain(sb.Brain):
         if stage != sb.Stage.TRAIN:
             predictions, hyps = predictions
 
+        # Transducer loss use logits from RNN-T model.
         loss = self.hparams.compute_cost(predictions, phns, wav_lens, phn_lens)
         self.transducer_metrics.append(
             ids, predictions, phns, wav_lens, phn_lens

--- a/speechbrain/nnet/loss/transducer_loss.py
+++ b/speechbrain/nnet/loss/transducer_loss.py
@@ -303,12 +303,12 @@ class TransducerLoss(Module):
     -------
     >>> import torch
     >>> loss = TransducerLoss(blank=0)
-    >>> acts = torch.randn((1,2,3,5)).cuda().log_softmax(dim=-1).requires_grad_()
+    >>> logits = torch.randn((1,2,3,5)).cuda().requires_grad_()
     >>> labels = torch.Tensor([[1,2]]).cuda().int()
     >>> act_length = torch.Tensor([2]).cuda().int()
     >>> # U = label_length+1
     >>> label_length = torch.Tensor([2]).cuda().int()
-    >>> l = loss(acts, labels, act_length, label_length)
+    >>> l = loss(logits, labels, act_length, label_length)
     >>> l.backward()
     """
 
@@ -333,5 +333,7 @@ class TransducerLoss(Module):
             err_msg += "conda install numba cudatoolkit=9.0"
             raise ImportError(err_msg)
 
-    def forward(self, log_probs, labels, T, U):
+    def forward(self, logits, labels, T, U):
+        # Transducer.apply function take log_probs tensor.
+        log_probs = logits.log_softmax(-1)
         return self.loss(log_probs, labels, T, U, self.blank, self.reduction)

--- a/speechbrain/nnet/losses.py
+++ b/speechbrain/nnet/losses.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 def transducer_loss(
-    log_probs,
+    logits,
     targets,
     input_lens,
     target_lens,
@@ -37,7 +37,7 @@ def transducer_loss(
 
     Arguments
     ---------
-    predictions : torch.Tensor
+    logits : torch.Tensor
         Predicted tensor, of shape [batch, maxT, maxU, num_labels].
     targets : torch.Tensor
         Target tensor, without any blanks, of shape [batch, target_len].
@@ -53,7 +53,7 @@ def transducer_loss(
         If True, use Transducer loss implementation from torchaudio, otherwise,
         use Speechbrain Numba implementation.
     """
-    input_lens = (input_lens * log_probs.shape[1]).round().int()
+    input_lens = (input_lens * logits.shape[1]).round().int()
     target_lens = (target_lens * targets.shape[1]).round().int()
 
     if use_torchaudio:
@@ -68,7 +68,7 @@ def transducer_loss(
             raise ImportError(err_msg)
 
         return rnnt_loss(
-            log_probs,
+            logits,
             targets.int(),
             input_lens,
             target_lens,
@@ -78,6 +78,8 @@ def transducer_loss(
     else:
         from speechbrain.nnet.loss.transducer_loss import Transducer
 
+        # Transducer.apply function take log_probs tensor.
+        log_probs = logits.log_softmax(-1)
         return Transducer.apply(
             log_probs, targets, input_lens, target_lens, blank_index, reduction,
         )


### PR DESCRIPTION
Hi @TParcollet ,
as reported in #1339, thanks to @csukuangfj,

Only torchaudio is using logits as input of the RNNT loss function. (other lib doesn't, see https://github.com/1ytic/warp-rnnt, https://github.com/HawkAaron/warp-transducer/tree/master/pytorch_binding)

Here is a fix to the RNN-T loss using torchaudio,


I will use this PR to add to our Numba code:
- [ ] // computation for alpha & beta.
- [ ] add fastemit_lambda (see https://arxiv.org/abs/2010.11148)