### PR TITLE
Fixing shuffle argument for distributed sampler in core.py

### DIFF
--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -755,7 +755,7 @@ class Brain:
             elif loader_kwargs.get("batch_sampler") is None:
                 # no sampler and batch-sampler
                 self.train_sampler = DistributedSampler(
-                    dataset, rank=self.rank, shuffle=False, drop_last=drop_last
+                    dataset, rank=self.rank, shuffle=True, drop_last=drop_last
                 )
 
                 # with DistributedSamplerWrapper, one must disable shuffling for dataloader
@@ -765,7 +765,7 @@ class Brain:
                 self.train_sampler = DistributedSamplerWrapper(
                     loader_kwargs.get("batch_sampler", None),
                     rank=self.rank,
-                    shuffle=False,
+                    shuffle=True,
                 )
                 loader_kwargs["batch_sampler"] = self.train_sampler
         elif self.distributed_launch and isinstance(dataset, IterableDataset):

--- a/speechbrain/dataio/sampler.py
+++ b/speechbrain/dataio/sampler.py
@@ -707,7 +707,8 @@ class DynamicBatchSampler(Sampler):
 # Heavily inspired by Catalyst, which is under Apache 2.0 licence.
 # https://github.com/catalyst-team/catalyst/blob/51428d7756e62b9b8ee5379f38e9fd576eeb36e5/catalyst/data/sampler.py#L522
 class DistributedSamplerWrapper(DistributedSampler):
-    """This wrapper allows using any sampler with Distributed Data Parallel (DDP) correctly.
+    """This wrapper allows using any sampler (for example batch) with Distributed Data Parallel (DDP)
+    correctly.
 
     Passing blindly the sampler to each DDP process will cause to have access
     within each process to all the data in the dataset instead of only a subset


### PR DESCRIPTION
Currently shuffling of the sample indices is not done before distributing the indices across nodes, this means the distribution will be the same for each epoch. This causes a small but noticeable decrease in performance. 

Fixes #1495 

I don't think there's ever a reason to have it set to False, therefore hardcoded to True.

I also took the liberty of adding a tiny bit of extra info to why `DistributedSamplerWrapper` needs to exist.