### PR TITLE
Fixed output_all_hiddens for hubert in huggingface_wav2vec

### DIFF
--- a/speechbrain/lobes/models/huggingface_wav2vec.py
+++ b/speechbrain/lobes/models/huggingface_wav2vec.py
@@ -289,10 +289,10 @@ class HuggingFaceWav2Vec2(nn.Module):
         out = self.model(wav, output_hidden_states=True)
 
         if self.output_all_hiddens:
-            out = torch.stack(list(out[-1]), dim=0)
+            out = torch.stack(list(out.hidden_states), dim=0)
             norm_shape = out.shape[-3:]
         else:
-            out = out[0]
+            out = out.last_hidden_state
             norm_shape = out.shape
 
         # We normalize the output if required

--- a/speechbrain/lobes/models/huggingface_wav2vec.py
+++ b/speechbrain/lobes/models/huggingface_wav2vec.py
@@ -289,7 +289,7 @@ class HuggingFaceWav2Vec2(nn.Module):
         out = self.model(wav, output_hidden_states=True)
 
         if self.output_all_hiddens:
-            out = torch.stack(list(out[2]), dim=0)
+            out = torch.stack(list(out[-1]), dim=0)
             norm_shape = out.shape[-3:]
         else:
             out = out[0]


### PR DESCRIPTION
I am trying to extract all hidden representations from several HF models using recently implemented in #1570 `output_all_hiddens` property.

Specifically, I used  `source=["facebook/wav2vec2-base", "facebook/hubert-base-ls960", "microsoft/wavlm-base", "microsoft/wavlm-base-plus"]` in `HuggingFaceWav2Vec2` class.

All works good except Hubert where we have `dim(out) = 2` so the code crashes. 

Unlike others, it does not have a 512-dimensional representation in the `out[1]`, which is not used anyway. 

Taking the last dimension for accessing all transformer layers should work for all these models unless I am missing something. 