### PR TITLE
Added README link to interactive sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The goal is to create a **single**, **flexible**, and **user-friendly** toolkit 
 **News:** SpeechBrain 0.5.12 has been released (June 26, 2022)!
 
 
-| **[Discourse](https://speechbrain.discourse.group)** | **[Tutorials](https://speechbrain.github.io/tutorial_basics.html)** | **[Website](https://speechbrain.github.io/)** | **[Documentation](https://speechbrain.readthedocs.io/en/latest/index.html)** | **[Contributing](https://speechbrain.readthedocs.io/en/latest/contributing.html)** | **[HuggingFace](https://huggingface.co/speechbrain)** |
+| **[Discourse](https://speechbrain.discourse.group)** | **[Tutorials](https://speechbrain.github.io/tutorial_basics.html)** | **[Website](https://speechbrain.github.io/)** | **[Documentation](https://speechbrain.readthedocs.io/en/latest/index.html)** | **[Contributing](https://speechbrain.readthedocs.io/en/latest/contributing.html)** | **[HuggingFace](https://huggingface.co/speechbrain)** | **[Interactive Sandbox](https://www.slai.io/s/ss0u0)** |
 
 # Key features
 


### PR DESCRIPTION
I was playing around with speechbrain and wanted an easy way to deploy the inference pipeline, so I hosted a basic app for the pretrained model on this [Slai Sandbox](https://www.slai.io/s/ss0u0). All the required libraries are installed, there's a sample audio file included, and the pipeline can be quickly customized or deployed as an API.