### PR TITLE
Fix input dimension for memory transformer (RE-Sepformer)

### DIFF
--- a/speechbrain/lobes/models/resepformer.py
+++ b/speechbrain/lobes/models/resepformer.py
@@ -579,8 +579,8 @@ class ResourceEfficientSeparationPipeline(nn.Module):
 
             if i < (self.num_blocks - 1):
                 if self.mem_type == "av":
-                    hc = output.mean(1).unsqueeze(0)
-                    hc = self.mem_model[i](hc).permute(1, 0, 2)
+                    hc = output.mean(1).reshape(B, S, D)  # B, S, D
+                    hc = self.mem_model[i](hc).reshape(B * S, 1, D)  # BS, 1, D
                 else:
                     hc = self.mem_model[i](hc, S)
 


### PR DESCRIPTION
If batch_size is greater than 1, current memory transformer calculates long-term dependency about all batch sequences.

This commit fixes to calculate independently between batch.

Before: 1, BS, D -> Changed: B, S, D is input to mem_model