### PR TITLE
Fix documented min python version to 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ SpeechBrain can be installed via PyPI. Moreover,  a local installation can be us
 
 ## Install via PyPI
 
-Once you have created your Python environment (Python 3.8+) you can simply type:
+Once you have created your Python environment (Python 3.7+) you can simply type:
 
 ```
 pip install speechbrain
@@ -178,7 +178,7 @@ import speechbrain as sb
 
 ## Install with GitHub
 
-Once you have created your Python environment (Python 3.8+) you can simply type:
+Once you have created your Python environment (Python 3.7+) you can simply type:
 
 ```
 git clone https://github.com/speechbrain/speechbrain.git

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -50,7 +50,7 @@ These will automatically check the code when you commit and when you push.
 
 ## Python
 ### Version
-SpeechBrain targets Python >= 3.8.
+SpeechBrain targets Python >= 3.7.
 
 ### Formatting
 To settle code formatting, SpeechBrain adopts the [black](https://black.readthedocs.io/en/stable/) code formatter. Before submitting  pull requests, please run the black formatter on your code.


### PR DESCRIPTION
Fixes #1593: The minimal Python version SB targets is 3.7, not 3.8.

Those were the only mentions to 3.8 being the minimal requirement I could find in the codebase. 

FWIW,

- readthedocs is configured for 3.8. I just noticed that TParcollet edited the version there from 3.9 to 3.8 a while back.
- pre-commit checks are run on the CI using 3.8.
- the PyPI publish step is run using 3.8.

Should anything be done about these?