### PR TITLE
Remove limit for HF hub as it does not work with colab

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -r lint-requirements.txt
-huggingface_hub>=0.6.0,<=0.8.0
+huggingface_hub>=0.7.0
 hyperpyyaml>=0.0.1
 joblib>=0.14.1
 numpy>=1.17.0


### PR DESCRIPTION
Google colab is failing because HF hub bellow 0.7 is not managed properly due to some tensor flow version mismatch. We remove the maximum HF HUB version to avoid this 