### PR TITLE
Added workaround for CyclicLR saving

### DIFF
--- a/speechbrain/utils/_workarounds.py
+++ b/speechbrain/utils/_workarounds.py
@@ -1,0 +1,33 @@
+"""This module implements some workarounds for dependencies
+
+Authors
+ * Aku Rouhe 2022
+"""
+import torch
+import weakref
+import warnings
+
+WEAKREF_MARKER = "WEAKREF"
+
+
+def _cycliclrsaver(obj, path):
+    state_dict = obj.state_dict()
+    if state_dict.get("_scale_fn_ref") is not None:
+        state_dict["_scale_fn_ref"] = WEAKREF_MARKER
+    torch.save(state_dict, path)
+
+
+def _cycliclrloader(obj, path, end_of_epoch, device=None):
+    del end_of_epoch  # Unused
+    state_dict = torch.load(path, map_location=device)
+    if state_dict.get("_scale_fn_ref") == WEAKREF_MARKER:
+        if not isinstance(obj._scale_fn_ref, weakref.WeakMethod):
+            MSG = "Loading CyclicLR scheduler and the _scale_ref_fn did not exist in instance."
+            MSG += " You did not construct it with the same parameters it was created!"
+            MSG += " Looks like you changed the scale function!"
+            MSG += " If this was not intentional, the scheduler might not work correctly."
+            warnings.warn(MSG)
+    try:
+        obj.load_state_dict(torch.load(path, map_location=device), strict=True)
+    except TypeError:
+        obj.load_state_dict(torch.load(path, map_location=device))

--- a/speechbrain/utils/checkpoints.py
+++ b/speechbrain/utils/checkpoints.py
@@ -58,6 +58,7 @@ import inspect
 import shutil
 import logging
 import warnings
+import speechbrain.utils._workarounds as __wa
 
 logger = logging.getLogger(__name__)
 
@@ -187,6 +188,10 @@ try:
 except ImportError:
     # SentencePiece not loaded, fine!
     pass
+
+# Add workarounds:
+DEFAULT_SAVE_HOOKS[torch.optim.lr_scheduler.CyclicLR] = __wa._cycliclrsaver
+DEFAULT_LOAD_HOOKS[torch.optim.lr_scheduler.CyclicLR] = __wa._cycliclrloader
 
 
 def mark_as_saver(method):


### PR DESCRIPTION
Adds special saver/loader for CyclicLR since they have weakref.WeakMethods, which cannnot be pickled. Fortunately, those are not really state that gets updated during training, but rather they are reconstructed if the new instance is created with the same arguments (i.e. no custom scale function suddenly). Trying to detect this anyway, but only raise a warning - maybe users know what they are doing.