### PR TITLE
Fix wav2vec2 masking

### DIFF
--- a/recipes/AISHELL-1/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/AISHELL-1/ASR/CTC/train_with_wav2vec.py
@@ -43,7 +43,7 @@ class ASR(sb.Brain):
                 wav_lens = torch.cat([wav_lens, wav_lens])
 
         # Forward pass
-        feats = self.modules.wav2vec2(wavs)
+        feats = self.modules.wav2vec2(wavs, wav_lens)
 
         if stage == sb.Stage.TRAIN:
             if hasattr(self.hparams, "SpecAugment"):

--- a/recipes/AISHELL-1/ASR/transformer/train_with_wav2vect.py
+++ b/recipes/AISHELL-1/ASR/transformer/train_with_wav2vect.py
@@ -33,7 +33,7 @@ class ASR(sb.core.Brain):
                 tokens_bos = torch.cat([tokens_bos, tokens_bos], dim=0)
 
         # compute features
-        feats = self.modules.wav2vec2(wavs)
+        feats = self.modules.wav2vec2(wavs, wav_lens)
         current_epoch = self.hparams.epoch_counter.current
 
         if stage == sb.Stage.TRAIN:

--- a/recipes/CommonVoice/ASR/CTC/hparams/train_de_with_wav2vec.yaml
+++ b/recipes/CommonVoice/ASR/CTC/hparams/train_de_with_wav2vec.yaml
@@ -65,7 +65,9 @@ character_coverage: 1.0
 dnn_neurons: 1024
 wav2vec_output_dim: !ref <dnn_neurons>
 freeze_wav2vec: False
+freeze_feature_extractor: False
 dropout: 0.15
+warmup_steps: 500
 
 # Outputs
 output_neurons: 32 # BPE size, index(blank/eos/bos) = 0
@@ -109,6 +111,7 @@ wav2vec2: !new:speechbrain.lobes.models.huggingface_wav2vec.HuggingFaceWav2Vec2
   source: !ref <wav2vec2_hub>
   output_norm: True
   freeze: !ref <freeze_wav2vec>
+  freeze_feature_extractor: !ref <freeze_feature_extractor>
   save_path: !ref <save_folder>/wav2vec2_checkpoint
 
 #####

--- a/recipes/CommonVoice/ASR/CTC/hparams/train_en_with_wav2vec.yaml
+++ b/recipes/CommonVoice/ASR/CTC/hparams/train_en_with_wav2vec.yaml
@@ -62,7 +62,9 @@ character_coverage: 1.0
 wav2vec_output_dim: 1024
 dnn_neurons: 1024
 freeze_wav2vec: False
+freeze_feature_extractor: False
 dropout: 0.15
+warmup_steps: 500
 
 # Outputs
 output_neurons: 1000  # BPE size, index(blank/eos/bos) = 0
@@ -109,6 +111,7 @@ wav2vec2: !new:speechbrain.lobes.models.huggingface_wav2vec.HuggingFaceWav2Vec2
     source: !ref <wav2vec2_hub>
     output_norm: True
     freeze: !ref <freeze_wav2vec>
+    freeze_feature_extractor: !ref <freeze_feature_extractor>
     save_path: !ref <save_folder>/wav2vec2_checkpoint
 
 #####

--- a/recipes/CommonVoice/ASR/CTC/hparams/train_fr_with_wav2vec.yaml
+++ b/recipes/CommonVoice/ASR/CTC/hparams/train_fr_with_wav2vec.yaml
@@ -62,6 +62,9 @@ character_coverage: 1.0
 wav2vec_output_dim: 1024
 dnn_neurons: 1024
 freeze_wav2vec: False
+freeze_feature_extractor: False
+dropout: 0.15
+warmup_steps: 500 # The wav2vec 2 model isn't updated for this amount of steps
 
 # Outputs
 output_neurons: 76  # BPE size, index(blank/eos/bos) = 0
@@ -78,36 +81,34 @@ eos_index: 2
 epoch_counter: !new:speechbrain.utils.epoch_loop.EpochCounter
     limit: !ref <number_of_epochs>
 
-augmentation: !new:speechbrain.lobes.augment.TimeDomainSpecAugment
-    sample_rate: !ref <sample_rate>
-    speeds: [95, 100, 105]
 
 enc: !new:speechbrain.nnet.containers.Sequential
     input_shape: [null, null, !ref <wav2vec_output_dim>]
     linear1: !name:speechbrain.nnet.linear.Linear
-        n_neurons: 1024
+        n_neurons: !ref <dnn_neurons>
         bias: True
     bn1: !name:speechbrain.nnet.normalization.BatchNorm1d
     activation: !new:torch.nn.LeakyReLU
     drop: !new:torch.nn.Dropout
-        p: 0.15
+        p: !ref <dropout>
     linear2: !name:speechbrain.nnet.linear.Linear
-        n_neurons: 1024
+        n_neurons: !ref <dnn_neurons>
         bias: True
     bn2: !name:speechbrain.nnet.normalization.BatchNorm1d
     activation2: !new:torch.nn.LeakyReLU
     drop2: !new:torch.nn.Dropout
-        p: 0.15
+        p: !ref <dropout>
     linear3: !name:speechbrain.nnet.linear.Linear
-        n_neurons: 1024
+        n_neurons: !ref <dnn_neurons>
         bias: True
     bn3: !name:speechbrain.nnet.normalization.BatchNorm1d
     activation3: !new:torch.nn.LeakyReLU
 
 wav2vec2: !new:speechbrain.lobes.models.huggingface_wav2vec.HuggingFaceWav2Vec2
     source: !ref <wav2vec2_hub>
-    output_norm: True
+    output_norm: False
     freeze: !ref <freeze_wav2vec>
+    freeze_feature_extractor: !ref <freeze_feature_extractor>
     save_path: !ref <save_folder>/wav2vec2_checkpoint
 
 #####

--- a/recipes/CommonVoice/ASR/CTC/hparams/train_it_with_wav2vec.yaml
+++ b/recipes/CommonVoice/ASR/CTC/hparams/train_it_with_wav2vec.yaml
@@ -63,7 +63,9 @@ character_coverage: 1.0
 wav2vec_output_dim: 1024
 dnn_neurons: 1024
 freeze_wav2vec: False
+freeze_feature_extractor: False
 dropout: 0.15
+warmup_steps: 500
 
 # Outputs
 output_neurons: 1000  # BPE size, index(blank/eos/bos) = 0
@@ -110,6 +112,7 @@ wav2vec2: !new:speechbrain.lobes.models.huggingface_wav2vec.HuggingFaceWav2Vec2
     source: !ref <wav2vec2_hub>
     output_norm: True
     freeze: !ref <freeze_wav2vec>
+    freeze_feature_extractor: !ref <freeze_feature_extractor>
     save_path: !ref <save_folder>/wav2vec2_checkpoint
 
 #####

--- a/recipes/CommonVoice/ASR/CTC/hparams/train_rw_with_wav2vec.yaml
+++ b/recipes/CommonVoice/ASR/CTC/hparams/train_rw_with_wav2vec.yaml
@@ -63,6 +63,9 @@ character_coverage: 1.0
 wav2vec_output_dim: 1024
 dnn_neurons: 1024
 freeze_wav2vec: False
+freeze_feature_extractor: False
+dropout: 0.15
+warmup_steps: 500
 
 # Outputs
 output_neurons: 1000  # BPE size, index(blank/eos/bos) = 0
@@ -86,21 +89,21 @@ augmentation: !new:speechbrain.lobes.augment.TimeDomainSpecAugment
 enc: !new:speechbrain.nnet.containers.Sequential
     input_shape: [null, null, !ref <wav2vec_output_dim>]
     linear1: !name:speechbrain.nnet.linear.Linear
-        n_neurons: 1024
+        n_neurons: !ref <dnn_neurons>
         bias: True
     bn1: !name:speechbrain.nnet.normalization.BatchNorm1d
     activation: !new:torch.nn.LeakyReLU
     drop: !new:torch.nn.Dropout
-        p: 0.15
+        p: !ref <dropout>
     linear2: !name:speechbrain.nnet.linear.Linear
-        n_neurons: 1024
+        n_neurons: !ref <dnn_neurons>
         bias: True
     bn2: !name:speechbrain.nnet.normalization.BatchNorm1d
     activation2: !new:torch.nn.LeakyReLU
     drop2: !new:torch.nn.Dropout
-        p: 0.15
+        p: !ref <dropout>
     linear3: !name:speechbrain.nnet.linear.Linear
-        n_neurons: 1024
+        n_neurons: !ref <dnn_neurons>
         bias: True
     bn3: !name:speechbrain.nnet.normalization.BatchNorm1d
     activation3: !new:torch.nn.LeakyReLU
@@ -109,6 +112,7 @@ wav2vec2: !new:speechbrain.lobes.models.huggingface_wav2vec.HuggingFaceWav2Vec2
     source: !ref <wav2vec2_hub>
     output_norm: True
     freeze: !ref <freeze_wav2vec>
+    freeze_feature_extractor: !ref <freeze_feature_extractor>
     save_path: !ref <save_folder>/wav2vec2_checkpoint
 
 #####

--- a/recipes/CommonVoice/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/CommonVoice/ASR/CTC/train_with_wav2vec.py
@@ -88,48 +88,45 @@ class ASR(sb.core.Brain):
 
     def fit_batch(self, batch):
         """Train the parameters given a single batch in input"""
+        should_step = self.step % self.grad_accumulation_factor == 0
+        # Managing automatic mixed precision
         if self.auto_mix_prec:
-
-            if not self.hparams.wav2vec2.freeze:
-                self.wav2vec_optimizer.zero_grad()
-            self.model_optimizer.zero_grad()
-
             with torch.cuda.amp.autocast():
                 outputs = self.compute_forward(batch, sb.Stage.TRAIN)
                 loss = self.compute_objectives(outputs, batch, sb.Stage.TRAIN)
+            with self.no_sync(not should_step):
+                self.scaler.scale(
+                    loss / self.grad_accumulation_factor
+                ).backward()
+            if should_step:
 
-            self.scaler.scale(loss).backward()
-            if not self.hparams.wav2vec2.freeze:
-                self.scaler.unscale_(self.wav2vec_optimizer)
-            self.scaler.unscale_(self.model_optimizer)
-
-            if self.check_gradients(loss):
                 if not self.hparams.wav2vec2.freeze:
-                    if self.optimizer_step >= self.hparams.warmup_steps:
-                        self.scaler.step(self.wav2vec_optimizer)
-                self.scaler.step(self.model_optimizer)
-
-            self.scaler.update()
-            self.optimizer_step += 1
+                    self.scaler.unscale_(self.wav2vec_optimizer)
+                self.scaler.unscale_(self.model_optimizer)
+                if self.check_gradients(loss):
+                    if not self.hparams.wav2vec2.freeze:
+                        if self.optimizer_step >= self.hparams.warmup_steps:
+                            self.scaler.step(self.wav2vec_optimizer)
+                    self.scaler.step(self.model_optimizer)
+                self.scaler.update()
+                self.zero_grad()
+                self.optimizer_step += 1
         else:
             outputs = self.compute_forward(batch, sb.Stage.TRAIN)
-
             loss = self.compute_objectives(outputs, batch, sb.Stage.TRAIN)
-            loss.backward()
+            with self.no_sync(not should_step):
+                (loss / self.grad_accumulation_factor).backward()
+            if should_step:
+                if self.check_gradients(loss):
+                    if not self.hparams.wav2vec2.freeze:
+                        if self.optimizer_step >= self.hparams.warmup_steps:
+                            self.wav2vec_optimizer.step()
+                    self.model_optimizer.step()
+                self.zero_grad()
+                self.optimizer_step += 1
 
-            if self.check_gradients(loss):
-                if not self.hparams.wav2vec2.freeze:
-                    if self.optimizer_step >= self.hparams.warmup_steps:
-                        self.wav2vec_optimizer.step()
-                self.model_optimizer.step()
-
-            if not self.hparams.wav2vec2.freeze:
-                self.wav2vec_optimizer.zero_grad()
-            self.model_optimizer.zero_grad()
-
-            self.optimizer_step += 1
-
-        return loss.detach()
+        self.on_fit_batch_end(batch, outputs, loss, should_step)
+        return loss.detach().cpu()
 
     def evaluate_batch(self, batch, stage):
         """Computations needed for validation/test batches"""

--- a/recipes/CommonVoice/ASR/seq2seq/train_with_wav2vec.py
+++ b/recipes/CommonVoice/ASR/seq2seq/train_with_wav2vec.py
@@ -53,7 +53,7 @@ class ASR(sb.core.Brain):
                 wavs = self.hparams.augmentation(wavs, wav_lens)
 
         # Forward pass
-        feats = self.modules.wav2vec2(wavs)
+        feats = self.modules.wav2vec2(wavs, wav_lens)
         x = self.modules.enc(feats)
 
         e_in = self.modules.emb(tokens_bos)  # y_in bos + tokens

--- a/recipes/CommonVoice/self-supervised-learning/wav2vec2/train_hf_wav2vec2.py
+++ b/recipes/CommonVoice/self-supervised-learning/wav2vec2/train_hf_wav2vec2.py
@@ -51,7 +51,7 @@ class W2VBrain(sb.core.Brain):
         # Forward on w2v2 and take the loss.
         # It has to be on train mode even for eval. Otherwise it would deactivate
         # the loss computation ...
-        out, mask = self.modules.wav2vec2(wavs)
+        out, mask = self.modules.wav2vec2(wavs, wav_lens)
         loss = out.loss
 
         if stage != sb.Stage.TRAIN:

--- a/recipes/DVoice/ASR/CTC/train_with_wav2vec2.py
+++ b/recipes/DVoice/ASR/CTC/train_with_wav2vec2.py
@@ -51,7 +51,7 @@ class ASR(sb.core.Brain):
                 wavs = self.hparams.augmentation(wavs, wav_lens)
 
         # Forward pass
-        feats = self.modules.wav2vec2(wavs)
+        feats = self.modules.wav2vec2(wavs, wav_lens)
         x = self.modules.enc(feats)
         logits = self.modules.ctc_lin(x)
         p_ctc = self.hparams.log_softmax(logits)
@@ -88,43 +88,53 @@ class ASR(sb.core.Brain):
 
     def fit_batch(self, batch):
         """Train the parameters given a single batch in input"""
+        should_step = self.step % self.grad_accumulation_factor == 0
+        # Managing automatic mixed precision
+        # TOFIX: CTC fine-tuning currently is unstable
+        # This is certainly due to CTC being done in fp16 instead of fp32
         if self.auto_mix_prec:
-
-            if not self.hparams.wav2vec2.freeze:
-                self.wav2vec_optimizer.zero_grad()
-            self.model_optimizer.zero_grad()
-
             with torch.cuda.amp.autocast():
-                outputs = self.compute_forward(batch, sb.Stage.TRAIN)
+                with self.no_sync():
+                    outputs = self.compute_forward(batch, sb.Stage.TRAIN)
                 loss = self.compute_objectives(outputs, batch, sb.Stage.TRAIN)
+            with self.no_sync(not should_step):
+                self.scaler.scale(
+                    loss / self.grad_accumulation_factor
+                ).backward()
+            if should_step:
 
-            self.scaler.scale(loss).backward()
-            if not self.hparams.wav2vec2.freeze:
-                self.scaler.unscale_(self.wav2vec_optimizer)
-            self.scaler.unscale_(self.model_optimizer)
-
-            if self.check_gradients(loss):
                 if not self.hparams.wav2vec2.freeze:
-                    self.scaler.step(self.wav2vec_optimizer)
-                self.scaler.step(self.model_optimizer)
-
-            self.scaler.update()
+                    self.scaler.unscale_(self.wav2vec_optimizer)
+                self.scaler.unscale_(self.model_optimizer)
+                if self.check_gradients(loss):
+                    if not self.hparams.wav2vec2.freeze:
+                        if self.optimizer_step >= self.hparams.warmup_steps:
+                            self.scaler.step(self.wav2vec_optimizer)
+                    self.scaler.step(self.model_optimizer)
+                self.scaler.update()
+                self.zero_grad()
+                self.optimizer_step += 1
         else:
-            outputs = self.compute_forward(batch, sb.Stage.TRAIN)
+            # This is mandatory because HF models have a weird behavior with DDP
+            # on the forward pass
+            with self.no_sync():
+                outputs = self.compute_forward(batch, sb.Stage.TRAIN)
 
             loss = self.compute_objectives(outputs, batch, sb.Stage.TRAIN)
-            loss.backward()
 
-            if self.check_gradients(loss):
-                if not self.hparams.wav2vec2.freeze:
-                    self.wav2vec_optimizer.step()
-                self.model_optimizer.step()
+            with self.no_sync(not should_step):
+                (loss / self.grad_accumulation_factor).backward()
+            if should_step:
+                if self.check_gradients(loss):
+                    if not self.hparams.wav2vec2.freeze:
+                        if self.optimizer_step >= self.hparams.warmup_steps:
+                            self.wav2vec_optimizer.step()
+                    self.model_optimizer.step()
+                self.zero_grad()
+                self.optimizer_step += 1
 
-            if not self.hparams.wav2vec2.freeze:
-                self.wav2vec_optimizer.zero_grad()
-            self.model_optimizer.zero_grad()
-
-        return loss.detach()
+        self.on_fit_batch_end(batch, outputs, loss, should_step)
+        return loss.detach().cpu()
 
     def evaluate_batch(self, batch, stage):
         """Computations needed for validation/test batches"""

--- a/recipes/IEMOCAP/emotion_recognition/train_with_wav2vec2.py
+++ b/recipes/IEMOCAP/emotion_recognition/train_with_wav2vec2.py
@@ -24,7 +24,7 @@ class EmoIdBrain(sb.Brain):
         batch = batch.to(self.device)
         wavs, lens = batch.sig
 
-        outputs = self.modules.wav2vec2(wavs)
+        outputs = self.modules.wav2vec2(wavs, lens)
 
         # last dim will be used for AdaptativeAVG pool
         outputs = self.hparams.avg_pool(outputs, lens)

--- a/recipes/IWSLT22_lowresource/train.py
+++ b/recipes/IWSLT22_lowresource/train.py
@@ -25,7 +25,7 @@ class ST(sb.core.Brain):
         tokens_bos, _ = batch.tokens_bos  # translation
 
         # wav2vec module
-        feats = self.modules.wav2vec2(wavs)
+        feats = self.modules.wav2vec2(wavs, wav_lens)
 
         # dimensionality reduction
         src = self.modules.enc(feats)

--- a/recipes/SLURP/direct/train_with_wav2vec2.py
+++ b/recipes/SLURP/direct/train_with_wav2vec2.py
@@ -38,7 +38,7 @@ class SLU(sb.Brain):
                 wavs = self.hparams.augmentation(wavs, wav_lens)
 
         #  encoder forward pass
-        wav2vec2_out = self.modules.wav2vec2(wavs)
+        wav2vec2_out = self.modules.wav2vec2(wavs, wav_lens)
 
         # SLU forward pass
         e_in = self.hparams.output_emb(tokens_bos)

--- a/recipes/Switchboard/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/Switchboard/ASR/CTC/train_with_wav2vec.py
@@ -77,7 +77,7 @@ class ASR(sb.core.Brain):
                 wavs = self.hparams.augmentation(wavs, wav_lens)
 
         # Forward pass
-        feats = self.modules.wav2vec2(wavs)
+        feats = self.modules.wav2vec2(wavs, wav_lens)
         x = self.modules.enc(feats)
         logits = self.modules.ctc_lin(x)
         p_ctc = self.hparams.log_softmax(logits)

--- a/recipes/TIMIT/ASR/seq2seq/train_with_wav2vec2.py
+++ b/recipes/TIMIT/ASR/seq2seq/train_with_wav2vec2.py
@@ -37,7 +37,7 @@ class ASR(sb.Brain):
             if hasattr(self.hparams, "augmentation"):
                 wavs = self.hparams.augmentation(wavs, wav_lens)
 
-        feats = self.modules.wav2vec2(wavs)
+        feats = self.modules.wav2vec2(wavs, wav_lens)
         x = self.modules.enc(feats)
 
         # output layer for ctc log-probabilities

--- a/recipes/TIMIT/ASR/transducer/train_wav2vec.py
+++ b/recipes/TIMIT/ASR/transducer/train_wav2vec.py
@@ -36,7 +36,7 @@ class ASR_Brain(sb.Brain):
                 wavs = self.hparams.augmentation(wavs, wav_lens)
 
         # Model computations
-        feats = self.modules.wav2vec2(wavs)
+        feats = self.modules.wav2vec2(wavs, wav_lens)
         x = self.modules.enc(feats)
         x = self.modules.enc_lin(x)
 

--- a/recipes/timers-and-such/direct/train_with_wav2vec2.py
+++ b/recipes/timers-and-such/direct/train_with_wav2vec2.py
@@ -41,7 +41,7 @@ class SLU(sb.Brain):
             if hasattr(self.hparams, "augmentation"):
                 wavs = self.hparams.augmentation(wavs, wav_lens)
         # wav2vec forward pass
-        wav2vec2_out = self.modules.wav2vec2(wavs)
+        wav2vec2_out = self.modules.wav2vec2(wavs, wav_lens)
         # SLU forward pass
         encoder_out = self.hparams.slu_enc(wav2vec2_out)
         e_in = self.hparams.output_emb(tokens_bos)

--- a/speechbrain/lobes/models/huggingface_wav2vec.py
+++ b/speechbrain/lobes/models/huggingface_wav2vec.py
@@ -295,7 +295,7 @@ class HuggingFaceWav2Vec2(nn.Module):
         out = self.model(
             wav,
             attention_mask=padding_masks,
-            output_hidden_states=self.output_all_hidden,
+            output_hidden_states=self.output_all_hiddens,
         )
 
         if self.output_all_hiddens:

--- a/speechbrain/lobes/models/huggingface_wav2vec.py
+++ b/speechbrain/lobes/models/huggingface_wav2vec.py
@@ -134,10 +134,6 @@ class HuggingFaceWav2Vec2(nn.Module):
         )
 
         self.model.config.apply_spec_augment = apply_spec_augment
-        # self.model.config.layer_norm_first = True
-        # self.model.config.do_stable_layer_norm = False
-
-        print(self.model)
 
         # We check if inputs need to be normalized w.r.t pretrained wav2vec2
         self.normalize_wav = self.feature_extractor.do_normalize
@@ -273,8 +269,9 @@ class HuggingFaceWav2Vec2(nn.Module):
             A batch of audio signals to transform to features.
         """
 
-        # If we freeze, we simply remove all grads and features from the graph.
         padding_mask = self.make_masks(wav, wav_len=wav_lens)
+
+        # If we freeze, we simply remove all grads from the graph.
         if self.freeze:
             with torch.no_grad():
                 return self.extract_features(wav, padding_mask)
@@ -295,7 +292,9 @@ class HuggingFaceWav2Vec2(nn.Module):
 
         # Extract wav2vec output
         out = self.model(
-            wav, attention_mask=padding_masks, output_hidden_states=False
+            wav,
+            attention_mask=padding_masks,
+            output_hidden_states=self.output_all_hidden,
         )
 
         if self.output_all_hiddens:

--- a/speechbrain/lobes/models/huggingface_wav2vec.py
+++ b/speechbrain/lobes/models/huggingface_wav2vec.py
@@ -155,7 +155,8 @@ class HuggingFaceWav2Vec2(nn.Module):
                     "speechbrain.lobes.models.huggingface_wav2vec - wav2vec 2.0 feature extractor is frozen."
                 )
                 self.model.feature_extractor.eval()
-                self.model.feature_extractor._freeze_parameters()
+                for param in self.model.feature_extractor.parameters():
+                    param.requires_grad = False
         self.output_all_hiddens = output_all_hiddens
 
     def _from_pretrained(self, source, config, model, save_path):

--- a/speechbrain/lobes/models/huggingface_wav2vec.py
+++ b/speechbrain/lobes/models/huggingface_wav2vec.py
@@ -154,6 +154,7 @@ class HuggingFaceWav2Vec2(nn.Module):
                 logger.warning(
                     "speechbrain.lobes.models.huggingface_wav2vec - wav2vec 2.0 feature extractor is frozen."
                 )
+                self.model.feature_extractor.eval()
                 self.model.feature_extractor._freeze_parameters()
         self.output_all_hiddens = output_all_hiddens
 
@@ -311,13 +312,13 @@ class HuggingFaceWav2Vec2(nn.Module):
         return out
 
     def make_masks(self, src, wav_len=None, pad_idx=0):
-        """This method generates the masks for training the transformer model.
+        """This method generates the padding masks.
         Arguments
         ---------
         src : tensor
             The sequence to the encoder (required).
-        tgt : tensor
-            The sequence to the decoder (required).
+        wav_len : tensor
+            The relative length of the wav given in SpeechBrain format.
         pad_idx : int
             The index for <pad> token (default=0).
         """


### PR DESCRIPTION
Fix an issue making fairseq and HF w2v2 models differ in terms of results.

We were not passing padding masks.

This will potential break all previous W2V2 models (results-wise).