### PR TITLE
Fix for #1881

### DIFF
--- a/recipes/AISHELL-1/ASR/CTC/hparams/train_with_wav2vec.yaml
+++ b/recipes/AISHELL-1/ASR/CTC/hparams/train_with_wav2vec.yaml
@@ -43,11 +43,11 @@ test_batch_size: 4
 
 dynamic_batching: False
 dynamic_batch_sampler:
-   feats_hop_size: 0.01
-   max_batch_len: 15 # in terms of "duration" in annotations by default, second here
-   left_bucket_len: 200 # old implementation attributs
-   multiplier: 1.1 # old implementation attributs
-   shuffle_ex: False # if true re-creates batches at each epoch shuffling examples.
+   # feats_hop_size: 0.01
+   max_duration_per_batch: 15 # in terms of "duration" in annotations by default, second here
+   # left_bucket_len: 200 # old implementation attributs
+   # multiplier: 1.1 # old implementation attributs
+   shuffle: False # if true re-creates batches at each epoch shuffling examples.
    num_buckets: 10 # floor(log(max_batch_len/left_bucket_len, multiplier)) + 1
    batch_ordering: ascending
 

--- a/recipes/AISHELL-1/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/AISHELL-1/ASR/CTC/train_with_wav2vec.py
@@ -277,24 +277,17 @@ def dataio_prepare(hparams):
         from speechbrain.dataio.sampler import DynamicBatchSampler  # noqa
 
         dynamic_hparams = hparams["dynamic_batch_sampler"]
-        num_buckets = dynamic_hparams["num_buckets"]
 
         train_batch_sampler = DynamicBatchSampler(
             train_data,
-            dynamic_hparams["max_batch_len"],
-            num_buckets=num_buckets,
-            length_func=lambda x: x["duration"],
-            shuffle=dynamic_hparams["shuffle_ex"],
-            batch_ordering=dynamic_hparams["batch_ordering"],
+            # length_func=lambda x: x["duration"],
+            **dynamic_hparams,
         )
 
         valid_batch_sampler = DynamicBatchSampler(
             valid_data,
-            dynamic_hparams["max_batch_len"],
-            num_buckets=num_buckets,
-            length_func=lambda x: x["duration"],
-            shuffle=dynamic_hparams["shuffle_ex"],
-            batch_ordering=dynamic_hparams["batch_ordering"],
+            # length_func=lambda x: x["duration"],
+            **dynamic_hparams,
         )
 
     return (

--- a/recipes/AISHELL-1/ASR/seq2seq/hparams/train.yaml
+++ b/recipes/AISHELL-1/ASR/seq2seq/hparams/train.yaml
@@ -37,11 +37,11 @@ sorting: ascending
 
 dynamic_batching: True
 dynamic_batch_sampler:
-   feats_hop_size: 0.01
-   max_batch_len: 15 # in terms of "duration" in annotations by default, second here
-   left_bucket_len: 200 # old implementation attributs
-   multiplier: 1.1 # old implementation attributs
-   shuffle_ex: False # if true re-creates batches at each epoch shuffling examples.
+   # feats_hop_size: 0.01
+   max_duration_per_batch: 15 # in terms of "duration" in annotations by default, second here
+   # left_bucket_len: 200 # old implementation attributs
+   # multiplier: 1.1 # old implementation attributs
+   shuffle: False # if true re-creates batches at each epoch shuffling examples.
    num_buckets: 10 # floor(log(max_batch_len/left_bucket_len, multiplier)) + 1
    batch_ordering: ascending
 

--- a/recipes/AISHELL-1/ASR/seq2seq/train.py
+++ b/recipes/AISHELL-1/ASR/seq2seq/train.py
@@ -255,24 +255,17 @@ def dataio_prepare(hparams):
         from speechbrain.dataio.sampler import DynamicBatchSampler  # noqa
 
         dynamic_hparams = hparams["dynamic_batch_sampler"]
-        num_buckets = dynamic_hparams["num_buckets"]
 
         train_batch_sampler = DynamicBatchSampler(
             train_data,
-            dynamic_hparams["max_batch_len"],
-            num_buckets=num_buckets,
-            length_func=lambda x: x["duration"],
-            shuffle=dynamic_hparams["shuffle_ex"],
-            batch_ordering=dynamic_hparams["batch_ordering"],
+            # length_func=lambda x: x["duration"],
+            **dynamic_hparams,
         )
 
         valid_batch_sampler = DynamicBatchSampler(
             valid_data,
-            dynamic_hparams["max_batch_len"],
-            num_buckets=num_buckets,
-            length_func=lambda x: x["duration"],
-            shuffle=dynamic_hparams["shuffle_ex"],
-            batch_ordering=dynamic_hparams["batch_ordering"],
+            # length_func=lambda x: x["duration"],
+            **dynamic_hparams,
         )
 
     return (

--- a/recipes/AISHELL-1/ASR/transformer/hparams/train_ASR_transformer.yaml
+++ b/recipes/AISHELL-1/ASR/transformer/hparams/train_ASR_transformer.yaml
@@ -36,11 +36,11 @@ sorting: random
 
 dynamic_batching: False
 dynamic_batch_sampler:
-    feats_hop_size: 0.01
-    max_batch_len: 15 # in terms of "duration" in annotations by default, second here
-    left_bucket_len: 200 # old implementation attributs
-    multiplier: 1.1 # old implementation attributs
-    shuffle_ex: False # if true re-creates batches at each epoch shuffling examples.
+    # feats_hop_size: 0.01
+    max_duration_per_batch: 15 # in terms of "duration" in annotations by default, second here
+    # left_bucket_len: 200 # old implementation attributs
+    # multiplier: 1.1 # old implementation attributs
+    shuffle: False # if true re-creates batches at each epoch shuffling examples.
     num_buckets: 10 # floor(log(max_batch_len/left_bucket_len, multiplier)) + 1
     batch_ordering: ascending
 

--- a/recipes/AISHELL-1/ASR/transformer/hparams/train_ASR_transformer_with_wav2vect.yaml
+++ b/recipes/AISHELL-1/ASR/transformer/hparams/train_ASR_transformer_with_wav2vect.yaml
@@ -41,11 +41,11 @@ sorting: random
 
 dynamic_batching: False
 dynamic_batch_sampler:
-    feats_hop_size: 0.01
-    max_batch_len: 15 # in terms of "duration" in annotations by default, second here
-    left_bucket_len: 200 # old implementation attributs
-    multiplier: 1.1 # old implementation attributs
-    shuffle_ex: False # if true re-creates batches at each epoch shuffling examples.
+    # feats_hop_size: 0.01
+    max_duration_per_batch: 15 # in terms of "duration" in annotations by default, second here
+    # left_bucket_len: 200 # old implementation attributs
+    # multiplier: 1.1 # old implementation attributs
+    shuffle: False # if true re-creates batches at each epoch shuffling examples.
     num_buckets: 10 # floor(log(max_batch_len/left_bucket_len, multiplier)) + 1
     batch_ordering: ascending
 

--- a/recipes/AISHELL-1/ASR/transformer/train.py
+++ b/recipes/AISHELL-1/ASR/transformer/train.py
@@ -359,24 +359,17 @@ def dataio_prepare(hparams):
         from speechbrain.dataio.sampler import DynamicBatchSampler  # noqa
 
         dynamic_hparams = hparams["dynamic_batch_sampler"]
-        num_buckets = dynamic_hparams["num_buckets"]
 
         train_batch_sampler = DynamicBatchSampler(
             train_data,
-            dynamic_hparams["max_batch_len"],
-            num_buckets=num_buckets,
-            length_func=lambda x: x["duration"],
-            shuffle=dynamic_hparams["shuffle_ex"],
-            batch_ordering=dynamic_hparams["batch_ordering"],
+            # length_func=lambda x: x["duration"],
+            **dynamic_hparams,
         )
 
         valid_batch_sampler = DynamicBatchSampler(
             valid_data,
-            dynamic_hparams["max_batch_len"],
-            num_buckets=num_buckets,
-            length_func=lambda x: x["duration"],
-            shuffle=dynamic_hparams["shuffle_ex"],
-            batch_ordering=dynamic_hparams["batch_ordering"],
+            # length_func=lambda x: x["duration"],
+            **dynamic_hparams,
         )
 
     return (

--- a/recipes/AISHELL-1/ASR/transformer/train_with_wav2vect.py
+++ b/recipes/AISHELL-1/ASR/transformer/train_with_wav2vect.py
@@ -378,24 +378,17 @@ def dataio_prepare(hparams):
         from speechbrain.dataio.sampler import DynamicBatchSampler  # noqa
 
         dynamic_hparams = hparams["dynamic_batch_sampler"]
-        num_buckets = dynamic_hparams["num_buckets"]
 
         train_batch_sampler = DynamicBatchSampler(
             train_data,
-            dynamic_hparams["max_batch_len"],
-            num_buckets=num_buckets,
-            length_func=lambda x: x["duration"],
-            shuffle=dynamic_hparams["shuffle_ex"],
-            batch_ordering=dynamic_hparams["batch_ordering"],
+            # length_func=lambda x: x["duration"],
+            **dynamic_hparams,
         )
 
         valid_batch_sampler = DynamicBatchSampler(
             valid_data,
-            dynamic_hparams["max_batch_len"],
-            num_buckets=num_buckets,
-            length_func=lambda x: x["duration"],
-            shuffle=dynamic_hparams["shuffle_ex"],
-            batch_ordering=dynamic_hparams["batch_ordering"],
+            # length_func=lambda x: x["duration"],
+            **dynamic_hparams,
         )
 
     return (

--- a/recipes/CommonVoice/self-supervised-learning/wav2vec2/hparams/wav2vec2_base.yaml
+++ b/recipes/CommonVoice/self-supervised-learning/wav2vec2/hparams/wav2vec2_base.yaml
@@ -80,9 +80,9 @@ dynamic_batching: False
 dyn_batch_len: 120 # Cumulative length of each batch, per gpu.
 max_batch_size: 64 # Max number of samples per batch, per gpu.
 dynamic_batch_sampler:
-    max_batch_len: !ref <dyn_batch_len>
+    max_duration_per_batch: !ref <dyn_batch_len>
     max_batch_ex: !ref <max_batch_size>
-    shuffle_ex: True
+    shuffle: True
     batch_ordering: !ref <sorting>
     num_buckets: 30
 

--- a/recipes/CommonVoice/self-supervised-learning/wav2vec2/train_hf_wav2vec2.py
+++ b/recipes/CommonVoice/self-supervised-learning/wav2vec2/train_hf_wav2vec2.py
@@ -259,24 +259,17 @@ def dataio_prepare(hparams):
         from speechbrain.dataio.sampler import DynamicBatchSampler  # noqa
 
         dynamic_hparams = hparams["dynamic_batch_sampler"]
-        num_buckets = dynamic_hparams["num_buckets"]
 
         train_batch_sampler = DynamicBatchSampler(
             train_data,
-            dynamic_hparams["max_batch_len"],
-            num_buckets=num_buckets,
-            length_func=lambda x: x["duration"],
-            shuffle=dynamic_hparams["shuffle_ex"],
-            batch_ordering=dynamic_hparams["batch_ordering"],
+            # length_func=lambda x: x["duration"],
+            **dynamic_hparams,
         )
 
         valid_batch_sampler = DynamicBatchSampler(
             valid_data,
-            dynamic_hparams["max_batch_len"],
-            num_buckets=num_buckets,
-            length_func=lambda x: x["duration"],
-            shuffle=dynamic_hparams["shuffle_ex"],
-            batch_ordering=dynamic_hparams["batch_ordering"],
+            # length_func=lambda x: x["duration"],
+            **dynamic_hparams,
         )
 
     return (

--- a/recipes/LibriSpeech/ASR/seq2seq/hparams/train_BPE_1000.yaml
+++ b/recipes/LibriSpeech/ASR/seq2seq/hparams/train_BPE_1000.yaml
@@ -51,10 +51,10 @@ sorting: ascending
 dynamic_batching: False
 
 # dynamic batching parameters, if used
+feats_hop_size: 0.01
 dynamic_batch_sampler:
-   feats_hop_size: 0.01
-   max_batch_len: 20000 # in terms of frames
-   shuffle_ex: True
+   max_duration_per_batch: 20000 # in terms of frames
+   shuffle: True
    batch_ordering: random
    num_buckets: 20
 

--- a/recipes/LibriSpeech/ASR/seq2seq/hparams/train_BPE_5000.yaml
+++ b/recipes/LibriSpeech/ASR/seq2seq/hparams/train_BPE_5000.yaml
@@ -51,10 +51,10 @@ sorting: ascending
 dynamic_batching: False
 
 # dynamic batching parameters, if used
+feats_hop_size: 0.01
 dynamic_batch_sampler:
-   feats_hop_size: 0.01
-   max_batch_len: 20000 # in terms of frames
-   shuffle_ex: True
+   max_duration_per_batch: 20000 # in terms of frames
+   shuffle: True
    batch_ordering: random
    num_buckets: 20
 

--- a/recipes/LibriSpeech/ASR/seq2seq/train.py
+++ b/recipes/LibriSpeech/ASR/seq2seq/train.py
@@ -301,26 +301,19 @@ def dataio_prepare(hparams):
         from speechbrain.dataio.batch import PaddedBatch  # noqa
 
         dynamic_hparams = hparams["dynamic_batch_sampler"]
-        hop_size = dynamic_hparams["feats_hop_size"]
-
-        num_buckets = dynamic_hparams["num_buckets"]
+        hop_size = hparams["feats_hop_size"]
 
         train_batch_sampler = DynamicBatchSampler(
             train_data,
-            dynamic_hparams["max_batch_len"],
-            num_buckets=num_buckets,
-            length_func=lambda x: x["duration"] * (1 / hop_size),
-            shuffle=dynamic_hparams["shuffle_ex"],
-            batch_ordering=dynamic_hparams["batch_ordering"],
+            length_func=lambda x: x["duration"]
+            * (1 / hop_size),  # maps duration to frames
+            **dynamic_hparams,
         )
 
         valid_batch_sampler = DynamicBatchSampler(
             valid_data,
-            dynamic_hparams["max_batch_len"],
-            num_buckets=num_buckets,
             length_func=lambda x: x["duration"] * (1 / hop_size),
-            shuffle=dynamic_hparams["shuffle_ex"],
-            batch_ordering=dynamic_hparams["batch_ordering"],
+            **dynamic_hparams,
         )
 
     return (

--- a/recipes/LibriSpeech/ASR/transformer/hparams/transformer.yaml
+++ b/recipes/LibriSpeech/ASR/transformer/hparams/transformer.yaml
@@ -63,11 +63,17 @@ max_batch_len: 600
 max_batch_len_val: 100 # we reduce it as the beam is much wider (VRAM)
 num_bucket: 200
 
-dynamic_batch_sampler:
-    max_batch_len: !ref <max_batch_len>
-    max_batch_len_val: !ref <max_batch_len_val>
+dynamic_batch_sampler_train:
+    max_duration_per_batch: !ref <max_batch_len>
     num_buckets: !ref <num_bucket>
-    shuffle_ex: True # if true re-creates batches at each epoch shuffling examples.
+    shuffle: True # if true re-creates batches at each epoch shuffling examples.
+    batch_ordering: random
+    max_batch_ex: 128
+
+dynamic_batch_sampler_valid:
+    max_duration_per_batch: !ref <max_batch_len_val>
+    num_buckets: !ref <num_bucket>
+    shuffle: True # if true re-creates batches at each epoch shuffling examples.
     batch_ordering: random
     max_batch_ex: 128
 

--- a/recipes/LibriSpeech/ASR/transformer/train.py
+++ b/recipes/LibriSpeech/ASR/transformer/train.py
@@ -380,25 +380,19 @@ def dataio_prepare(hparams):
     if hparams["dynamic_batching"]:
         from speechbrain.dataio.sampler import DynamicBatchSampler  # noqa
 
-        dynamic_hparams = hparams["dynamic_batch_sampler"]
-        num_buckets = dynamic_hparams["num_buckets"]
+        dynamic_hparams_train = hparams["dynamic_batch_sampler_train"]
+        dynamic_hparams_valid = hparams["dynamic_batch_sampler_valid"]
 
         train_batch_sampler = DynamicBatchSampler(
             train_data,
-            dynamic_hparams["max_batch_len"],
-            num_buckets=num_buckets,
-            length_func=lambda x: x["duration"],
-            shuffle=dynamic_hparams["shuffle_ex"],
-            batch_ordering=dynamic_hparams["batch_ordering"],
+            # length_func=lambda x: x["duration"],
+            **dynamic_hparams_train,
         )
 
         valid_batch_sampler = DynamicBatchSampler(
             valid_data,
-            dynamic_hparams["max_batch_len_val"],
-            num_buckets=num_buckets,
-            length_func=lambda x: x["duration"],
-            shuffle=dynamic_hparams["shuffle_ex"],
-            batch_ordering=dynamic_hparams["batch_ordering"],
+            # length_func=lambda x: x["duration"],
+            **dynamic_hparams_valid,
         )
 
     return (

--- a/recipes/LibriSpeech/self-supervised-learning/wav2vec2/hparams/wav2vec2_base.yaml
+++ b/recipes/LibriSpeech/self-supervised-learning/wav2vec2/hparams/wav2vec2_base.yaml
@@ -30,8 +30,12 @@ number_of_epochs: 3000
 optimizer_step_limit: 400000
 
 # Dynamic Batching parameters
-train_num_buckets: 70
-seconds_per_batch: 200 # Fits in a 32GB GPUs (V100)
+dynamic_batch_sampler_train:
+   num_buckets: 70  # for training
+   # seconds_per_batch
+   max_duration_per_batch: 200 # Fits in a 32GB GPUs (V100)
+   batch_ordering: random
+   shuffle: True
 
 train_dataloader_options:
    num_workers: 4

--- a/recipes/LibriSpeech/self-supervised-learning/wav2vec2/train_sb_wav2vec2.py
+++ b/recipes/LibriSpeech/self-supervised-learning/wav2vec2/train_sb_wav2vec2.py
@@ -292,13 +292,11 @@ def dataio_prepare(hparams):
     sb.dataio.dataset.set_output_keys(datasets, ["id", "sig"])
 
     # We create the DynamicBatch Sampler
+    dynamic_hparams = hparams["dynamic_batch_sampler_train"]
     train_sampler = DynamicBatchSampler(
         train_data,
-        hparams["seconds_per_batch"],
-        num_buckets=hparams["train_num_buckets"],
-        length_func=lambda x: x["duration"],
-        batch_ordering="random",
-        shuffle=True,
+        # length_func=lambda x: x["duration"],
+        **dynamic_hparams,
     )
 
     # We define the custom collation function that is necessary for w2v2 to

--- a/recipes/Switchboard/ASR/seq2seq/hparams/train_BPE_2000.yaml
+++ b/recipes/Switchboard/ASR/seq2seq/hparams/train_BPE_2000.yaml
@@ -66,10 +66,10 @@ sorting: ascending
 dynamic_batching: False
 
 # dynamic batching parameters, if used
+feats_hop_size: 0.01
 dynamic_batch_sampler:
-   feats_hop_size: 0.01
-   max_batch_len: 20000 # in terms of frames
-   shuffle_ex: True
+   max_duration_per_batch: 20000 # in terms of frames
+   shuffle: True
    batch_ordering: random
    num_buckets: 20
 

--- a/recipes/Switchboard/ASR/seq2seq/train.py
+++ b/recipes/Switchboard/ASR/seq2seq/train.py
@@ -345,26 +345,20 @@ def dataio_prepare(hparams):
         from speechbrain.dataio.batch import PaddedBatch  # noqa
 
         dynamic_hparams = hparams["dynamic_batch_sampler"]
-        hop_size = dynamic_hparams["feats_hop_size"]
-
-        num_buckets = dynamic_hparams["num_buckets"]
+        hop_size = hparams["feats_hop_size"]
 
         train_batch_sampler = DynamicBatchSampler(
             train_data,
-            dynamic_hparams["max_batch_len"],
-            num_buckets=num_buckets,
-            length_func=lambda x: int(float(x["duration"]) * (1 / hop_size)),
-            shuffle=dynamic_hparams["shuffle_ex"],
-            batch_ordering=dynamic_hparams["batch_ordering"],
+            length_func=lambda x: int(
+                float(x["duration"]) * (1 / hop_size)
+            ),  # to frames
+            **dynamic_hparams,
         )
 
         valid_batch_sampler = DynamicBatchSampler(
             valid_data,
-            dynamic_hparams["max_batch_len"],
-            num_buckets=num_buckets,
             length_func=lambda x: int(float(x["duration"]) * (1 / hop_size)),
-            shuffle=dynamic_hparams["shuffle_ex"],
-            batch_ordering=dynamic_hparams["batch_ordering"],
+            **dynamic_hparams,
         )
 
     return (

--- a/recipes/TIMIT/ASR/seq2seq/hparams/train.yaml
+++ b/recipes/TIMIT/ASR/seq2seq/hparams/train.yaml
@@ -76,11 +76,11 @@ test_dataloader_opts:
 # For more info, see speechbrain.dataio.sampler.DynamicBatchSampler
 dynamic_batching: False
 
+feats_hop_size: 0.01
 dynamic_batch_sampler:
-    feats_hop_size: 0.01
-    max_batch_len: 5000 # in terms of frames
+    max_duration_per_batch: 5000 # in terms of frames
     num_buckets: 20
-    shuffle_ex: False # if true re-creates batches at each epoch shuffling examples.
+    shuffle: False # if true re-creates batches at each epoch shuffling examples.
     batch_ordering: random
 
 

--- a/recipes/TIMIT/ASR/seq2seq/train.py
+++ b/recipes/TIMIT/ASR/seq2seq/train.py
@@ -281,11 +281,8 @@ def dataio_prep(hparams):
 
         batch_sampler = DynamicBatchSampler(
             train_data,
-            dynamic_hparams["max_batch_len"],
-            num_buckets=dynamic_hparams["num_buckets"],
-            length_func=lambda x: x["duration"] * (1 / hop_size),
-            shuffle=dynamic_hparams["shuffle_ex"],
-            batch_ordering=dynamic_hparams["batch_ordering"],
+            length_func=lambda x: x["duration"] * (1 / hop_size),  # to frames
+            **dynamic_hparams,
         )
 
         train_data = SaveableDataLoader(

--- a/speechbrain/dataio/sampler.py
+++ b/speechbrain/dataio/sampler.py
@@ -631,7 +631,7 @@ class DynamicBatchSampler(Sampler):
             for bucket_indx in range(len(self._bucket_boundaries)):
                 try:
                     num_batches = stats_tracker[bucket_indx]["tot"] // (
-                        self._max_seconds_per_batch
+                        self._max_duration_per_batch
                     )
                     pad_factor = (
                         stats_tracker[bucket_indx]["max"]


### PR DESCRIPTION
As it looks like, none of the recipes which referred to the dynamic batch sampler were able to make use of all parameters specified in the recipe's hparams file. The reason is that the depending class is not instantiated through hyperpyyaml but during the recipe.

Furthermore, "length" as a variable name seems inconclusive as there were two args (length as duration & length as number of examples). As a result, the `max_batch_len` can be confused with `max_batch_ex`. The former term has been renamed here to make clear, it is about the duration. This change breaks the interface of the dynamic batch sampler, which is relevant only during training, for only few recipes (five of them have dynamic batching on). If that's an issue -> we can put this PR also on the unstable-v0.6 branch.

To test, simply run:
```
python -c 'from tests.utils.recipe_tests import run_recipe_tests; print("TEST FAILED!") if not(run_recipe_tests(filters_fields=["Hparam_file"], filters=[["recipes/TIMIT/ASR/seq2seq/hparams/train.yaml", "recipes/Switchboard/ASR/seq2seq/hparams/train_BPE_2000.yaml", "recipes/LibriSpeech/self-supervised-learning/wav2vec2/hparams/wav2vec2_base.yaml", "recipes/LibriSpeech/ASR/transformer/hparams/transformer.yaml", "recipes/LibriSpeech/ASR/seq2seq/hparams/train_BPE_5000.yaml", "recipes/LibriSpeech/ASR/seq2seq/hparams/train_BPE_1000.yaml", "recipes/CommonVoice/self-supervised-learning/wav2vec2/hparams/wav2vec2_base.yaml", "recipes/AISHELL-1/ASR/transformer/hparams/train_ASR_transformer_with_wav2vect.yaml", "recipes/AISHELL-1/ASR/transformer/hparams/train_ASR_transformer.yaml", "recipes/AISHELL-1/ASR/seq2seq/hparams/train.yaml", "recipes/AISHELL-1/ASR/CTC/hparams/train_with_wav2vec.yaml", "recipes/Switchboard/ASR/CTC/hparams/train_with_wav2vec.yaml", "recipes/Switchboard/Tokenizer/hparams/2K_unigram_subword_bpe.yaml", "recipes/Switchboard/LM/hparams/transformer.yaml"]], do_checks=False, run_opts="--device=cuda")) else print("TEST PASSED")'
```
This includes extra test cases for one Switchboard recipe, which are dependency test cases (need to run before the one depending on this PR).