### PR TITLE
Fix consistency issue with threshold

### DIFF
--- a/speechbrain/utils/metric_stats.py
+++ b/speechbrain/utils/metric_stats.py
@@ -422,7 +422,7 @@ class BinaryMetricStats(MetricStats):
 
             eer, threshold = EER(positive_scores, negative_scores)
 
-        pred = (self.scores >= threshold).float()
+        pred = (self.scores > threshold).float()
         true = self.labels
 
         TP = self.summary["TP"] = float(pred.mul(true).sum())


### PR DESCRIPTION
In lines 496 and 566, the predicted positives are defined as the scores that are strictly greater than the threshold.
In line 425, there was a consistency issue because the predicted positives were defined as scores greater than or equal to the threshold.
I fixed it and removed the equal sign, so now there is consistency between the definitions of predicted positives throughout the file.