### PR TITLE
Fix for #1886

### DIFF
--- a/speechbrain/processing/features.py
+++ b/speechbrain/processing/features.py
@@ -36,7 +36,6 @@ Authors
 import math
 import torch
 import logging
-from packaging import version
 from speechbrain.utils.checkpoints import (
     mark_as_saver,
     mark_as_loader,

--- a/speechbrain/processing/features.py
+++ b/speechbrain/processing/features.py
@@ -145,31 +145,18 @@ class STFT(torch.nn.Module):
             x = x.transpose(1, 2)
             x = x.reshape(or_shape[0] * or_shape[2], or_shape[1])
 
-        if version.parse(torch.__version__) <= version.parse("1.6.0"):
-            stft = torch.stft(
-                x,
-                self.n_fft,
-                self.hop_length,
-                self.win_length,
-                self.window.to(x.device),
-                self.center,
-                self.pad_mode,
-                self.normalized_stft,
-                self.onesided,
-            )
-        else:
-            stft = torch.stft(
-                x,
-                self.n_fft,
-                self.hop_length,
-                self.win_length,
-                self.window.to(x.device),
-                self.center,
-                self.pad_mode,
-                self.normalized_stft,
-                self.onesided,
-                return_complex=False,
-            )
+        stft = torch.stft(
+            x,
+            self.n_fft,
+            self.hop_length,
+            self.win_length,
+            self.window.to(x.device),
+            self.center,
+            self.pad_mode,
+            self.normalized_stft,
+            self.onesided,
+            return_complex=False,
+        )
 
         # Retrieving the original dimensionality (batch,time, channels)
         if len(or_shape) == 3:


### PR DESCRIPTION
As pointed in #1886 it's an out-dated check.
https://github.com/speechbrain/speechbrain/blob/beec862238c4c2ccfcb20d9ca592b671673ee6af/speechbrain/processing/features.py#L148-L173

Dropped the if branch of the statement. 
Note: the then branch adds `return_complex=False,` to the parameters.