### PR TITLE
Remove reference to possibly non-existing attribute of dataset in DynamicBatchSampler

### DIFF
--- a/speechbrain/dataio/sampler.py
+++ b/speechbrain/dataio/sampler.py
@@ -428,7 +428,6 @@ class DynamicBatchSampler(Sampler):
     ):
         self._dataset = dataset
         self._ex_lengths = {}
-        ex_ids = self._dataset.data_ids
         self.verbose = verbose
 
         # We do not put a default on num_buckets to encourage users to play with this parameter
@@ -450,7 +449,7 @@ class DynamicBatchSampler(Sampler):
                 )
             for indx in range(len(self._dataset)):
                 self._ex_lengths[str(indx)] = length_func(
-                    self._dataset.data[ex_ids[indx]]
+                    self._dataset.data[self._dataset.data_ids[indx]]
                 )
 
         if len(bucket_boundaries) > 0:


### PR DESCRIPTION
Fix for bug #1844 
`DynamicBatchSampler` expects `data_ids` attribute in `__init__()`, which can be absent in plain `torch.utils.data.Dataset`. In this fix, we try to use `data_ids` only when we are sure we work with `DynamicItemDataset`.
