### PR TITLE
fix LibriSpeech CTC pretrainer

### DIFF
--- a/recipes/LibriSpeech/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/LibriSpeech/ASR/CTC/train_with_wav2vec.py
@@ -350,8 +350,9 @@ if __name__ == "__main__":
     )
 
     # We load the pretrained wav2vec2 model
-    run_on_main(hparams["pretrainer"].collect_files)
-    hparams["pretrainer"].load_collected(asr_brain.device)
+    if "pretrainer" in hparams.keys():
+        run_on_main(hparams["pretrainer"].collect_files)
+        hparams["pretrainer"].load_collected(asr_brain.device)
 
     # We dynamicaly add the tokenizer to our brain class.
     # NB: This tokenizer corresponds to the one used for the LM!!


### PR DESCRIPTION
Hi @TParcollet , this is a fix for the fail I got due to a lack of pretrainer in `train_hf_wav2vec.yaml`, after the modifications from https://github.com/speechbrain/speechbrain/pull/1312