### PR TITLE
fixing the convtasnet causal=True bug

### DIFF
--- a/recipes/WSJ0Mix/separation/hparams/convtasnet.yaml
+++ b/recipes/WSJ0Mix/separation/hparams/convtasnet.yaml
@@ -116,7 +116,7 @@ MaskNet: !new:speechbrain.lobes.models.conv_tasnet.MaskNet
     R: 4
     C: !ref <num_spks>
     norm_type: 'gLN'
-    causal: False
+    causal: True
     mask_nonlinear: 'relu'
 
 Decoder: !new:speechbrain.lobes.models.dual_path.Decoder

--- a/speechbrain/lobes/models/conv_tasnet.py
+++ b/speechbrain/lobes/models/conv_tasnet.py
@@ -421,11 +421,10 @@ class DepthwiseSeparableConv(sb.nnet.containers.Sequential):
         batchsize, time, in_channels = input_shape
 
         # [M, K, H] -> [M, K, H]
-
         if causal:
             paddingval = dilation * (kernel_size - 1)
-            padding = 'causal'
-            default_padding = 'same'
+            padding = "causal"
+            default_padding = "same"
         else:
             default_padding = 0
 
@@ -439,7 +438,7 @@ class DepthwiseSeparableConv(sb.nnet.containers.Sequential):
             groups=in_channels,
             bias=False,
             layer_name="conv_0",
-            default_padding=default_padding
+            default_padding=default_padding,
         )
 
         if causal:

--- a/speechbrain/lobes/models/conv_tasnet.py
+++ b/speechbrain/lobes/models/conv_tasnet.py
@@ -421,6 +421,14 @@ class DepthwiseSeparableConv(sb.nnet.containers.Sequential):
         batchsize, time, in_channels = input_shape
 
         # [M, K, H] -> [M, K, H]
+
+        if causal:
+            paddingval = dilation * (kernel_size - 1)
+            padding = 'causal'
+            default_padding = 'same'
+        else:
+            default_padding = 0
+
         self.append(
             sb.nnet.CNN.Conv1d,
             out_channels=in_channels,
@@ -431,10 +439,11 @@ class DepthwiseSeparableConv(sb.nnet.containers.Sequential):
             groups=in_channels,
             bias=False,
             layer_name="conv_0",
+            default_padding=default_padding
         )
 
         if causal:
-            self.append(Chomp1d(padding), layer_name="chomp")
+            self.append(Chomp1d(paddingval), layer_name="chomp")
 
         self.append(nn.PReLU(), layer_name="act")
         self.append(choose_norm(norm_type, in_channels), layer_name="act")

--- a/speechbrain/nnet/CNN.py
+++ b/speechbrain/nnet/CNN.py
@@ -339,6 +339,8 @@ class Conv1d(nn.Module):
     weight_norm : bool
         If True, use weight normalization,
         to be removed with self.remove_weight_norm() at inference
+    default_padding: str or int
+        This sets the default padding mode that will be used by the pytorch Conv1d backend.
 
     Example
     -------
@@ -366,6 +368,7 @@ class Conv1d(nn.Module):
         skip_transpose=False,
         weight_norm=False,
         conv_init=None,
+        default_padding=0,
     ):
         super().__init__()
         self.kernel_size = kernel_size
@@ -390,7 +393,7 @@ class Conv1d(nn.Module):
             self.kernel_size,
             stride=self.stride,
             dilation=self.dilation,
-            padding=0,
+            padding=default_padding,
             groups=groups,
             bias=bias,
         )


### PR DESCRIPTION
This PR aims to fix the bug pointed out in https://github.com/speechbrain/speechbrain/issues/1613. 

I had to modify `Conv1d` class in `CNN.py`, but the default behavior is not changed. @Adel-Moumen please double check that everything is fine. 