### PR TITLE
Hypotheses scores

### DIFF
--- a/speechbrain/decoders/seq2seq.py
+++ b/speechbrain/decoders/seq2seq.py
@@ -832,7 +832,7 @@ class S2SBeamSearcher(S2SBaseSearcher):
         if self.return_log_probs:
             return predictions, topk_scores, log_probs
         else:
-            return predictions, topk_scores
+            return predictions, topk_scores, torch.exp(log_probs)
 
     def ctc_forward_step(self, x):
         """Applies a ctc step during bramsearch."""

--- a/speechbrain/decoders/seq2seq.py
+++ b/speechbrain/decoders/seq2seq.py
@@ -278,9 +278,9 @@ class S2SBeamSearcher(S2SBaseSearcher):
     beam_size : int
         The width of beam.
     topk : int
-        The number of hypothesis to return. (default: 1)
+        The number of hypothesis to return and its respective scores. (default: 1)
     return_log_probs : bool
-        Whether to return log-probabilities. (default: False)
+        Whether to return log-probabilities, instead of probabilities. (default: False)
     using_eos_threshold : bool
         Whether to use eos threshold. (default: true)
     eos_threshold : float


### PR DESCRIPTION
Related to https://github.com/speechbrain/speechbrain/issues/1514. Top-k argument in the S2SBeamSearcher is described as _The number of hypotheses to return_. However, if we don't specify the return_log_probs argument, only final scores for each hypothesis are returned (without a probability path for each hypothesis). This is somewhat confusing from the point of the user. 

Hereby, I propose to change slightly S2SBeamSearcher to return either log_probs, or probs, depending whether return_log_probs is True or False.

_I am not sure if that change might be breaking some stuff as a number of returned elements is changed (please check!)_. In that case, we should make just crystal clear in the documentation that multiple probability paths will be returned only if topk > 1 and return_log_probs = True. If that's the case, let me know so I will just change the docs strings accordingly.