### PR TITLE
[FIX] Flush gradients and save memory for validation.

### DIFF
--- a/recipes/AISHELL-1/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/AISHELL-1/ASR/CTC/train_with_wav2vec.py
@@ -109,7 +109,9 @@ class ASR(sb.Brain):
                 self.wav2vec_optimizer.step()
             self.model_optimizer.step()
 
-        self.zero_grad()
+        if not self.hparams.wav2vec2.freeze:
+            self.wav2vec_optimizer.zero_grad()
+        self.model_optimizer.zero_grad()
 
         return loss.detach()
 

--- a/recipes/AISHELL-1/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/AISHELL-1/ASR/CTC/train_with_wav2vec.py
@@ -109,9 +109,7 @@ class ASR(sb.Brain):
                 self.wav2vec_optimizer.step()
             self.model_optimizer.step()
 
-        if not self.hparams.wav2vec2.freeze:
-            self.wav2vec_optimizer.zero_grad()
-        self.model_optimizer.zero_grad()
+        self.zero_grad()
 
         return loss.detach()
 
@@ -191,6 +189,11 @@ class ASR(sb.Brain):
 
         if self.checkpointer is not None:
             self.checkpointer.add_recoverable("modelopt", self.model_optimizer)
+
+    def zero_grad(self, set_to_none=False):
+        if not self.hparams.wav2vec2.freeze:
+            self.wav2vec_optimizer.zero_grad(set_to_none)
+        self.model_optimizer.zero_grad(set_to_none)
 
 
 def dataio_prepare(hparams):

--- a/recipes/AISHELL-1/ASR/transformer/train_with_wav2vect.py
+++ b/recipes/AISHELL-1/ASR/transformer/train_with_wav2vect.py
@@ -134,8 +134,7 @@ class ASR(sb.core.Brain):
 
             self.optimizer.step()
             self.optimizer_wav2vect.step()
-            self.optimizer.zero_grad()
-            self.optimizer_wav2vect.zero_grad()
+            self.zero_grad()
 
             # anneal lr every update
             self.hparams.noam_annealing(self.optimizer)
@@ -288,6 +287,10 @@ class ASR(sb.core.Brain):
                 "wav2vec_opt", self.optimizer_wav2vect
             )
             self.checkpointer.add_recoverable("modelopt", self.optimizer)
+
+    def zero_grad(self, set_to_none=False):
+        self.optimizer_wav2vect.zero_grad(set_to_none)
+        self.optimizer.zero_grad(set_to_none)
 
 
 def dataio_prepare(hparams):

--- a/recipes/AISHELL-1/ASR/transformer/train_with_wav2vect.py
+++ b/recipes/AISHELL-1/ASR/transformer/train_with_wav2vect.py
@@ -134,7 +134,8 @@ class ASR(sb.core.Brain):
 
             self.optimizer.step()
             self.optimizer_wav2vect.step()
-            self.zero_grad()
+            self.optimizer.zero_grad()
+            self.optimizer_wav2vect.zero_grad()
 
             # anneal lr every update
             self.hparams.noam_annealing(self.optimizer)

--- a/recipes/CommonVoice/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/CommonVoice/ASR/CTC/train_with_wav2vec.py
@@ -90,7 +90,9 @@ class ASR(sb.core.Brain):
         """Train the parameters given a single batch in input"""
         if self.auto_mix_prec:
 
-            self.zero_grad()
+            if not self.hparams.wav2vec2.freeze:
+                self.wav2vec_optimizer.zero_grad()
+            self.model_optimizer.zero_grad()
 
             with torch.cuda.amp.autocast():
                 outputs = self.compute_forward(batch, sb.Stage.TRAIN)
@@ -118,7 +120,9 @@ class ASR(sb.core.Brain):
                     self.wav2vec_optimizer.step()
                 self.model_optimizer.step()
 
-            self.zero_grad()
+            if not self.hparams.wav2vec2.freeze:
+                self.wav2vec_optimizer.zero_grad()
+            self.model_optimizer.zero_grad()
 
         return loss.detach()
 

--- a/recipes/CommonVoice/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/CommonVoice/ASR/CTC/train_with_wav2vec.py
@@ -90,9 +90,7 @@ class ASR(sb.core.Brain):
         """Train the parameters given a single batch in input"""
         if self.auto_mix_prec:
 
-            if not self.hparams.wav2vec2.freeze:
-                self.wav2vec_optimizer.zero_grad()
-            self.model_optimizer.zero_grad()
+            self.zero_grad()
 
             with torch.cuda.amp.autocast():
                 outputs = self.compute_forward(batch, sb.Stage.TRAIN)
@@ -120,9 +118,7 @@ class ASR(sb.core.Brain):
                     self.wav2vec_optimizer.step()
                 self.model_optimizer.step()
 
-            if not self.hparams.wav2vec2.freeze:
-                self.wav2vec_optimizer.zero_grad()
-            self.model_optimizer.zero_grad()
+            self.zero_grad()
 
         return loss.detach()
 
@@ -203,6 +199,11 @@ class ASR(sb.core.Brain):
 
         if self.checkpointer is not None:
             self.checkpointer.add_recoverable("modelopt", self.model_optimizer)
+
+    def zero_grad(self, set_to_none=False):
+        if not self.hparams.wav2vec2.freeze:
+            self.wav2vec_optimizer.zero_grad(set_to_none)
+        self.model_optimizer.zero_grad(set_to_none)
 
 
 # Define custom data procedure

--- a/recipes/CommonVoice/ASR/seq2seq/train_with_wav2vec.py
+++ b/recipes/CommonVoice/ASR/seq2seq/train_with_wav2vec.py
@@ -128,9 +128,7 @@ class ASR(sb.core.Brain):
         """Train the parameters given a single batch in input"""
         if self.auto_mix_prec:
 
-            if not self.hparams.wav2vec2.freeze:
-                self.wav2vec_optimizer.zero_grad()
-            self.model_optimizer.zero_grad()
+            self.zero_grad()
 
             with torch.cuda.amp.autocast():
                 outputs = self.compute_forward(batch, sb.Stage.TRAIN)
@@ -158,9 +156,7 @@ class ASR(sb.core.Brain):
                     self.wav2vec_optimizer.step()
                 self.model_optimizer.step()
 
-            if not self.hparams.wav2vec2.freeze:
-                self.wav2vec_optimizer.zero_grad()
-            self.model_optimizer.zero_grad()
+            self.zero_grad()
 
         return loss.detach()
 
@@ -238,6 +234,11 @@ class ASR(sb.core.Brain):
 
         if self.checkpointer is not None:
             self.checkpointer.add_recoverable("modelopt", self.model_optimizer)
+
+    def zero_grad(self, set_to_none=False):
+        self.model_optimizer.zero_grad(set_to_none)
+        if not self.hparams.wav2vec2.freeze:
+            self.wav2vec_optimizer.zero_grad(set_to_none)
 
 
 # Define custom data procedure

--- a/recipes/CommonVoice/ASR/seq2seq/train_with_wav2vec.py
+++ b/recipes/CommonVoice/ASR/seq2seq/train_with_wav2vec.py
@@ -128,7 +128,9 @@ class ASR(sb.core.Brain):
         """Train the parameters given a single batch in input"""
         if self.auto_mix_prec:
 
-            self.zero_grad()
+            if not self.hparams.wav2vec2.freeze:
+                self.wav2vec_optimizer.zero_grad()
+            self.model_optimizer.zero_grad()
 
             with torch.cuda.amp.autocast():
                 outputs = self.compute_forward(batch, sb.Stage.TRAIN)
@@ -156,7 +158,9 @@ class ASR(sb.core.Brain):
                     self.wav2vec_optimizer.step()
                 self.model_optimizer.step()
 
-            self.zero_grad()
+            if not self.hparams.wav2vec2.freeze:
+                self.wav2vec_optimizer.zero_grad()
+            self.model_optimizer.zero_grad()
 
         return loss.detach()
 

--- a/recipes/DVoice/ASR/CTC/train_with_wav2vec2.py
+++ b/recipes/DVoice/ASR/CTC/train_with_wav2vec2.py
@@ -90,7 +90,9 @@ class ASR(sb.core.Brain):
         """Train the parameters given a single batch in input"""
         if self.auto_mix_prec:
 
-            self.zero_grad()
+            if not self.hparams.wav2vec2.freeze:
+                self.wav2vec_optimizer.zero_grad()
+            self.model_optimizer.zero_grad()
 
             with torch.cuda.amp.autocast():
                 outputs = self.compute_forward(batch, sb.Stage.TRAIN)
@@ -118,7 +120,9 @@ class ASR(sb.core.Brain):
                     self.wav2vec_optimizer.step()
                 self.model_optimizer.step()
 
-            self.zero_grad()
+            if not self.hparams.wav2vec2.freeze:
+                self.wav2vec_optimizer.zero_grad()
+            self.model_optimizer.zero_grad()
 
         return loss.detach()
 

--- a/recipes/DVoice/ASR/CTC/train_with_wav2vec2.py
+++ b/recipes/DVoice/ASR/CTC/train_with_wav2vec2.py
@@ -90,9 +90,7 @@ class ASR(sb.core.Brain):
         """Train the parameters given a single batch in input"""
         if self.auto_mix_prec:
 
-            if not self.hparams.wav2vec2.freeze:
-                self.wav2vec_optimizer.zero_grad()
-            self.model_optimizer.zero_grad()
+            self.zero_grad()
 
             with torch.cuda.amp.autocast():
                 outputs = self.compute_forward(batch, sb.Stage.TRAIN)
@@ -120,9 +118,7 @@ class ASR(sb.core.Brain):
                     self.wav2vec_optimizer.step()
                 self.model_optimizer.step()
 
-            if not self.hparams.wav2vec2.freeze:
-                self.wav2vec_optimizer.zero_grad()
-            self.model_optimizer.zero_grad()
+            self.zero_grad()
 
         return loss.detach()
 
@@ -203,6 +199,11 @@ class ASR(sb.core.Brain):
 
         if self.checkpointer is not None:
             self.checkpointer.add_recoverable("modelopt", self.model_optimizer)
+
+    def zero_grad(self, set_to_none=False):
+        if not self.hparams.wav2vec2.freeze:
+            self.wav2vec_optimizer.zero_grad(set_to_none)
+        self.model_optimizer.zero_grad(set_to_none)
 
 
 # Define custom data procedure

--- a/recipes/IEMOCAP/emotion_recognition/train_with_wav2vec2.py
+++ b/recipes/IEMOCAP/emotion_recognition/train_with_wav2vec2.py
@@ -57,7 +57,8 @@ class EmoIdBrain(sb.Brain):
             self.wav2vec2_optimizer.step()
             self.optimizer.step()
 
-        self.zero_grad()
+        self.wav2vec2_optimizer.zero_grad()
+        self.optimizer.zero_grad()
 
         return loss.detach()
 

--- a/recipes/IEMOCAP/emotion_recognition/train_with_wav2vec2.py
+++ b/recipes/IEMOCAP/emotion_recognition/train_with_wav2vec2.py
@@ -57,8 +57,7 @@ class EmoIdBrain(sb.Brain):
             self.wav2vec2_optimizer.step()
             self.optimizer.step()
 
-        self.wav2vec2_optimizer.zero_grad()
-        self.optimizer.zero_grad()
+        self.zero_grad()
 
         return loss.detach()
 
@@ -151,6 +150,10 @@ class EmoIdBrain(sb.Brain):
                 "wav2vec2_opt", self.wav2vec2_optimizer
             )
             self.checkpointer.add_recoverable("optimizer", self.optimizer)
+
+    def zero_grad(self, set_to_none=False):
+        self.wav2vec2_optimizer.zero_grad(set_to_none)
+        self.optimizer.zero_grad(set_to_none)
 
 
 def dataio_prep(hparams):

--- a/recipes/IWSLT22_lowresource/train.py
+++ b/recipes/IWSLT22_lowresource/train.py
@@ -113,7 +113,9 @@ class ST(sb.core.Brain):
                 self.wav2vec_optimizer.step()
             self.adam_optimizer.step()
 
-        self.zero_grad()
+        if not self.hparams.wav2vec2_frozen:
+            self.wav2vec_optimizer.zero_grad()
+        self.adam_optimizer.zero_grad()
 
         return loss.detach().cpu()
 

--- a/recipes/IWSLT22_lowresource/train.py
+++ b/recipes/IWSLT22_lowresource/train.py
@@ -97,6 +97,11 @@ class ST(sb.core.Brain):
             self.hparams.model.parameters()
         )
 
+    def zero_grad(self, set_to_none=False):
+        if not self.hparams.wav2vec2_frozen:
+            self.wav2vec_optimizer.zero_grad(set_to_none)
+        self.adam_optimizer.zero_grad(set_to_none)
+
     def fit_batch(self, batch):
         """Train the parameters given a single batch in input"""
         predictions = self.compute_forward(batch, sb.Stage.TRAIN)
@@ -108,9 +113,7 @@ class ST(sb.core.Brain):
                 self.wav2vec_optimizer.step()
             self.adam_optimizer.step()
 
-        if not self.hparams.wav2vec2_frozen:
-            self.wav2vec_optimizer.zero_grad()
-        self.adam_optimizer.zero_grad()
+        self.zero_grad()
 
         return loss.detach().cpu()
 

--- a/recipes/LJSpeech/TTS/vocoder/hifi_gan/train.py
+++ b/recipes/LJSpeech/TTS/vocoder/hifi_gan/train.py
@@ -153,6 +153,11 @@ class HifiGanBrain(sb.Brain):
                     "scheduler_d", self.scheduler_d
                 )
 
+    def zero_grad(self, set_to_none=False):
+        if self.opt_class is not None:
+            self.optimizer_g.zero_grad(set_to_none)
+            self.optimizer_d.zero_grad(set_to_none)
+
     def _remember_sample(self, batch, predictions):
         """Remembers samples of spectrograms and the batch for logging purposes
 

--- a/recipes/LibriSpeech/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/LibriSpeech/ASR/CTC/train_with_wav2vec.py
@@ -103,8 +103,7 @@ class ASR(sb.Brain):
 
         # Managing automatic mixed precision
         if self.auto_mix_prec:
-            self.wav2vec_optimizer.zero_grad()
-            self.model_optimizer.zero_grad()
+            self.zero_grad()
             with torch.cuda.amp.autocast():
                 outputs = self.compute_forward(batch, sb.Stage.TRAIN)
             loss = self.compute_objectives(outputs, batch, sb.Stage.TRAIN)
@@ -125,8 +124,7 @@ class ASR(sb.Brain):
                 if self.check_gradients(loss):
                     self.wav2vec_optimizer.step()
                     self.model_optimizer.step()
-                self.wav2vec_optimizer.zero_grad()
-                self.model_optimizer.zero_grad()
+                self.zero_grad()
                 self.optimizer_step += 1
 
         return loss.detach().cpu()
@@ -203,6 +201,10 @@ class ASR(sb.Brain):
                 "wav2vec_opt", self.wav2vec_optimizer
             )
             self.checkpointer.add_recoverable("modelopt", self.model_optimizer)
+
+    def zero_grad(self, set_to_none=False):
+        self.wav2vec_optimizer.zero_grad(set_to_none)
+        self.model_optimizer.zero_grad(set_to_none)
 
 
 def dataio_prepare(hparams):

--- a/recipes/LibriSpeech/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/LibriSpeech/ASR/CTC/train_with_wav2vec.py
@@ -103,7 +103,8 @@ class ASR(sb.Brain):
 
         # Managing automatic mixed precision
         if self.auto_mix_prec:
-            self.zero_grad()
+            self.wav2vec_optimizer.zero_grad()
+            self.model_optimizer.zero_grad()
             with torch.cuda.amp.autocast():
                 outputs = self.compute_forward(batch, sb.Stage.TRAIN)
             loss = self.compute_objectives(outputs, batch, sb.Stage.TRAIN)
@@ -124,7 +125,8 @@ class ASR(sb.Brain):
                 if self.check_gradients(loss):
                     self.wav2vec_optimizer.step()
                     self.model_optimizer.step()
-                self.zero_grad()
+                self.wav2vec_optimizer.zero_grad()
+                self.model_optimizer.zero_grad()
                 self.optimizer_step += 1
 
         return loss.detach().cpu()

--- a/recipes/SLURP/direct/train_with_wav2vec2.py
+++ b/recipes/SLURP/direct/train_with_wav2vec2.py
@@ -145,7 +145,8 @@ class SLU(sb.Brain):
         if self.check_gradients(loss):
             self.wav2vec2_optimizer.step()
             self.optimizer.step()
-        self.zero_grad()
+        self.wav2vec2_optimizer.zero_grad()
+        self.optimizer.zero_grad()
         self.batch_count += 1
         return loss.detach()
 

--- a/recipes/SLURP/direct/train_with_wav2vec2.py
+++ b/recipes/SLURP/direct/train_with_wav2vec2.py
@@ -145,8 +145,7 @@ class SLU(sb.Brain):
         if self.check_gradients(loss):
             self.wav2vec2_optimizer.step()
             self.optimizer.step()
-        self.wav2vec2_optimizer.zero_grad()
-        self.optimizer.zero_grad()
+        self.zero_grad()
         self.batch_count += 1
         return loss.detach()
 
@@ -218,6 +217,10 @@ class SLU(sb.Brain):
                 "wav2vec2_opt", self.wav2vec2_optimizer
             )
             self.checkpointer.add_recoverable("optimizer", self.optimizer)
+
+    def zero_grad(self, set_to_none=False):
+        self.wav2vec2_optimizer.zero_grad(set_to_none)
+        self.optimizer.zero_grad(set_to_none)
 
 
 def dataio_prepare(hparams):

--- a/recipes/TIMIT/ASR/seq2seq/train_with_wav2vec2.py
+++ b/recipes/TIMIT/ASR/seq2seq/train_with_wav2vec2.py
@@ -179,7 +179,8 @@ class ASR(sb.Brain):
         # Managing automatic mixed precision
         if self.auto_mix_prec:
 
-            self.zero_grad()
+            self.wav2vec_optimizer.zero_grad()
+            self.adam_optimizer.zero_grad()
 
             with torch.cuda.amp.autocast():
                 outputs = self.compute_forward(batch, sb.Stage.TRAIN)
@@ -204,7 +205,8 @@ class ASR(sb.Brain):
                 self.wav2vec_optimizer.step()
                 self.adam_optimizer.step()
 
-            self.zero_grad()
+            self.wav2vec_optimizer.zero_grad()
+            self.adam_optimizer.zero_grad()
 
         return loss.detach().cpu()
 

--- a/recipes/TIMIT/ASR/seq2seq/train_with_wav2vec2.py
+++ b/recipes/TIMIT/ASR/seq2seq/train_with_wav2vec2.py
@@ -179,8 +179,7 @@ class ASR(sb.Brain):
         # Managing automatic mixed precision
         if self.auto_mix_prec:
 
-            self.wav2vec_optimizer.zero_grad()
-            self.adam_optimizer.zero_grad()
+            self.zero_grad()
 
             with torch.cuda.amp.autocast():
                 outputs = self.compute_forward(batch, sb.Stage.TRAIN)
@@ -205,8 +204,7 @@ class ASR(sb.Brain):
                 self.wav2vec_optimizer.step()
                 self.adam_optimizer.step()
 
-            self.wav2vec_optimizer.zero_grad()
-            self.adam_optimizer.zero_grad()
+            self.zero_grad()
 
         return loss.detach().cpu()
 
@@ -224,6 +222,10 @@ class ASR(sb.Brain):
                 "wav2vec_opt", self.wav2vec_optimizer
             )
             self.checkpointer.add_recoverable("adam_opt", self.adam_optimizer)
+
+    def zero_grad(self, set_to_none=False):
+        self.wav2vec_optimizer.zero_grad(set_to_none)
+        self.adam_optimizer.zero_grad(set_to_none)
 
 
 def dataio_prep(hparams):

--- a/recipes/TIMIT/ASR/transducer/train_wav2vec.py
+++ b/recipes/TIMIT/ASR/transducer/train_wav2vec.py
@@ -169,8 +169,7 @@ class ASR_Brain(sb.Brain):
         # Managing automatic mixed precision
         if self.auto_mix_prec:
 
-            self.wav2vec_optimizer.zero_grad()
-            self.adam_optimizer.zero_grad()
+            self.zero_grad()
 
             with torch.cuda.amp.autocast():
                 outputs = self.compute_forward(batch, sb.Stage.TRAIN)
@@ -195,8 +194,7 @@ class ASR_Brain(sb.Brain):
                 self.wav2vec_optimizer.step()
                 self.adam_optimizer.step()
 
-            self.wav2vec_optimizer.zero_grad()
-            self.adam_optimizer.zero_grad()
+            self.zero_grad()
 
         return loss.detach()
 
@@ -214,6 +212,10 @@ class ASR_Brain(sb.Brain):
                 "wav2vec_opt", self.wav2vec_optimizer
             )
             self.checkpointer.add_recoverable("adam_opt", self.adam_optimizer)
+
+    def zero_grad(self, set_to_none=False):
+        self.wav2vec_optimizer.zero_grad(set_to_none)
+        self.adam_optimizer.zero_grad(set_to_none)
 
 
 def dataio_prep(hparams):

--- a/recipes/TIMIT/ASR/transducer/train_wav2vec.py
+++ b/recipes/TIMIT/ASR/transducer/train_wav2vec.py
@@ -169,7 +169,8 @@ class ASR_Brain(sb.Brain):
         # Managing automatic mixed precision
         if self.auto_mix_prec:
 
-            self.zero_grad()
+            self.wav2vec_optimizer.zero_grad()
+            self.adam_optimizer.zero_grad()
 
             with torch.cuda.amp.autocast():
                 outputs = self.compute_forward(batch, sb.Stage.TRAIN)
@@ -194,7 +195,8 @@ class ASR_Brain(sb.Brain):
                 self.wav2vec_optimizer.step()
                 self.adam_optimizer.step()
 
-            self.zero_grad()
+            self.wav2vec_optimizer.zero_grad()
+            self.adam_optimizer.zero_grad()
 
         return loss.detach()
 

--- a/recipes/Voicebank/dereverb/MetricGAN-U/train.py
+++ b/recipes/Voicebank/dereverb/MetricGAN-U/train.py
@@ -650,6 +650,10 @@ class MetricGanBrain(sb.Brain):
             self.checkpointer.add_recoverable("g_opt", self.g_optimizer)
             self.checkpointer.add_recoverable("d_opt", self.d_optimizer)
 
+    def zero_grad(self, set_to_none=False):
+        self.g_optimizer.zero_grad(set_to_none)
+        self.d_optimizer.zero_grad(set_to_none)
+
 
 # Define audio piplines for training set
 @sb.utils.data_pipeline.takes("noisy_wav")

--- a/recipes/Voicebank/enhance/MetricGAN-U/train.py
+++ b/recipes/Voicebank/enhance/MetricGAN-U/train.py
@@ -640,6 +640,10 @@ class MetricGanBrain(sb.Brain):
             self.checkpointer.add_recoverable("g_opt", self.g_optimizer)
             self.checkpointer.add_recoverable("d_opt", self.d_optimizer)
 
+    def zero_grad(self, set_to_none=False):
+        self.g_optimizer.zero_grad(set_to_none)
+        self.d_optimizer.zero_grad(set_to_none)
+
 
 # Define audio piplines for training set
 @sb.utils.data_pipeline.takes("noisy_wav")

--- a/recipes/Voicebank/enhance/MetricGAN/train.py
+++ b/recipes/Voicebank/enhance/MetricGAN/train.py
@@ -489,6 +489,10 @@ class MetricGanBrain(sb.Brain):
             self.checkpointer.add_recoverable("g_opt", self.g_optimizer)
             self.checkpointer.add_recoverable("d_opt", self.d_optimizer)
 
+    def zero_grad(self, set_to_none=False):
+        self.g_optimizer.zero_grad(set_to_none)
+        self.d_optimizer.zero_grad(set_to_none)
+
 
 # Define audio piplines
 @sb.utils.data_pipeline.takes("noisy_wav", "clean_wav")

--- a/recipes/Voicebank/enhance/SEGAN/train.py
+++ b/recipes/Voicebank/enhance/SEGAN/train.py
@@ -310,6 +310,10 @@ class SEBrain(sb.Brain):
                     "optimizer_d", self.optimizer_d
                 )
 
+    def zero_grad(self, set_to_none=False):
+        self.optimizer_d.zero_grad(set_to_none)
+        self.optimizer_g.zero_grad(set_to_none)
+
     def on_stage_start(self, stage, epoch=None):
         """Gets called at the beginning of each epoch"""
         self.loss_metric_d1 = MetricStats(

--- a/recipes/timers-and-such/direct/train_with_wav2vec2.py
+++ b/recipes/timers-and-such/direct/train_with_wav2vec2.py
@@ -118,8 +118,7 @@ class SLU(sb.Brain):
             self.wav2vec2_optimizer.step()
             self.optimizer.step()
 
-        self.wav2vec2_optimizer.zero_grad()
-        self.optimizer.zero_grad()
+        self.zero_grad()
         self.batch_count += 1
         return loss.detach()
 
@@ -194,6 +193,10 @@ class SLU(sb.Brain):
                 "wav2vec2_opt", self.wav2vec2_optimizer
             )
             self.checkpointer.add_recoverable("optimizer", self.optimizer)
+
+    def zero_grad(self, set_to_none=False):
+        self.wav2vec2_optimizer.zero_grad(set_to_none)
+        self.optimizer.zero_grad(set_to_none)
 
 
 def dataio_prepare(hparams):

--- a/recipes/timers-and-such/direct/train_with_wav2vec2.py
+++ b/recipes/timers-and-such/direct/train_with_wav2vec2.py
@@ -118,7 +118,8 @@ class SLU(sb.Brain):
             self.wav2vec2_optimizer.step()
             self.optimizer.step()
 
-        self.zero_grad()
+        self.wav2vec2_optimizer.zero_grad()
+        self.optimizer.zero_grad()
         self.batch_count += 1
         return loss.detach()
 

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -822,7 +822,7 @@ class Brain:
         if ``set_to_none=False`` (default) or to None otherwise.
 
         Setting gradients to None should save the memory, e.g.
-        during ``evaluate()`` and thus larger batch might be used
+        during ``evaluate()`` and thus larger batch might be used.
         """
         if hasattr(self, "optimizer"):
             self.optimizer.zero_grad(set_to_none)

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -818,8 +818,11 @@ class Brain:
                 self.checkpointer.add_recoverable("optimizer", self.optimizer)
 
     def zero_grad(self, set_to_none=False):
-        """Sets the gradients of all optimized `torch.Tensor`s to zero
-        if `set_to_none=False` (default) or to `None` otherwise.
+        """Sets the gradients of all optimized ``torch.Tensor``s to zero
+        if ``set_to_none=False`` (default) or to None otherwise.
+
+        Setting gradients to None should save the memory, e.g.
+        during ``evaluate()`` and thus larger batch might be used
         """
         if hasattr(self, "optimizer"):
             self.optimizer.zero_grad(set_to_none)

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -817,6 +817,10 @@ class Brain:
             if self.checkpointer is not None:
                 self.checkpointer.add_recoverable("optimizer", self.optimizer)
 
+    def zero_grad(self, set_to_none=False):
+        if hasattr(self, "optimizer"):
+            self.optimizer.zero_grad(set_to_none)
+
     def on_evaluate_start(self, max_key=None, min_key=None):
         """Gets called at the beginning of ``evaluate()``
 
@@ -984,8 +988,8 @@ class Brain:
     def _fit_train(self, train_set, epoch, enable):
         # Training stage
         self.on_stage_start(Stage.TRAIN, epoch)
-        self.optimizer.zero_grad()
         self.modules.train()
+        self.zero_grad()
 
         # Reset nonfinite count to 0 each epoch
         self.nonfinite_count = 0
@@ -1041,9 +1045,7 @@ class Brain:
                     last_ckpt_time = time.time()
 
         # Run train "on_stage_end" on all processes
-        self.optimizer.zero_grad(
-            set_to_none=True
-        )  # flush gradients and save mem
+        self.zero_grad(set_to_none=True)  # flush gradients
         self.on_stage_end(Stage.TRAIN, self.avg_train_loss, epoch)
         self.avg_train_loss = 0.0
         self.step = 0

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -865,7 +865,6 @@ class Brain:
         should_step = self.step % self.grad_accumulation_factor == 0
         # Managing automatic mixed precision
         if self.auto_mix_prec:
-            self.optimizer.zero_grad()
             with torch.cuda.amp.autocast():
                 outputs = self.compute_forward(batch, Stage.TRAIN)
                 loss = self.compute_objectives(outputs, batch, Stage.TRAIN)
@@ -878,6 +877,7 @@ class Brain:
                 if self.check_gradients(loss):
                     self.scaler.step(self.optimizer)
                 self.scaler.update()
+                self.optimizer.zero_grad()
                 self.optimizer_step += 1
         else:
             outputs = self.compute_forward(batch, Stage.TRAIN)

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -887,7 +887,7 @@ class Brain:
                 if self.check_gradients(loss):
                     self.scaler.step(self.optimizer)
                 self.scaler.update()
-                self.optimizer.zero_grad()
+                self.zero_grad()
                 self.optimizer_step += 1
         else:
             outputs = self.compute_forward(batch, Stage.TRAIN)
@@ -897,7 +897,7 @@ class Brain:
             if should_step:
                 if self.check_gradients(loss):
                     self.optimizer.step()
-                self.optimizer.zero_grad()
+                self.zero_grad()
                 self.optimizer_step += 1
 
         self.on_fit_batch_end(batch, outputs, loss, should_step)

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -358,7 +358,7 @@ class Brain:
         These modules are passed to the optimizer by default if they have
         trainable parameters, and will have ``train()``/``eval()`` called on them.
     opt_class : torch.optim class
-        A torch optimizer constructor that has takes only the list of
+        A torch optimizer constructor that takes only the list of
         parameters (e.g. a lambda or partial function definition). By default,
         this will be passed all modules in ``modules`` at the
         beginning of the ``fit()`` method. This behavior can be changed
@@ -984,6 +984,7 @@ class Brain:
     def _fit_train(self, train_set, epoch, enable):
         # Training stage
         self.on_stage_start(Stage.TRAIN, epoch)
+        self.optimizer.zero_grad()
         self.modules.train()
 
         # Reset nonfinite count to 0 each epoch
@@ -1040,6 +1041,7 @@ class Brain:
                     last_ckpt_time = time.time()
 
         # Run train "on_stage_end" on all processes
+        self.optimizer.zero_grad(set_to_none=True)  # flush gradients and save mem
         self.on_stage_end(Stage.TRAIN, self.avg_train_loss, epoch)
         self.avg_train_loss = 0.0
         self.step = 0

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -818,6 +818,9 @@ class Brain:
                 self.checkpointer.add_recoverable("optimizer", self.optimizer)
 
     def zero_grad(self, set_to_none=False):
+        """Sets the gradients of all optimized `torch.Tensor`s to zero
+        if `set_to_none=False` (default) or to `None` otherwise.
+        """
         if hasattr(self, "optimizer"):
             self.optimizer.zero_grad(set_to_none)
 

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -1041,7 +1041,9 @@ class Brain:
                     last_ckpt_time = time.time()
 
         # Run train "on_stage_end" on all processes
-        self.optimizer.zero_grad(set_to_none=True)  # flush gradients and save mem
+        self.optimizer.zero_grad(
+            set_to_none=True
+        )  # flush gradients and save mem
         self.on_stage_end(Stage.TRAIN, self.avg_train_loss, epoch)
         self.avg_train_loss = 0.0
         self.step = 0

--- a/tests/integration/enhance_GAN/example_enhance_gan_experiment.py
+++ b/tests/integration/enhance_GAN/example_enhance_gan_experiment.py
@@ -97,6 +97,11 @@ class EnhanceGanBrain(sb.Brain):
             self.modules.discriminator.parameters()
         )
 
+    def zero_grad(self, set_to_none=False):
+        """Sets the gradients of all optimized `torch.Tensor`s to zero."""
+        self.g_optimizer.zero_grad(set_to_none)
+        self.d_optimizer.zero_grad(set_to_none)
+
 
 def data_prep(data_folder):
     "Creates the datasets and their data processing pipelines."


### PR DESCRIPTION
When `fit_train` is done we should call optimizer.zero_grad(set_to_none=True) , which should force to clear the gradients from memory. In the current version of the code, the `optimizer.zero_grad()`  is the last call, which however store zeros in memory.
This minor change should allow to use bigger batch during `_fit_valid`  or `evaluate` and thus speed-it up. This is especially useful, when you use large models like SepFormer with significant memory footprint.

More details can be found in [this PyTorch Tuning Guide](https://pytorch.org/tutorials/recipes/recipes/tuning_guide.html#use-parameter-grad-none-instead-of-model-zero-grad-or-optimizer-zero-grad).