### PR TITLE
DDP wrong command in doc

### DIFF
--- a/speechbrain/utils/distributed.py
+++ b/speechbrain/utils/distributed.py
@@ -106,7 +106,7 @@ def ddp_barrier():
 
 def ddp_init_group(run_opts):
     """This function will initialize the ddp group if
-    distributed_launch=True bool is given in the python command line.
+    distributed_launch bool is given in the python command line.
 
     The ddp group will use distributed_backend arg for setting the
     DDP communication protocol. `RANK` Unix variable will be used for
@@ -122,7 +122,7 @@ def ddp_init_group(run_opts):
             raise ValueError(
                 "To use DDP backend, start your script with:\n\t"
                 "python -m torch.distributed.launch [args]\n\t"
-                "experiment.py hyperparams.yaml --distributed_launch=True "
+                "experiment.py hyperparams.yaml --distributed_launch "
                 "--distributed_backend=nccl"
             )
         else:
@@ -135,7 +135,7 @@ def ddp_init_group(run_opts):
             raise ValueError(
                 "To use DDP backend, start your script with:\n\t"
                 "python -m torch.distributed.launch [args]\n\t"
-                "experiment.py hyperparams.yaml --distributed_launch=True "
+                "experiment.py hyperparams.yaml --distributed_launch "
                 "--distributed_backend=nccl"
             )
         rank = int(os.environ["RANK"])
@@ -177,8 +177,8 @@ def ddp_init_group(run_opts):
         if "local_rank" in run_opts and run_opts["local_rank"] > 0:
             raise ValueError(
                 "DDP is disabled, local_rank must not be set.\n"
-                "For DDP training, please use --distributed_launch=True. "
+                "For DDP training, please use --distributed_launch. "
                 "For example:\n\tpython -m torch.distributed.launch "
                 "experiment.py hyperparams.yaml "
-                "--distributed_launch=True --distributed_backend=nccl"
+                "--distributed_launch --distributed_backend=nccl"
             )


### PR DESCRIPTION
Hello, 

In the file `distributed.py`, some errors can be raised suggesting the use of `--distributed_launch=True` which is misleading because it is not what the user is supposed to do. According to the official documentation of SpeechBrain, if one wants to use DDP then he needs to use `--distributed_launch` instead of `--distributed_launch=True` -> https://speechbrain.readthedocs.io/en/v0.5.8/multigpu.html

Moreover, `--distributed_launch=True` will not work. I tried to do a little example on my GPUs cluster where I'm training an LSTM on the CommonVoice French recipe of SpeechBrain using 2x v100s: 

with `--distributed_launch=True`  I got an error: torch.distributed.elastic.multiprocessing.errors.ChildFailedError ......
whearas  `--distributed_launch` do everything that is expected, i.e train the LSTM.

I got the same return from a colleague who tried to use DDP and was stuck due to the errors thrown that were suggesting to set to `True`.  

P.S.: I also need to change every comment in the recipes that suggests that. E.g. CommonVoice ASR seq2seq in `train.py` -> `# If distributed_launch=True` but I'm waiting for an official reviewer to confirm the problem. 

Best,

