### PR TITLE
BinaryMetricStats can score time-variable samples _ small VAD recipe fixes

### DIFF
--- a/recipes/LibriParty/VAD/hparams/train.yaml
+++ b/recipes/LibriParty/VAD/hparams/train.yaml
@@ -39,6 +39,7 @@ skip_prep: False # Skip data preparation
 
 # Training parameters
 N_epochs: 100
+N_workers: 2
 lr: 1.0
 lr_final: 0.1
 batch_size: 2
@@ -47,10 +48,13 @@ sample_rate: 16000
 time_resolution: 0.01 # in seconds
 train_dataloader_opts:
     batch_size: !ref <batch_size>
+    num_workers: !ref <N_workers>
 valid_dataloader_opts:
     batch_size: !ref <batch_size>
+    num_workers: !ref <N_workers>
 test_dataloader_opts:
     batch_size: !ref <batch_size>
+    num_workers: !ref <N_workers>
 
 # Feature parameters
 n_fft: 400

--- a/recipes/LibriParty/VAD/libriparty_prepare.py
+++ b/recipes/LibriParty/VAD/libriparty_prepare.py
@@ -49,7 +49,9 @@ def clean_dataframe(df):
     )
 
     # Sort by start/stop
-    df = df.groupby("session_id").apply(lambda x: x.sort_values("start"))
+    df = df.groupby("session_id", group_keys=False).apply(
+        lambda x: x.sort_values("start")
+    )
     df = pd.melt(df, id_vars=["session_id", "start"])
     df.drop(["variable"], axis=1, inplace=True)
     df.rename({"value": "stop"}, axis=1, inplace=True)
@@ -59,6 +61,7 @@ def clean_dataframe(df):
 def create_dataframe(df, json):
     sessions = list(json.keys())
     session_id = 0
+    records_lst = []
     for session in sessions:
         sub_section = list(json[session].keys())
         for sub in sub_section:
@@ -67,9 +70,10 @@ def create_dataframe(df, json):
                 for i in range(length):
                     temp_dict = json[session][sub][i]
                     temp_dict["session_id"] = session_id
-                    df = df.append([temp_dict])
+                    records_lst.append(temp_dict)
         session_id += 1
 
+    df = pd.concat([df, pd.DataFrame(records_lst)])
     df = clean_dataframe(df)
     return df
 

--- a/speechbrain/utils/metric_stats.py
+++ b/speechbrain/utils/metric_stats.py
@@ -384,8 +384,8 @@ class BinaryMetricStats(MetricStats):
         """
 
         if isinstance(self.scores, list):
-            self.scores = torch.stack(self.scores)
-            self.labels = torch.stack(self.labels)
+            self.scores = torch.cat(self.scores)
+            self.labels = torch.cat(self.labels)
 
         if threshold is None:
             positive_scores = self.scores[


### PR DESCRIPTION
`speechbrain.metric_stats.BinaryMetricStats`:
-   fixed issue score with time-variable samples 

`recipes.LibriParty.VAD`:
  - fix FutureWarnings
  - added the number of workers to hparam file (Dataloaders)