### PR TITLE
Quick fix for HF API with EncoderASR Interface

### DIFF
--- a/speechbrain/pretrained/interfaces.py
+++ b/speechbrain/pretrained/interfaces.py
@@ -712,7 +712,7 @@ class EncoderASR(Pretrained):
                 self.tokenizer, speechbrain.dataio.encoder.CTCTextEncoder
             ):
                 predicted_words = [
-                    "".join(self.tokenizer.decode_ndim(token_seq)).split(" ")
+                    "".join(self.tokenizer.decode_ndim(token_seq))
                     for token_seq in predictions
                 ]
             elif isinstance(


### PR DESCRIPTION
The new EncoderASR for wav2vec2-librispeech was giving a list instead of a string as output. This is now fixed.