### PR TITLE
read_audio fixes and docs cleanup

### DIFF
--- a/speechbrain/dataio/dataio.py
+++ b/speechbrain/dataio/dataio.py
@@ -7,6 +7,7 @@ Authors
  * Ju-Chieh Chou 2020
  * Samuele Cornell 2020
  * Abdel HEBA 2020
+ * Sylvain de Langen 2022
 """
 
 import os

--- a/speechbrain/dataio/dataio.py
+++ b/speechbrain/dataio/dataio.py
@@ -164,26 +164,41 @@ def read_audio(waveforms_obj):
     Expected use case is in conjunction with Datasets
     specified by JSON.
 
-    The custom notation:
+    The parameter may just be a path to a file:
+    `read_audio("/path/to/wav1.wav")`
 
-    The annotation can be just a path to a file:
-    "/path/to/wav1.wav"
+    Alternatively, you can specify more options in a dict, e.g.:
+    ```
+    # load a file from sample 8000 through 15999
+    read_audio({
+        "file": "/path/to/wav2.wav",
+        "start": 8000,
+        "stop": 16000
+    })
+    ```
 
-    Or can specify more options in a dict:
-    {"file": "/path/to/wav2.wav",
-    "start": 8000,
-    "stop": 16000
-    }
+    Which codecs are supported depends on your torchaudio backend.
+    Refer to `torchaudio.load` documentation for further details.
 
     Arguments
     ----------
     waveforms_obj : str, dict
-        Audio reading annotation, see above for format.
+        Path to audio or dict with the desired configuration.
+
+        Keys for the dict variant:
+        - `"file"` (str): Path to the audio file.
+        - `"start"` (int, optional): The first sample to load.
+        If unspecified, load from the very first frame.
+        - `"stop"` (int, optional): The last sample to load (exclusive).
+        If unspecified or equal to start, load from `start` to the end.
+        Will not fail if `stop` is past the sample count of the file and will
+        return less frames.
 
     Returns
     -------
     torch.Tensor
-        Audio tensor with shape: (samples, ).
+        1-channel: audio tensor with shape: `(samples, )`.
+        >=2-channels:, audio tensor with shape: `(samples, channels)`.
 
     Example
     -------
@@ -198,15 +213,37 @@ def read_audio(waveforms_obj):
     """
     if isinstance(waveforms_obj, str):
         audio, _ = torchaudio.load(waveforms_obj)
-        return audio.transpose(0, 1).squeeze(1)
+    else:
+        path = waveforms_obj["file"]
+        start = waveforms_obj.get("start", 0)
+        # To match past SB behavior, `start == stop` or omitted `stop` means to
+        # load all frames from `start` to the file end.
+        stop = waveforms_obj.get("stop", start)
 
-    path = waveforms_obj["file"]
-    start = waveforms_obj.get("start", 0)
-    # Default stop to start -> if not specified, num_frames becomes 0,
-    # which is the torchaudio default
-    stop = waveforms_obj.get("stop", start)
-    num_frames = stop - start
-    audio, fs = torchaudio.load(path, num_frames=num_frames, frame_offset=start)
+        if start < 0:
+            raise ValueError(
+                f"Invalid sample range (start < 0): {start}..{stop}!"
+            )
+
+        if stop < start:
+            # Could occur if the user tried one of two things:
+            # - specify a negative value as an attempt to index from the end;
+            # - specify -1 as an attempt to load up to the last sample.
+            raise ValueError(
+                f"Invalid sample range (stop < start): {start}..{stop}!\n"
+                'Hint: Omit "stop" if you want to read to the end of file.'
+            )
+
+        # Requested to load until a specific frame?
+        if start != stop:
+            num_frames = stop - start
+            audio, fs = torchaudio.load(
+                path, num_frames=num_frames, frame_offset=start
+            )
+        else:
+            # Load to the end.
+            audio, fs = torchaudio.load(path, frame_offset=start)
+
     audio = audio.transpose(0, 1)
     return audio.squeeze(1)
 

--- a/speechbrain/dataio/dataio.py
+++ b/speechbrain/dataio/dataio.py
@@ -198,7 +198,7 @@ def read_audio(waveforms_obj):
     -------
     torch.Tensor
         1-channel: audio tensor with shape: `(samples, )`.
-        >=2-channels:, audio tensor with shape: `(samples, channels)`.
+        >=2-channels: audio tensor with shape: `(samples, channels)`.
 
     Example
     -------

--- a/tests/unittests/test_data_io.py
+++ b/tests/unittests/test_data_io.py
@@ -13,9 +13,29 @@ def test_read_audio(tmpdir, device):
     for i in range(3):
         start = torch.randint(0, 8000, (1,), device=device).item()
         stop = start + torch.randint(500, 1000, (1,), device=device).item()
-        wav_obj = {"wav": {"file": wavfile, "start": start, "stop": stop}}
-        loaded = read_audio(wav_obj["wav"]).to(device)
-        assert loaded.allclose(test_waveform[start:stop], atol=1e-4)
+        
+        loaded_range = read_audio({
+            "file": wavfile,
+            "start": start,
+            "stop": stop
+        }).to(device)
+        assert loaded_range.allclose(test_waveform[start:stop], atol=1e-4)
+
+        loaded_omit_start = read_audio({
+            "file": wavfile,
+            "stop": stop
+        }).to(device)
+        assert loaded_omit_start.allclose(test_waveform[:stop], atol=1e-4)
+
+        loaded_omit_stop = read_audio({
+            "file": wavfile,
+            "start": start
+        }).to(device)
+        assert loaded_omit_stop.allclose(test_waveform[start:], atol=1e-4)
+
+        loaded_simple = read_audio(wavfile).to(device)
+        assert loaded_simple.allclose(test_waveform, atol=1e-4)
+
         # set to equal when switching to the sox_io backend
         # assert torch.all(torch.eq(loaded, test_waveform[0, start:stop]))
 

--- a/tests/unittests/test_data_io.py
+++ b/tests/unittests/test_data_io.py
@@ -13,24 +13,20 @@ def test_read_audio(tmpdir, device):
     for i in range(3):
         start = torch.randint(0, 8000, (1,), device=device).item()
         stop = start + torch.randint(500, 1000, (1,), device=device).item()
-        
-        loaded_range = read_audio({
-            "file": wavfile,
-            "start": start,
-            "stop": stop
-        }).to(device)
+
+        loaded_range = read_audio(
+            {"file": wavfile, "start": start, "stop": stop}
+        ).to(device)
         assert loaded_range.allclose(test_waveform[start:stop], atol=1e-4)
 
-        loaded_omit_start = read_audio({
-            "file": wavfile,
-            "stop": stop
-        }).to(device)
+        loaded_omit_start = read_audio({"file": wavfile, "stop": stop}).to(
+            device
+        )
         assert loaded_omit_start.allclose(test_waveform[:stop], atol=1e-4)
 
-        loaded_omit_stop = read_audio({
-            "file": wavfile,
-            "start": start
-        }).to(device)
+        loaded_omit_stop = read_audio({"file": wavfile, "start": start}).to(
+            device
+        )
         assert loaded_omit_stop.allclose(test_waveform[start:], atol=1e-4)
 
         loaded_simple = read_audio(wavfile).to(device)


### PR DESCRIPTION
When using the `dict` variant of `read_audio`, omitting the `"stop"` key would fail due to a breaking change in torchaudio `0.8.0` (SB currently requires any version newer than `0.9.0`).

While this was undocumented, the code seemed to intend it as possible.

This PR does several things:

- The function was cleaned up, with the call to `torchaudio.load` fixed, keeping backwards-compatibility.
- Added sanity checks, which raise an exception when the start-stop range seems incorrect. Let me know if these are overkill.
- It attempts to improve the documentation for `read_audio` significantly, documenting edge cases and previously undocumented behavior, namely

  - Keys for the dict variant are documented properly, and it is explained which ones are optional.
  - Behavior for multi-channel files is now explained properly.
  - General cleanups and formatting improvements.

Following this PR, all of these now work:

```python
# always has worked
a = read_audio("/path/to/file.wav")

# always has worked
b = read_audio({
    "file": "/path/to/file.wav",
    "start": 8000,
    "stop": 16000
})

# was failing, now works
c = read_audio({
    "file": "/path/to/file.wav"
})

# was failing, now works
d = read_audio({
    "file": "/path/to/file.wav",
    "start": 8000
})
```

Tests were added accordingly.

## Root cause

Previously, the `num_frames` parameter defaulted to `0`, which meant "load from `frame_offset` through the end of file".  
This is not the case anymore: `num_frames` now defaults to `-1`, with the same meaning. However, passing `0` now fails.

## Implementation details

In order to best match the past intended behavior, if `start == stop`, this PR leaves the `num_frames` parameter unspecified, which I feel is more intuitive than the previous code here.
