### PR TITLE
add whisper normalization on training

### DIFF
--- a/recipes/LibriSpeech/ASR/transformer/train_with_whisper.py
+++ b/recipes/LibriSpeech/ASR/transformer/train_with_whisper.py
@@ -213,9 +213,11 @@ def dataio_prepare(hparams, tokenizer):
         "wrd", "tokens_list", "tokens_bos", "tokens_eos", "tokens"
     )
     def text_pipeline(wrd):
-        yield wrd
         #carry on the whisper normalization for fintunning
-        tokens_list = tokenizer.encode(tokenizer._normalize(wrd))
+        if hasattr(hparams, "normalized_transcripts"):
+            wrd =tokenizer._normalize(wrd)
+        yield wrd
+        tokens_list = tokenizer.encode(wrd)
         # avoid bos and eos tokens.
         tokens_list = tokens_list[1:-1]
         yield tokens_list

--- a/recipes/LibriSpeech/ASR/transformer/train_with_whisper.py
+++ b/recipes/LibriSpeech/ASR/transformer/train_with_whisper.py
@@ -214,7 +214,8 @@ def dataio_prepare(hparams, tokenizer):
     )
     def text_pipeline(wrd):
         yield wrd
-        tokens_list = tokenizer.encode(wrd)
+        #carry on the whisper normalization for fintunning
+        tokens_list = tokenizer.encode(tokenizer._normalize(wrd))
         # avoid bos and eos tokens.
         tokens_list = tokens_list[1:-1]
         yield tokens_list


### PR DESCRIPTION
Hi :D 

In the present whisper finetuning implementation, we are training with raw text (no normalisation) and then we do testing and validating using whisper normalisation. This is a little adjustment to fine-tune the model on whisper normalisation, as encode only accomplishes tokenisation and not normalisation.

```python

from transformers.models.whisper.tokenization_whisper import WhisperTokenizer

test = "hello i have fifty two dollars"

tokenizer = WhisperTokenizer.from_pretrained("openai/whisper-base")
print(tokenizer._normalize(test))
print(tokenizer.decode(tokenizer.encode(test)))
print(tokenizer.decode(tokenizer.encode(tokenizer._normalize(test))))
```

```
#print outputs
hello i have $52
<|startoftranscript|><|notimestamps|>hello i have fifty two dollars<|endoftext|>
<|startoftranscript|><|notimestamps|>hello i have $52<|endoftext|>
```