### PR TITLE
Remove torch maximum compatible version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ pre-commit>=2.3.0
 scipy>=1.4.1
 sentencepiece>=0.1.91
 SoundFile; sys_platform == 'win32'
-torch>=1.9.0,<=1.11.1
-torchaudio>=0.9.0,<=0.11.1
+torch>=1.9.0
+torchaudio>=0.9.0
 tqdm>=4.42.0

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "packaging",
         "scipy",
         "sentencepiece",
-        "torch>=1.7,<=1.11",
+        "torch>=1.9",
         "torchaudio",
         "tqdm",
         "huggingface_hub",


### PR DESCRIPTION
Closes #1493 

As PyTorch is more stable, I think it makes sense to remove the maximum compatible version.

Is anyone aware of why the minimum versions were different between `setup.py` and `requirements.txt`? I updated `setup.py` to reflect the more stringent requirement in `requirements.txt` but anyone with more info could chime in if there is a good reason for it.