### PR TITLE
Allow specifying expected encoder category count

### DIFF
--- a/speechbrain/dataio/encoder.py
+++ b/speechbrain/dataio/encoder.py
@@ -69,6 +69,7 @@ class CategoricalEncoder:
     >>> from speechbrain.dataio.dataset import DynamicItemDataset
     >>> dataset = [[x+1, x+2] for x in range(20)]
     >>> encoder = CategoricalEncoder()
+    >>> encoder.ignore_len()
     >>> encoder.update_from_iterable(dataset, sequence_input=True)
     >>> assert len(encoder) == 21 # there are only 21 unique elements 1-21
 
@@ -636,6 +637,7 @@ class CategoricalEncoder:
         >>> # So the first time you run the experiment, the encoding is created.
         >>> # However, later, the encoding exists:
         >>> encoder = CategoricalEncoder()
+        >>> encoder.expect_len(4)
         >>> if not encoder.load_if_possible(encoding_file):
         ...     assert False  # We won't get here!
         >>> encoder.decode_ndim(range(4))
@@ -677,7 +679,18 @@ class CategoricalEncoder:
             The expected final category count, i.e. `len(encoder)`.
 
         Example
-        -------"""
+        -------
+        >>> encoder = CategoricalEncoder()
+        >>> encoder.update_from_iterable("abcd")
+        >>> encoder.expect_len(3)
+        >>> encoder.encode_label("a")
+        Traceback (most recent call last):
+          ...
+        RuntimeError: .expect_len(3) was called, but 4 categories found
+        >>> encoder.expect_len(4)
+        >>> encoder.encode_label("a")
+        0
+        """
         # TODO
         self.expected_len = expected_len
 
@@ -804,10 +817,12 @@ class TextEncoder(CategoricalEncoder):
     >>> dataset = [["encode", "this", "textencoder"], ["foo", "bar"]]
     >>> encoder = TextEncoder()
     >>> encoder.update_from_iterable(dataset)
+    >>> encoder.expect_len(5)
     >>> encoder.encode_label("this")
     1
     >>> encoder.add_unk()
     5
+    >>> encoder.expect_len(6)
     >>> encoder.encode_sequence(["this", "out-of-vocab"])
     [1, 5]
     >>>
@@ -816,6 +831,7 @@ class TextEncoder(CategoricalEncoder):
     insert_bos_eos, add_bos_eos.
 
     >>> encoder.add_bos_eos()
+    >>> encoder.expect_len(8)
     >>> encoder.lab2ind[encoder.eos_label]
     7
     >>>
@@ -823,6 +839,7 @@ class TextEncoder(CategoricalEncoder):
     >>> encoder = TextEncoder()
     >>> encoder.update_from_iterable(dataset)
     >>> encoder.insert_bos_eos(bos_index=0, eos_index=1)
+    >>> encoder.expect_len(7)
     >>> encoder.lab2ind[encoder.eos_label]
     1
     >>>
@@ -1029,6 +1046,7 @@ class CTCTextEncoder(TextEncoder):
     >>> encoder = CTCTextEncoder()
     >>> encoder.update_from_iterable(chars)
     >>> encoder.add_blank()
+    >>> encoder.expect_len(5)
     >>> encoder.encode_sequence(chars)
     [0, 1, 2, 3]
     >>> encoder.get_blank_index()

--- a/speechbrain/dataio/encoder.py
+++ b/speechbrain/dataio/encoder.py
@@ -684,7 +684,7 @@ class CategoricalEncoder:
     def ignore_len(self):
         """Specifies that category count shall be ignored at encoding/decoding
         time.
-        
+
         Effectively inhibits the ".expect_len was never called" warning.
         Prefer :py:meth:`~CategoricalEncoder.expect_len` when the category count
         is known."""

--- a/speechbrain/dataio/encoder.py
+++ b/speechbrain/dataio/encoder.py
@@ -691,7 +691,6 @@ class CategoricalEncoder:
         >>> encoder.encode_label("a")
         0
         """
-        # TODO
         self.expected_len = expected_len
 
     def ignore_len(self):

--- a/speechbrain/dataio/encoder.py
+++ b/speechbrain/dataio/encoder.py
@@ -69,7 +69,7 @@ class CategoricalEncoder:
     >>> from speechbrain.dataio.dataset import DynamicItemDataset
     >>> dataset = [[x+1, x+2] for x in range(20)]
     >>> encoder = CategoricalEncoder()
-    >>> encoder .ignore_len()
+    >>> encoder.ignore_len()
     >>> encoder.update_from_iterable(dataset, sequence_input=True)
     >>> assert len(encoder) == 21 # there are only 21 unique elements 1-21
 

--- a/speechbrain/dataio/encoder.py
+++ b/speechbrain/dataio/encoder.py
@@ -69,7 +69,7 @@ class CategoricalEncoder:
     >>> from speechbrain.dataio.dataset import DynamicItemDataset
     >>> dataset = [[x+1, x+2] for x in range(20)]
     >>> encoder = CategoricalEncoder()
-    >>> encoder.ignore_len()
+    >>> encoder .ignore_len()
     >>> encoder.update_from_iterable(dataset, sequence_input=True)
     >>> assert len(encoder) == 21 # there are only 21 unique elements 1-21
 

--- a/speechbrain/dataio/encoder.py
+++ b/speechbrain/dataio/encoder.py
@@ -709,9 +709,9 @@ class CategoricalEncoder:
         else:
             warnings.warn(
                 f"{self.__class__.__name__}.expect_len was never called: "
-                f"assuming category count of {len(self)} to be correct!\n"
+                f"assuming category count of {len(self)} to be correct! "
                 "Sanity check your encoder using `.expect_len`. "
-                "Ensure that downstream code also uses the correct size.\n"
+                "Ensure that downstream code also uses the correct size. "
                 "If you are sure this does not apply to you, use `.ignore_len`."
             )
             self.ignore_len()

--- a/speechbrain/pretrained/interfaces.py
+++ b/speechbrain/pretrained/interfaces.py
@@ -881,6 +881,7 @@ class EncoderClassifier(Pretrained):
     ...     source="speechbrain/spkrec-ecapa-voxceleb",
     ...     savedir=tmpdir,
     ... )
+    >>> classifier.hparams.label_encoder.ignore_len()
 
     >>> # Compute embeddings
     >>> signal, fs = torchaudio.load("tests/samples/single-mic/example1.wav")

--- a/tests/integration/ASR_CTC/example_asr_ctc_experiment.py
+++ b/tests/integration/ASR_CTC/example_asr_ctc_experiment.py
@@ -72,6 +72,7 @@ def data_prep(data_folder, hparams):
     )
     datasets = [train_data, valid_data]
     label_encoder = sb.dataio.encoder.CTCTextEncoder()
+    label_encoder.expect_len(hparams["num_labels"])
 
     # 2. Define audio pipeline:
     @sb.utils.data_pipeline.takes("wav")

--- a/tests/integration/ASR_CTC/example_asr_ctc_experiment_complex_net.py
+++ b/tests/integration/ASR_CTC/example_asr_ctc_experiment_complex_net.py
@@ -72,6 +72,7 @@ def data_prep(data_folder, hparams):
     )
     datasets = [train_data, valid_data]
     label_encoder = sb.dataio.encoder.CTCTextEncoder()
+    label_encoder.expect_len(hparams["num_labels"])
 
     # 2. Define audio pipeline:
     @sb.utils.data_pipeline.takes("wav")

--- a/tests/integration/ASR_CTC/example_asr_ctc_experiment_quaternion_net.py
+++ b/tests/integration/ASR_CTC/example_asr_ctc_experiment_quaternion_net.py
@@ -72,6 +72,7 @@ def data_prep(data_folder, hparams):
     )
     datasets = [train_data, valid_data]
     label_encoder = sb.dataio.encoder.CTCTextEncoder()
+    label_encoder.expect_len(hparams["num_labels"])
 
     # 2. Define audio pipeline:
     @sb.utils.data_pipeline.takes("wav")

--- a/tests/integration/ASR_Transducer/example_asr_transducer_experiment.py
+++ b/tests/integration/ASR_Transducer/example_asr_transducer_experiment.py
@@ -90,6 +90,7 @@ def data_prep(data_folder, hparams):
     )
     datasets = [train_data, valid_data]
     label_encoder = sb.dataio.encoder.CTCTextEncoder()
+    label_encoder.expect_len(hparams["num_labels"])
 
     # 2. Define audio pipeline:
     @sb.utils.data_pipeline.takes("wav")

--- a/tests/integration/ASR_alignment_forward/example_asr_alignment_forward_experiment.py
+++ b/tests/integration/ASR_alignment_forward/example_asr_alignment_forward_experiment.py
@@ -66,6 +66,7 @@ def data_prep(data_folder, hparams):
     )
     datasets = [train_data, valid_data]
     label_encoder = sb.dataio.encoder.CTCTextEncoder()
+    label_encoder.expect_len(hparams["num_labels"])
 
     # 2. Define audio pipeline:
     @sb.utils.data_pipeline.takes("wav")

--- a/tests/integration/ASR_alignment_forward/hyperparams.yaml
+++ b/tests/integration/ASR_alignment_forward/hyperparams.yaml
@@ -8,6 +8,9 @@ lr: 0.004
 dataloader_options:
     batch_size: 1
 
+# Labels
+num_labels: 43  # 43 phonemes, no blank
+
 # Model parameters
 activation: !name:torch.nn.LeakyReLU
 dropout: 0.15
@@ -42,7 +45,7 @@ model: !new:speechbrain.lobes.models.CRDNN.CRDNN
 
 lin: !new:speechbrain.nnet.linear.Linear
     input_size: !ref <dnn_neurons>
-    n_neurons: 43  # 43 phonemes, no blank
+    n_neurons: !ref <num_labels>
     bias: False
 
 modules:

--- a/tests/integration/ASR_alignment_viterbi/example_asr_alignment_viterbi_experiment.py
+++ b/tests/integration/ASR_alignment_viterbi/example_asr_alignment_viterbi_experiment.py
@@ -72,6 +72,7 @@ def data_prep(data_folder, hparams):
 
     datasets = [train_data, valid_data]
     label_encoder = sb.dataio.encoder.CTCTextEncoder()
+    label_encoder.expect_len(hparams["num_labels"])
 
     # 2. Define audio pipeline:
     @sb.utils.data_pipeline.takes("wav")

--- a/tests/integration/ASR_alignment_viterbi/hyperparams.yaml
+++ b/tests/integration/ASR_alignment_viterbi/hyperparams.yaml
@@ -8,6 +8,9 @@ lr: 0.004
 dataloader_options:
     batch_size: 1
 
+# Labels
+num_labels: 43  # 43 phonemes, no blank
+
 # Model parameters
 activation: !name:torch.nn.LeakyReLU
 dropout: 0.15
@@ -42,7 +45,7 @@ model: !new:speechbrain.lobes.models.CRDNN.CRDNN
 
 lin: !new:speechbrain.nnet.linear.Linear
     input_size: !ref <dnn_neurons>
-    n_neurons: 43  # 43 phonemes, no blank
+    n_neurons: !ref <num_labels>
     bias: False
 
 modules:

--- a/tests/integration/ASR_seq2seq/example_asr_seq2seq_experiment.py
+++ b/tests/integration/ASR_seq2seq/example_asr_seq2seq_experiment.py
@@ -97,6 +97,7 @@ def data_prep(data_folder, hparams):
     )
     datasets = [train_data, valid_data]
     label_encoder = sb.dataio.encoder.TextEncoder()
+    label_encoder.expect_len(hparams["num_labels"])
 
     # 2. Define audio pipeline:
     @sb.utils.data_pipeline.takes("wav")

--- a/tests/integration/G2P/example_g2p.py
+++ b/tests/integration/G2P/example_g2p.py
@@ -97,6 +97,7 @@ def data_prep(data_folder, hparams):
     char_encoder.insert_bos_eos(bos_index=hparams["bos_index"])
     char_encoder.update_from_didataset(train_data, output_key="char_list")
     char_encoder.update_from_didataset(valid_data, output_key="char_list")
+    char_encoder.expect_len(hparams["num_chars"])
 
     # 4. Define char pipeline:
     @sb.utils.data_pipeline.takes("phn")
@@ -119,6 +120,7 @@ def data_prep(data_folder, hparams):
     phn_encoder.insert_bos_eos(bos_index=hparams["bos_index"])
     phn_encoder.update_from_didataset(train_data, output_key="phn_list")
     phn_encoder.update_from_didataset(valid_data, output_key="phn_list")
+    phn_encoder.expect_len(hparams["num_phns"])
 
     # 6. Set output:
     sb.dataio.dataset.set_output_keys(

--- a/tests/integration/G2P/hyperparams.yaml
+++ b/tests/integration/G2P/hyperparams.yaml
@@ -11,7 +11,7 @@ dataloader_options:
 # token information
 bos_index: 0 # eos_index = bos_index + 1
 num_phns: 45 # 43 phonemes + 1 bos + 1 eos
-num_chars: 26 # 24 chars + 1 bos + 1 eos
+num_chars: 25 # 23 chars + 1 bos + 1 eos
 
 
 # Model parameters

--- a/tests/integration/LM_RNN/example_lm_rnn_experiment.py
+++ b/tests/integration/LM_RNN/example_lm_rnn_experiment.py
@@ -54,6 +54,7 @@ def data_prep(data_folder, hparams):
     )
     datasets = [train_data, valid_data]
     char_encoder = sb.dataio.encoder.TextEncoder()
+    char_encoder.expect_len(hparams["num_chars"])
 
     # 2. Define char pipeline:
     @sb.utils.data_pipeline.takes("char")

--- a/tests/integration/LM_RNN/hyperparams.yaml
+++ b/tests/integration/LM_RNN/hyperparams.yaml
@@ -10,7 +10,7 @@ dataloader_options:
 
 # token information
 bos_index: 0 # eos_index = bos_index + 1
-num_chars: 26 # 24 chars + 1 bos + 1 eos
+num_chars: 25 # 23 chars + 1 bos + 1 eos
 
 # Model parameters
 rnn_layers: 1

--- a/tests/integration/speaker_id/example_xvector_experiment.py
+++ b/tests/integration/speaker_id/example_xvector_experiment.py
@@ -65,6 +65,7 @@ def data_prep(data_folder, hparams):
     )
     datasets = [train_data, valid_data]
     label_encoder = sb.dataio.encoder.CategoricalEncoder()
+    label_encoder.expect_len(hparams["num_spks"])
 
     # 2. Define audio pipeline:
     @sb.utils.data_pipeline.takes("wav")

--- a/tests/unittests/test_categorical_encoder.py
+++ b/tests/unittests/test_categorical_encoder.py
@@ -155,6 +155,23 @@ def test_categorical_encoder_from_dataset():
     assert encoder.decode_ndim(dataset[0]["words_t"]) == ["hello", "world"]
 
 
+def test_categorical_encoder_length_check():
+    from speechbrain.dataio.encoder import CategoricalEncoder
+
+    encoder = CategoricalEncoder()
+    encoder.update_from_iterable("abcd")
+
+    encoder.expect_len(3)
+    with pytest.raises(RuntimeError):
+        encoder.encode_label("a")
+
+    encoder.ignore_len()
+    encoder.encode_label("a")
+
+    encoder.expect_len(4)
+    encoder.encode_label("a")
+
+
 def test_text_encoder(tmpdir):
     from speechbrain.dataio.encoder import TextEncoder
 

--- a/tests/unittests/test_categorical_encoder.py
+++ b/tests/unittests/test_categorical_encoder.py
@@ -5,6 +5,7 @@ def test_categorical_encoder(device):
     from speechbrain.dataio.encoder import CategoricalEncoder
 
     encoder = CategoricalEncoder()
+    encoder.expect_len(4)
     encoder.update_from_iterable("abcd")
     integers = encoder.encode_sequence("dcba")
     assert all(isinstance(i, int) for i in integers)
@@ -23,6 +24,7 @@ def test_categorical_encoder(device):
     import torch
 
     encoder = CategoricalEncoder()
+    encoder.expect_len(4)
     encoder.update_from_iterable("abcd")
     result = encoder.decode_torch(
         torch.tensor([[0, 0], [1, 1], [2, 2], [3, 3]], device=device)
@@ -42,11 +44,13 @@ def test_categorical_encoder(device):
     assert result == [["a", "a"], ["b"], ["c", "c", "c"], []]
 
     encoder = CategoricalEncoder()
+    encoder.expect_len(3)
     encoder.limited_labelset_from_iterable("aabbbcccd", n_most_common=3)
     encoder.encode_sequence("abc")
     with pytest.raises(KeyError):
         encoder.encode_label("d")
     encoder = CategoricalEncoder()
+    encoder.expect_len(2)
     encoder.limited_labelset_from_iterable("aabbbcccd", min_count=3)
     encoder.encode_sequence("cbcb")
     with pytest.raises(KeyError):
@@ -54,6 +58,7 @@ def test_categorical_encoder(device):
     with pytest.raises(KeyError):
         encoder.encode_label("d")
     encoder = CategoricalEncoder()
+    encoder.expect_len(2)
     encoder.limited_labelset_from_iterable(
         "aabbbcccd", n_most_common=3, min_count=3
     )
@@ -64,6 +69,7 @@ def test_categorical_encoder(device):
         encoder.encode_label("d")
 
     encoder = CategoricalEncoder(unk_label="<unk>")
+    encoder.expect_len(4)
     encoder.update_from_iterable("abc")
     assert encoder.encode_label("a") == 1
     assert encoder.encode_label("d") == 0
@@ -83,6 +89,7 @@ def test_categorical_encoder_saving(tmpdir):
         assert False  # We should not get here!
     # Now, imagine a recovery:
     encoder = CategoricalEncoder()
+    encoder.expect_len(4)
     # The second time, the encoding is just loaded from file:
     if not encoder.load_if_possible(encoding_file):
         assert False  # We should not get here!
@@ -98,6 +105,7 @@ def test_categorical_encoder_saving(tmpdir):
     encoder.save(encoding_file)
     # Reload
     encoder = CategoricalEncoder()
+    encoder.expect_len(2)
     assert encoder.load_if_possible(encoding_file)
     assert encoder.encode_label((1, 2)) == -1
 
@@ -107,12 +115,14 @@ def test_categorical_encoder_saving(tmpdir):
     encoder.update_from_iterable("abc")
     encoder.save(encoding_file)
     encoder = CategoricalEncoder()
+    encoder.expect_len(4)
     assert encoder.load_if_possible(encoding_file)
     assert encoder.encode_label("a") == 1
     assert encoder.decode_ndim(encoder.encode_label("d")) == "UNKNOWN"
     # Even if set differently:
     encoder = CategoricalEncoder()
     encoder.add_unk()
+    encoder.expect_len(4)
     assert encoder.load_if_possible(encoding_file)
     assert encoder.encode_label("a") == 1
     assert encoder.decode_ndim(encoder.encode_label("d")) == "UNKNOWN"
@@ -140,6 +150,7 @@ def test_categorical_encoder_from_dataset():
     output_keys = ["words_t"]
     dataset = DynamicItemDataset(data, dynamic_items, output_keys)
     encoder.update_from_didataset(dataset, "words", sequence_input=True)
+    encoder.expect_len(7)
     assert dataset[0]["words_t"] == [0, 1]
     assert encoder.decode_ndim(dataset[0]["words_t"]) == ["hello", "world"]
 
@@ -154,6 +165,7 @@ def test_text_encoder(tmpdir):
         [["hello", "world"], ["how", "are", "you", "world"]],
         sequence_input=True,
     )
+    encoder.expect_len(7)
     encoded = encoder.encode_sequence(
         encoder.prepend_bos_label(["are", "you", "world"])
     )
@@ -164,6 +176,7 @@ def test_text_encoder(tmpdir):
     assert encoded[-1] == 1  # By default uses just one sentence_boundary marker
     encoder.save(encoding_file)
     encoder = TextEncoder()
+    encoder.expect_len(7)
     assert encoder.load_if_possible(encoding_file)
     encoded = encoder.encode_sequence(
         encoder.append_eos_label(["are", "you", "world"])
@@ -179,6 +192,7 @@ def test_ctc_encoder(tmpdir):
     from speechbrain.dataio.encoder import CTCTextEncoder
 
     encoder = CTCTextEncoder()
+    encoder.expect_len(9)  # "abcdef" + bos + eos + blank
     encoder.insert_bos_eos(
         bos_label="<s>", bos_index=0, eos_label="</s>", eos_index=1
     )
@@ -189,6 +203,7 @@ def test_ctc_encoder(tmpdir):
     assert encoded[0] == 0
     encoder.save(encoding_file)
     encoder = CTCTextEncoder()
+    encoder.expect_len(9)
     assert encoder.load_if_possible(encoding_file)
     assert (
         "".join(encoder.collapse_labels("_bb_aaa___bbbbb_b_eeee_____"))


### PR DESCRIPTION
This introduces new user methods to `CategoricalEncoder`: `expect_len` and `ignore_len`. When neither of these are called, a `UserWarning` will be emitted once, informing the user that it is recommended to explicitly provide the category count they expect.

`expect_len` can be used to specify the expected final length of the encoder. When a mismatch is observed between that value and the real observed `len()` of the encoder during encoding or decoding, an exception is raised.

Solves #1589 and #1696 as `CTCTextEncoder` is a subclass of `CategoricalEncoder` (through `TextEncoder`).

TODOs:

- [x] Implement tests for the feature (alongside other tests in `test_categorical_encoder`)
- [x] ~~Modify existing recipes to eliminate warnings~~ See comments
- [x] Modify existing tests to eliminate warnings
- [x] Modify existing doctests to eliminate warnings
- [x] Add examples/doctests to the docs