### PR TITLE
Linters updates (housekeeping)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0  # Use the ref you want to point at
+    rev: v4.4.0  # Use the ref you want to point at
     hooks:
       - id: trailing-whitespace
         types: [file, text]
@@ -14,18 +14,17 @@ repos:
         args: [--maxkb=1024]
 
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 23.1.0
     hooks:
       - id: black
         types: [python]
-        additional_dependencies: ['click==8.0.4']
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.7.9
+    rev: 6.0.0
     hooks:
       - id: flake8
         types: [python]
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.23.0
+    rev: v1.29.0
     hooks:
       - id: yamllint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,10 +18,17 @@ repos:
     hooks:
       - id: black
         types: [python]
+
   - repo: https://github.com/PyCQA/flake8
     rev: 6.0.0
     hooks:
       - id: flake8
+        types: [python]
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
         types: [python]
 
   - repo: https://github.com/adrienverge/yamllint

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,5 +1,6 @@
 black==23.1.0
 flake8==6.0.0
+isort==5.12.0
 pycodestyle==2.10.0
 pytest==7.2.2
 yamllint==1.29.0

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,6 +1,5 @@
-black==19.10b0
-click==8.0.4
-flake8==3.7.9
-pycodestyle==2.5.0
-pytest==5.4.1
-yamllint==1.23.0
+black==23.1.0
+flake8==6.0.0
+pycodestyle==2.10.0
+pytest==7.2.2
+yamllint==1.29.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 -r lint-requirements.txt
+cchardet
+chardet
 huggingface_hub>=0.12.1
 hyperpyyaml>=1.1.0
 joblib>=1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 -r lint-requirements.txt
-huggingface_hub>=0.7.0
-hyperpyyaml>=0.0.1
-joblib>=0.14.1
-numpy>=1.17.0
+huggingface_hub>=0.12.1
+hyperpyyaml>=1.1.0
+joblib>=1.2.0
+numpy>=1.24.0
 packaging
-pre-commit>=2.3.0
-scipy>=1.4.1, <1.9
-sentencepiece>=0.1.91
+pre-commit>=3.1.1
+scipy>=1.10.0
+sentencepiece>=0.1.97
 SoundFile; sys_platform == 'win32'
-torch>=1.9.0
-torchaudio>=0.9.0
-tqdm>=4.42.0
+torch>=1.13.1
+torchaudio>=0.13.1
+tqdm>=4.65.0


### PR DESCRIPTION
This PR accompanies #1353.

When running
```shell
pre-commit run --all-files
```
in a fresh environment (e.g. Pyhon 3.8), the log will look like this:
```python
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Initializing environment for https://github.com/psf/black.
[INFO] Initializing environment for https://github.com/PyCQA/flake8.
[INFO] Initializing environment for https://github.com/adrienverge/yamllint.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/psf/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/flake8.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/adrienverge/yamllint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
fix requirements.txt.....................................................Failed
- hook id: requirements-txt-fixer
- exit code: 1
- files were modified by this hook

Sorting docs/docs-requirements.txt

mixed line ending........................................................Passed
check for added large files..............................................Passed
black....................................................................Failed
- hook id: black
- files were modified by this hook

reformatted recipes/AISHELL-1/Tokenizer/pretrained.py
...
reformatted tests/utils/recipe_tests.py

All done! ✨ 🍰 ✨
264 files reformatted, 115 files left unchanged.

flake8...................................................................Failed
- hook id: flake8
- exit code: 1

recipes/Aishell1Mix/separation/scripts/create_aishell1mix_from_metadata.py:313:27: F541 f-string is missing placeholders
...
speechbrain/lobes/models/HifiGAN.py:650:13: E741 ambiguous variable name 'l'

yamllint.................................................................Passed
```

As this line indicates
```python
fix requirements.txt.....................................................Failed
```
the linters checks for this PR itself & its direct changes is not the goal at its opening. This PR is not to loose sight of that requirements will need updating when it comes to v0.6 (at some later point; hence its merging to the `unstable-v0.6` branch).

When merging this one alongside with cspell, the latest versions need to be agreed upon. As one can readily identify from this PR's file changes, there are quite some version gaps which can be recovered ;-)

Recommendation to keep the `unstable-v0.6` branch as clean as possible:
* get everything that needs to be on unstable-v0.6 on it
* cspell PR: move to latest version & check proposed file changes
* this PR: final reformattings -> please feel free to add into this PR branch directly

My gut feeling is that this will happen after April.