### PR TITLE
adding pretrainer in hyperparameter file LJSPEECH/TTS recipe

### DIFF
--- a/recipes/LJSpeech/TTS/tacotron2/hparams/train.yaml
+++ b/recipes/LJSpeech/TTS/tacotron2/hparams/train.yaml
@@ -231,3 +231,10 @@ progress_sample_logger: !new:speechbrain.utils.train_logger.ProgressSampleLogger
   batch_sample_size: !ref <progress_batch_sample_size>
   formats:
     raw_batch: raw
+
+
+text_to_sequence: !name:speechbrain.utils.text_to_sequence.text_to_sequence
+
+pretrainer: !new:speechbrain.utils.parameter_transfer.Pretrainer
+    loadables:
+        model: !ref <model>

--- a/recipes/LJSpeech/TTS/vocoder/hifi_gan/hparams/train.yaml
+++ b/recipes/LJSpeech/TTS/vocoder/hifi_gan/hparams/train.yaml
@@ -183,3 +183,7 @@ checkpointer: !new:speechbrain.utils.checkpoints.Checkpointer
     generator: !ref <generator>
     discriminator: !ref <discriminator>
     counter: !ref <epoch_counter>
+
+pretrainer: !new:speechbrain.utils.parameter_transfer.Pretrainer
+    loadables:
+        generator: !ref <generator>


### PR DESCRIPTION
Adding pretrainer in the hyperparameter file for both Tacotron2 and the vocoder in order to be able to do the inference with a local trained model since for the TTS task the best way to evaluate a model is listening.