### PR TITLE
fix endless doctest despite no example

### DIFF
--- a/speechbrain/utils/check_url.py
+++ b/speechbrain/utils/check_url.py
@@ -21,7 +21,7 @@ def get_url(path):
         Path of the file where to search for URLs.
 
     Returns
-    ---------
+    -------
     urls: list
         a list of all the URLs found in the specified path.
     """
@@ -55,7 +55,7 @@ def get_all_urls(file_lst, avoid_urls):
         List of URLs to avoid.
 
     Returns
-    ---------
+    -------
     urls: dict
         A dictionary where the keys are the detected URLs and the values
     are the files where the URLs are found.
@@ -95,7 +95,7 @@ def check_url(url):
         URL to check
 
     Returns
-    ---------
+    -------
     Bool
         False if the URL is broken, True otherwise.
     """
@@ -109,7 +109,7 @@ def check_url(url):
         return False
 
 
-def test_links(
+def check_links(
     folder=".",
     match_or=[".py", ".md", ".txt"],
     exclude_or=[".pyc"],

--- a/tests/.run-url-checks.sh
+++ b/tests/.run-url-checks.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 pip install requests
-python -c 'from speechbrain.utils.check_url import test_links; print("TEST FAILED!") if not(test_links()) else print("TEST PASSED!")'
+python -c 'from speechbrain.utils.check_url import check_links; print("TEST FAILED!") if not(check_links()) else print("TEST PASSED!")'


### PR DESCRIPTION
A recent testing for a PR ran endlessly, and was cancelled after 6h.
see: https://github.com/speechbrain/speechbrain/actions/runs/3175083475/jobs/5182679440

A second re-run took 45min, then I cancelled that workflow, too.
After running doctests locally, it came clear that 
```
pytest --doctest-modules speechbrain/utils/check_url.py
```
caused the issue - BUT - this file does not have any doctest examples !!

When I found this
https://github.com/pytest-dev/pytest/issues/2188#issuecomment-272124937

I checked the file again for anything that could potentially knock off the doctest-module collection and found the function
```python
def test_links
```
-> does it work to simply rename this one?
It did...