### PR TITLE
updating scipy version in requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ joblib>=0.14.1
 numpy>=1.17.0
 packaging
 pre-commit>=2.3.0
-scipy>=1.4.1
+scipy>=1.4.1, <1.9
 sentencepiece>=0.1.91
 SoundFile; sys_platform == 'win32'
 torch>=1.9.0


### PR DESCRIPTION
Hi @TParcollet ,
As we discussed over chat, there are some issues with the latest version of spicy (1.9) and PLDA code. I tested the code and it works with the latest version of scipy on MacOS but fails on Linux.  I made changes to the requirements.txt to restrict scipy to 1.8.1 till we find a reason for this behavior. Meanwhile, it should be safe to merge PRs that do not make use of scipy. 