### PR TITLE
fix distributed namespace

### DIFF
--- a/speechbrain/lobes/augment.py
+++ b/speechbrain/lobes/augment.py
@@ -504,7 +504,7 @@ def _prepare_csv(folder, filelist, csv_file, max_length=None):
     """
     try:
         # make sure all processing reached here before main preocess create csv_file
-        sb.distributed.ddp_barrier()
+        sb.utils.distributed.ddp_barrier()
         if sb.utils.distributed.if_main_process():
             with open(csv_file, "w") as w:
                 w.write("ID,duration,wav,wav_format,wav_opts\n\n")

--- a/speechbrain/utils/data_utils.py
+++ b/speechbrain/utils/data_utils.py
@@ -300,7 +300,7 @@ def download_file(
     """
     try:
         # make sure all processing reached here before main preocess create dest_dir
-        sb.distributed.ddp_barrier()
+        sb.utils.distributed.ddp_barrier()
         if sb.utils.distributed.if_main_process():
 
             class DownloadProgressBar(tqdm.tqdm):


### PR DESCRIPTION
Issue resulting from #1536 - the `utils` namespace is missing.

Running the template:
```python train.py tokenizer.yaml```

throws: `AttributeError: module 'speechbrain' has no attribute 'distributed'`

Not catched by our current unit & doc tests.

