### PR TITLE
Fix bugs of update_learning_rate

### DIFF
--- a/speechbrain/nnet/schedulers.py
+++ b/speechbrain/nnet/schedulers.py
@@ -41,6 +41,8 @@ def update_learning_rate(optimizer, new_lr, param_group=None):
     # Iterate all groups if none is provided
     if param_group is None:
         groups = range(len(optimizer.param_groups))
+    else:
+        groups = param_group
 
     for i in groups:
         old_lr = optimizer.param_groups[i]["lr"]


### PR DESCRIPTION
Fix bugs of update_learning_rate, in which param_group doesn't work as expected:
When the input optional param param_group is NOT None, [0] or [0,1] for example, it will throws Exception because of None groups.