### PR TITLE
Adding no_sync and on_fit_batch_end method to core

### DIFF
--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -883,11 +883,11 @@ class Brain:
                     self.optimizer.step()
                 self.optimizer.zero_grad()
                 self.optimizer_step += 1
-        if should_step:
-            self.on_fit_batch_end()
+
+        self.on_fit_batch_end(batch, outputs, loss, should_step)
         return loss.detach().cpu()
 
-    def on_fit_batch_end(self):
+    def on_fit_batch_end(self, batch, outputs, loss, should_step):
         """Called after ``fit_batch()``"""
         pass
 
@@ -929,7 +929,7 @@ class Brain:
                 return False
 
         # Clip gradient norm
-        if self.max_grad_norm != 0.0:
+        if self.max_grad_norm > 0.0:
             torch.nn.utils.clip_grad_norm_(
                 (p for p in self.modules.parameters()), self.max_grad_norm
             )
@@ -1300,7 +1300,7 @@ class Brain:
         Arguments
         ---------
         use : bool
-            If set to `False` will still sync gradients.
+            If set to `False` will still sync gradients, useful to make behaviour togglable.
         """
         if use:
             old_values_list = []


### PR DESCRIPTION
The wav2vec PR would change some things to core.py, this is a new PR to integrate the changes that have a wider impact (are in `core.py`) first.

The main change is a new `no_sync()` method, this is for when one is doing DDP and gradient accumulation, in which case it is wasteful to sync gradients on every forward-backward pass. One would use the `nn.module.no_sync()` context-manager to change that, but this is very awkward to do in SB since one tends to have multiple modules. This method simplifies things: You can just (in fit_batch) do `with self.no_sync(not should_step):` and everything will be taken care of.

Two other minor things are:
1. Adding a method `on_fit_batch_end()`, upon suggestion from @TParcollet this is to keep the logging separate from the training related stuff happening in `fit_batch()`. Not sure if some arguments should be passed from `fit_batch()` by default?
2. `clip_grad_norm_` is only called if `max_grad_norm != 0.`