### PR TITLE
Decay gumbel temperature over training steps

### DIFF
--- a/recipes/CommonVoice/self-supervised-learning/wav2vec2/hparams/wav2vec2_base.yaml
+++ b/recipes/CommonVoice/self-supervised-learning/wav2vec2/hparams/wav2vec2_base.yaml
@@ -41,6 +41,9 @@ number_of_epochs: 100
 lr_adam: 2.0 # This will get reduced by the training scheduler
 weight_decay: 0.01
 d_model: 768  # Needed by the scheduler. 768 is for the BASE w2v2
+gumbel_temp_max: 2.0
+gumbel_temp_min: 0.5
+gumbel_temp_decay: 0.999995 # Decay of gumbel temperature during training
 sorting: ascending
 auto_mix_prec: False
 sample_rate: 16000

--- a/recipes/CommonVoice/self-supervised-learning/wav2vec2/train.py
+++ b/recipes/CommonVoice/self-supervised-learning/wav2vec2/train.py
@@ -123,6 +123,10 @@ class W2VBrain(sb.core.Brain):
 
                 # anneal lr every update
                 self.hparams.noam_annealing(self.optimizer)
+                # decay gumbel temperature until it reaches the minimum value
+                self.modules.wav2vec2.module.model.set_gumbel_temperature(
+                    max(self.hparams.gumbel_temp_max * .99995 ** self.step // self.hparams.gradient_accumulation,
+                        self.hparams.gumbel_temp_min))
 
         return loss.detach()
 


### PR DESCRIPTION
Updated the Common Voice / self-supervised learning / wav2vec training recipe to decay the gumbel temperature at the end of each update.  Added three values to the corresponding yaml file in support:
gumbel_temp_max: 2.0
gumbel_temp_min: 0.5
gumbel_temp_decay: 0.999995 # Decay of gumbel temperature during training
The default values are the same used within the huggingface trainer: https://github.com/huggingface/transformers/blob/v4.20.1/examples/research_projects/wav2vec2/run_pretrain.py#L275-L282

