### PR TITLE
Minor fix to the SpeechBrain G2P CLI tool

### DIFF
--- a/tools/g2p.py
+++ b/tools/g2p.py
@@ -409,7 +409,7 @@ def main():
         )
     else:
         g2p = GraphemeToPhoneme.from_hparams(
-            hparams_file_name=hparams_file_name,
+            hparams_file=hparams_file_name,
             source=arguments.model,
             overrides=overrides,
             run_opts=run_opts,


### PR DESCRIPTION
This PR addresses a parameter typo when using G2P CLI with a pertained model.