### PR TITLE
Fix return value of batch_evaluation for separation recipes

### DIFF
--- a/recipes/BinauralWSJ0Mix/separation/train.py
+++ b/recipes/BinauralWSJ0Mix/separation/train.py
@@ -283,7 +283,7 @@ class Separation(sb.Brain):
             else:
                 self.save_audio(snt_id[0], mixture, targets, predictions)
 
-        return loss.detach()
+        return loss.mean().detach()
 
     def on_stage_end(self, stage, stage_loss, epoch):
         """Gets called at the end of a epoch."""

--- a/recipes/LibriMix/separation/train.py
+++ b/recipes/LibriMix/separation/train.py
@@ -211,7 +211,7 @@ class Separation(sb.Brain):
             else:
                 self.save_audio(snt_id[0], mixture, targets, predictions)
 
-        return loss.detach()
+        return loss.mean().detach()
 
     def on_stage_end(self, stage, stage_loss, epoch):
         """Gets called at the end of a epoch."""

--- a/recipes/WHAMandWHAMR/separation/train.py
+++ b/recipes/WHAMandWHAMR/separation/train.py
@@ -207,7 +207,7 @@ class Separation(sb.Brain):
             else:
                 self.save_audio(snt_id[0], mixture, targets, predictions)
 
-        return loss.detach()
+        return loss.mean().detach()
 
     def on_stage_end(self, stage, stage_loss, epoch):
         """Gets called at the end of a epoch."""

--- a/recipes/WSJ0Mix/separation/train.py
+++ b/recipes/WSJ0Mix/separation/train.py
@@ -195,7 +195,7 @@ class Separation(sb.Brain):
             else:
                 self.save_audio(snt_id[0], mixture, targets, predictions)
 
-        return loss.detach()
+        return loss.mean().detach()
 
     def on_stage_end(self, stage, stage_loss, epoch):
         """Gets called at the end of a epoch."""


### PR DESCRIPTION
In case of 'batch_size' is not 1, evaluate_batch() returns tensor array (in separation recipes).
It occurs exception in _fit_valid() (https://github.com/speechbrain/speechbrain/issues/988)
So, this commit fixes return values as API reference of [evaluate_batch()](https://speechbrain.readthedocs.io/en/latest/API/speechbrain.core.html#speechbrain.core.Brain.evaluate_batch)

But, I expect there are a lot of same issues in other recipes.
So, I'd like to suggest changing update_average() in core.py.
If 'list of tensors' are allowed to input argument, solution is more simple.