### PR TITLE
loss must be avg when BS>1 when calling evaluate_batch()

### DIFF
--- a/recipes/WHAMandWHAMR/enhancement/train.py
+++ b/recipes/WHAMandWHAMR/enhancement/train.py
@@ -233,8 +233,7 @@ class Separation(sb.Brain):
 
         with torch.no_grad():
             predictions, targets = self.compute_forward(mixture, targets, stage)
-            loss = self.compute_objectives(predictions, targets)
-            loss = torch.mean(loss)
+            loss = self.compute_objectives(predictions, targets).mean()
 
         if stage != sb.Stage.TRAIN:
             self.pesq_metric.append(

--- a/recipes/WHAMandWHAMR/enhancement/train.py
+++ b/recipes/WHAMandWHAMR/enhancement/train.py
@@ -234,6 +234,7 @@ class Separation(sb.Brain):
         with torch.no_grad():
             predictions, targets = self.compute_forward(mixture, targets, stage)
             loss = self.compute_objectives(predictions, targets)
+            loss = torch.mean(loss)
 
         if stage != sb.Stage.TRAIN:
             self.pesq_metric.append(


### PR DESCRIPTION
Hi @ycemsubakan ,

I initiate this PR to fix a bug in the `WHAMandWHAMR` recipe. I realized that the current recipe works fine on batch_size as 1. However, when increased, losses are not averaged when `evaluate_batch` is called. 
Basically, it makes sense to write
```python
loss = self.compute_objectives(predictions, targets)
loss = torch.mean(loss)   # Avg losses in a batch
```


Thank You