### PR TITLE
Fix Conformer Instabilities and add Large Model

### DIFF
--- a/recipes/LibriSpeech/ASR/transformer/hparams/conformer_large.yaml
+++ b/recipes/LibriSpeech/ASR/transformer/hparams/conformer_large.yaml
@@ -184,7 +184,7 @@ model: !new:torch.nn.ModuleList
     - [!ref <CNN>, !ref <Transformer>, !ref <seq_lin>, !ref <ctc_lin>]
 
 # define two optimizers here for two-stage training
-Adam: !name:torch.optim.AdamW
+Adam: !name:torch.optim.Adam
     lr: !ref <lr_adam>
     betas: (0.9, 0.98)
     eps: 0.000000001

--- a/recipes/LibriSpeech/ASR/transformer/hparams/conformer_large.yaml
+++ b/recipes/LibriSpeech/ASR/transformer/hparams/conformer_large.yaml
@@ -236,7 +236,7 @@ seq_cost: !name:speechbrain.nnet.losses.kldiv_loss
 
 noam_annealing: !new:speechbrain.nnet.schedulers.NoamScheduler
     lr_initial: !ref <lr_adam>
-    n_warmup_steps: 35000
+    n_warmup_steps: 25000
 
 checkpointer: !new:speechbrain.utils.checkpoints.Checkpointer
     checkpoints_dir: !ref <save_folder>

--- a/recipes/LibriSpeech/ASR/transformer/hparams/conformer_large.yaml
+++ b/recipes/LibriSpeech/ASR/transformer/hparams/conformer_large.yaml
@@ -1,0 +1,291 @@
+# ############################################################################
+# Model: E2E ASR with Transformer
+# Encoder: Conformer Encoder
+# Decoder: Transformer Decoder + (CTC/ATT joint) beamsearch + TransformerLM
+# Tokens: unigram
+# losses: CTC + KLdiv (Label Smoothing loss)
+# Training: Librispeech 960h
+# Authors:  Jianyuan Zhong, Titouan Parcollet, Samuele Cornell
+# ############################################################################
+# Seed needs to be set at top of yaml, before objects with parameters are made
+
+seed: 5555
+__set_seed: !apply:torch.manual_seed [!ref <seed>]
+output_folder: !ref results/conformer_large/<seed>
+wer_file: !ref <output_folder>/wer.txt
+save_folder: !ref <output_folder>/save
+train_log: !ref <output_folder>/train_log.txt
+
+# Language model (LM) pretraining
+# NB: To avoid mismatch, the speech recognizer must be trained with the same
+# tokenizer used for LM training. Here, we download everything from the
+# speechbrain HuggingFace repository. However, a local path pointing to a
+# directory containing the lm.ckpt and tokenizer.ckpt may also be specified
+# instead. E.g if you want to use your own LM / tokenizer.
+pretrained_lm_tokenizer_path: speechbrain/asr-transformer-transformerlm-librispeech
+
+# Data files
+data_folder: !PLACEHOLDER  # e.g., /path/to/LibriSpeech
+# If RIRS_NOISES dir exists in /localscratch/xxx_corpus/RIRS_NOISES
+# then data_folder_rirs should be /localscratch/xxx_corpus
+# otherwise the dataset will automatically be downloaded
+# data_folder_rirs: !ref <data_folder>
+train_splits: ["train-clean-100", "train-clean-360", "train-other-500"]
+dev_splits: ["dev-clean"]
+test_splits: ["test-clean", "test-other"]
+skip_prep: False
+train_csv: !ref <output_folder>/train.csv
+valid_csv: !ref <output_folder>/dev-clean.csv
+test_csv:
+    - !ref <output_folder>/test-clean.csv
+    - !ref <output_folder>/test-other.csv
+
+# Training parameters
+# To make Transformers converge, the global bath size should be large enough.
+# The global batch size is computed as batch_size * n_gpus * gradient_accumulation.
+# Empirically, we found that this value should be >= 128.
+# Please, set your parameters accordingly.
+number_of_epochs: 110
+batch_size: 16 # This works for 2x GPUs with 32GB
+ctc_weight: 0.3
+grad_accumulation_factor: 1
+max_grad_norm: 5.0
+loss_reduction: 'batchmean'
+sorting: random
+num_workers: 4
+rel_pos: RelPosMHAXL
+
+# stages related parameters
+# stage_one_epochs: 90
+lr_adam: 0.0005
+# lr_sgd: 0.000025
+
+# Feature parameters
+sample_rate: 16000
+n_fft: 400
+n_mels: 80
+
+# This setup works well for V100 32GB GPU, adapts it to your needs.
+# Or turn it off (but training speed will decrease)
+dynamic_batching: True
+max_batch_len: 900
+max_batch_len_val: 100 # we reduce it as the beam is much wider (VRAM)
+num_bucket: 200
+
+dynamic_batch_sampler:
+    max_batch_len: !ref <max_batch_len>
+    max_batch_len_val: !ref <max_batch_len_val>
+    num_buckets: !ref <num_bucket>
+    shuffle_ex: True # if true re-creates batches at each epoch shuffling examples.
+    batch_ordering: random
+    max_batch_ex: 128
+
+# Dataloader options
+train_dataloader_opts:
+    batch_size: !ref <batch_size>
+    shuffle: True
+    num_workers: !ref <num_workers>
+
+valid_dataloader_opts:
+    batch_size: 1
+
+test_dataloader_opts:
+    batch_size: 1
+
+####################### Model parameters ###########################
+# Transformer
+d_model: 512
+nhead: 8
+num_encoder_layers: 10
+num_decoder_layers: 4
+d_ffn: 2048
+transformer_dropout: 0.1
+activation: !name:torch.nn.GELU
+output_neurons: 5000
+
+# Outputs
+blank_index: 0
+label_smoothing: 0.0
+pad_index: 0
+bos_index: 1
+eos_index: 2
+
+# Decoding parameters
+min_decode_ratio: 0.0
+max_decode_ratio: 1.0
+valid_search_interval: 10
+valid_beam_size: 10
+test_beam_size: 66
+lm_weight: 0.60
+ctc_weight_decode: 0.40
+
+############################## models ################################
+
+CNN: !new:speechbrain.lobes.models.convolution.ConvolutionFrontEnd
+    input_shape: (8, 10, 80)
+    num_blocks: 2
+    num_layers_per_block: 1
+    out_channels: (64, 32)
+    kernel_sizes: (3, 3)
+    strides: (2, 2)
+    residuals: (False, False)
+
+Transformer: !new:speechbrain.lobes.models.transformer.TransformerASR.TransformerASR # yamllint disable-line rule:line-length
+    input_size: 640
+    tgt_vocab: !ref <output_neurons>
+    d_model: !ref <d_model>
+    nhead: !ref <nhead>
+    num_encoder_layers: !ref <num_encoder_layers>
+    num_decoder_layers: !ref <num_decoder_layers>
+    d_ffn: !ref <d_ffn>
+    dropout: !ref <transformer_dropout>
+    activation: !ref <activation>
+    encoder_module: conformer
+    attention_type: !ref <rel_pos>
+    normalize_before: True
+    causal: False
+
+# This is the TransformerLM that is used according to the Huggingface repository
+# Visit the HuggingFace model corresponding to the pretrained_lm_tokenizer_path
+# For more details about the model!
+# NB: It has to match the pre-trained TransformerLM!!
+lm_model: !new:speechbrain.lobes.models.transformer.TransformerLM.TransformerLM # yamllint disable-line rule:line-length
+    vocab: !ref <output_neurons>
+    d_model: 768
+    nhead: 12
+    num_encoder_layers: 12
+    num_decoder_layers: 0
+    d_ffn: 3072
+    dropout: 0.0
+    activation: !name:torch.nn.GELU
+    normalize_before: False
+
+tokenizer: !new:sentencepiece.SentencePieceProcessor
+
+ctc_lin: !new:speechbrain.nnet.linear.Linear
+    input_size: !ref <d_model>
+    n_neurons: !ref <output_neurons>
+
+seq_lin: !new:speechbrain.nnet.linear.Linear
+    input_size: !ref <d_model>
+    n_neurons: !ref <output_neurons>
+
+normalize: !new:speechbrain.processing.features.InputNormalization
+    norm_type: global
+    update_until_epoch: 4
+
+modules:
+    CNN: !ref <CNN>
+    Transformer: !ref <Transformer>
+    seq_lin: !ref <seq_lin>
+    ctc_lin: !ref <ctc_lin>
+    normalize: !ref <normalize>
+
+model: !new:torch.nn.ModuleList
+    - [!ref <CNN>, !ref <Transformer>, !ref <seq_lin>, !ref <ctc_lin>]
+
+# define two optimizers here for two-stage training
+Adam: !name:torch.optim.Adam
+    lr: !ref <lr_adam>
+    betas: (0.9, 0.98)
+    eps: 0.000000001
+
+#SGD: !name:torch.optim.SGD
+#    lr: !ref <lr_sgd>
+#    momentum: 0.99
+#    nesterov: True
+
+valid_search: !new:speechbrain.decoders.S2STransformerBeamSearch
+    modules: [!ref <Transformer>, !ref <seq_lin>, !ref <ctc_lin>]
+    bos_index: !ref <bos_index>
+    eos_index: !ref <eos_index>
+    blank_index: !ref <blank_index>
+    min_decode_ratio: !ref <min_decode_ratio>
+    max_decode_ratio: !ref <max_decode_ratio>
+    beam_size: !ref <valid_beam_size>
+    ctc_weight: !ref <ctc_weight_decode>
+    using_eos_threshold: False
+    length_normalization: False
+
+
+test_search: !new:speechbrain.decoders.S2STransformerBeamSearch
+    modules: [!ref <Transformer>, !ref <seq_lin>, !ref <ctc_lin>]
+    bos_index: !ref <bos_index>
+    eos_index: !ref <eos_index>
+    blank_index: !ref <blank_index>
+    min_decode_ratio: !ref <min_decode_ratio>
+    max_decode_ratio: !ref <max_decode_ratio>
+    beam_size: !ref <test_beam_size>
+    ctc_weight: !ref <ctc_weight_decode>
+    lm_weight: !ref <lm_weight>
+    lm_modules: !ref <lm_model>
+    temperature: 1.15
+    temperature_lm: 1.15
+    using_eos_threshold: False
+    length_normalization: True
+
+log_softmax: !new:torch.nn.LogSoftmax
+    dim: -1
+
+ctc_cost: !name:speechbrain.nnet.losses.ctc_loss
+    blank_index: !ref <blank_index>
+    reduction: !ref <loss_reduction>
+
+seq_cost: !name:speechbrain.nnet.losses.kldiv_loss
+    label_smoothing: !ref <label_smoothing>
+    reduction: !ref <loss_reduction>
+
+noam_annealing: !new:speechbrain.nnet.schedulers.NoamScheduler
+    lr_initial: !ref <lr_adam>
+    n_warmup_steps: 40000
+
+checkpointer: !new:speechbrain.utils.checkpoints.Checkpointer
+    checkpoints_dir: !ref <save_folder>
+    recoverables:
+        model: !ref <model>
+        noam_scheduler: !ref <noam_annealing>
+        normalizer: !ref <normalize>
+        counter: !ref <epoch_counter>
+
+epoch_counter: !new:speechbrain.utils.epoch_loop.EpochCounter
+    limit: !ref <number_of_epochs>
+
+augmentation: !new:speechbrain.lobes.augment.SpecAugment
+    time_warp: True
+    time_warp_window: 5
+    time_warp_mode: bicubic
+    freq_mask: True
+    n_freq_mask: 2
+    time_mask: True
+    n_time_mask: 2
+    replace_with_zero: False
+    freq_mask_width: 30
+    time_mask_width: 40
+
+speed_perturb: !new:speechbrain.processing.speech_augmentation.SpeedPerturb
+    orig_freq: !ref <sample_rate>
+    speeds: [95, 100, 105]
+
+compute_features: !new:speechbrain.lobes.features.Fbank
+    sample_rate: !ref <sample_rate>
+    n_fft: !ref <n_fft>
+    n_mels: !ref <n_mels>
+
+train_logger: !new:speechbrain.utils.train_logger.FileTrainLogger
+    save_file: !ref <train_log>
+
+error_rate_computer: !name:speechbrain.utils.metric_stats.ErrorRateStats
+acc_computer: !name:speechbrain.utils.Accuracy.AccuracyStats
+
+# The pretrainer allows a mapping between pretrained files and instances that
+# are declared in the yaml. E.g here, we will download the file lm.ckpt
+# and it will be loaded into "lm" which is pointing to the <lm_model> defined
+# before.
+pretrainer: !new:speechbrain.utils.parameter_transfer.Pretrainer
+    collect_in: !ref <save_folder>
+    loadables:
+        lm: !ref <lm_model>
+        tokenizer: !ref <tokenizer>
+    paths:
+        lm: !ref <pretrained_lm_tokenizer_path>/lm.ckpt
+        tokenizer: !ref <pretrained_lm_tokenizer_path>/tokenizer.ckpt

--- a/recipes/LibriSpeech/ASR/transformer/hparams/conformer_large.yaml
+++ b/recipes/LibriSpeech/ASR/transformer/hparams/conformer_large.yaml
@@ -9,9 +9,9 @@
 # ############################################################################
 # Seed needs to be set at top of yaml, before objects with parameters are made
 
-seed: 5555
+seed: 7775
 __set_seed: !apply:torch.manual_seed [!ref <seed>]
-output_folder: !ref results/conformer_large/<seed>
+output_folder: !ref results/conformer_small/<seed>
 wer_file: !ref <output_folder>/wer.txt
 save_folder: !ref <output_folder>/save
 train_log: !ref <output_folder>/train_log.txt
@@ -53,11 +53,10 @@ max_grad_norm: 5.0
 loss_reduction: 'batchmean'
 sorting: random
 num_workers: 4
-rel_pos: RelPosMHAXL
 
 # stages related parameters
 # stage_one_epochs: 90
-lr_adam: 0.0005
+lr_adam: 0.001
 # lr_sgd: 0.000025
 
 # Feature parameters
@@ -96,8 +95,8 @@ test_dataloader_opts:
 # Transformer
 d_model: 512
 nhead: 8
-num_encoder_layers: 10
-num_decoder_layers: 4
+num_encoder_layers: 12
+num_decoder_layers: 6
 d_ffn: 2048
 transformer_dropout: 0.1
 activation: !name:torch.nn.GELU
@@ -141,7 +140,7 @@ Transformer: !new:speechbrain.lobes.models.transformer.TransformerASR.Transforme
     dropout: !ref <transformer_dropout>
     activation: !ref <activation>
     encoder_module: conformer
-    attention_type: !ref <rel_pos>
+    attention_type: RelPosMHAXL
     normalize_before: True
     causal: False
 
@@ -237,7 +236,7 @@ seq_cost: !name:speechbrain.nnet.losses.kldiv_loss
 
 noam_annealing: !new:speechbrain.nnet.schedulers.NoamScheduler
     lr_initial: !ref <lr_adam>
-    n_warmup_steps: 40000
+    n_warmup_steps: 25000
 
 checkpointer: !new:speechbrain.utils.checkpoints.Checkpointer
     checkpoints_dir: !ref <save_folder>

--- a/recipes/LibriSpeech/ASR/transformer/hparams/conformer_large.yaml
+++ b/recipes/LibriSpeech/ASR/transformer/hparams/conformer_large.yaml
@@ -56,7 +56,7 @@ num_workers: 4
 
 # stages related parameters
 # stage_one_epochs: 90
-lr_adam: 0.001
+lr_adam: 0.0005
 # lr_sgd: 0.000025
 
 # Feature parameters
@@ -184,7 +184,7 @@ model: !new:torch.nn.ModuleList
     - [!ref <CNN>, !ref <Transformer>, !ref <seq_lin>, !ref <ctc_lin>]
 
 # define two optimizers here for two-stage training
-Adam: !name:torch.optim.Adam
+Adam: !name:torch.optim.AdamW
     lr: !ref <lr_adam>
     betas: (0.9, 0.98)
     eps: 0.000000001
@@ -236,7 +236,7 @@ seq_cost: !name:speechbrain.nnet.losses.kldiv_loss
 
 noam_annealing: !new:speechbrain.nnet.schedulers.NoamScheduler
     lr_initial: !ref <lr_adam>
-    n_warmup_steps: 25000
+    n_warmup_steps: 35000
 
 checkpointer: !new:speechbrain.utils.checkpoints.Checkpointer
     checkpoints_dir: !ref <save_folder>

--- a/recipes/LibriSpeech/ASR/transformer/hparams/conformer_large_unstable.yaml
+++ b/recipes/LibriSpeech/ASR/transformer/hparams/conformer_large_unstable.yaml
@@ -236,7 +236,7 @@ seq_cost: !name:speechbrain.nnet.losses.kldiv_loss
 
 noam_annealing: !new:speechbrain.nnet.schedulers.NoamScheduler
     lr_initial: !ref <lr_adam>
-    n_warmup_steps: 35000
+    n_warmup_steps: 25000
 
 checkpointer: !new:speechbrain.utils.checkpoints.Checkpointer
     checkpoints_dir: !ref <save_folder>

--- a/recipes/LibriSpeech/ASR/transformer/hparams/conformer_large_unstable.yaml
+++ b/recipes/LibriSpeech/ASR/transformer/hparams/conformer_large_unstable.yaml
@@ -1,0 +1,290 @@
+# ############################################################################
+# Model: E2E ASR with Transformer
+# Encoder: Conformer Encoder
+# Decoder: Transformer Decoder + (CTC/ATT joint) beamsearch + TransformerLM
+# Tokens: unigram
+# losses: CTC + KLdiv (Label Smoothing loss)
+# Training: Librispeech 960h
+# Authors:  Jianyuan Zhong, Titouan Parcollet, Samuele Cornell
+# ############################################################################
+# Seed needs to be set at top of yaml, before objects with parameters are made
+
+seed: 7775
+__set_seed: !apply:torch.manual_seed [!ref <seed>]
+output_folder: !ref results/conformer_small/<seed>
+wer_file: !ref <output_folder>/wer.txt
+save_folder: !ref <output_folder>/save
+train_log: !ref <output_folder>/train_log.txt
+
+# Language model (LM) pretraining
+# NB: To avoid mismatch, the speech recognizer must be trained with the same
+# tokenizer used for LM training. Here, we download everything from the
+# speechbrain HuggingFace repository. However, a local path pointing to a
+# directory containing the lm.ckpt and tokenizer.ckpt may also be specified
+# instead. E.g if you want to use your own LM / tokenizer.
+pretrained_lm_tokenizer_path: speechbrain/asr-transformer-transformerlm-librispeech
+
+# Data files
+data_folder: !PLACEHOLDER  # e.g., /path/to/LibriSpeech
+# If RIRS_NOISES dir exists in /localscratch/xxx_corpus/RIRS_NOISES
+# then data_folder_rirs should be /localscratch/xxx_corpus
+# otherwise the dataset will automatically be downloaded
+# data_folder_rirs: !ref <data_folder>
+train_splits: ["train-clean-100", "train-clean-360", "train-other-500"]
+dev_splits: ["dev-clean"]
+test_splits: ["test-clean", "test-other"]
+skip_prep: False
+train_csv: !ref <output_folder>/train.csv
+valid_csv: !ref <output_folder>/dev-clean.csv
+test_csv:
+    - !ref <output_folder>/test-clean.csv
+    - !ref <output_folder>/test-other.csv
+
+# Training parameters
+# To make Transformers converge, the global bath size should be large enough.
+# The global batch size is computed as batch_size * n_gpus * gradient_accumulation.
+# Empirically, we found that this value should be >= 128.
+# Please, set your parameters accordingly.
+number_of_epochs: 110
+batch_size: 16 # This works for 2x GPUs with 32GB
+ctc_weight: 0.3
+grad_accumulation_factor: 1
+max_grad_norm: 5.0
+loss_reduction: 'batchmean'
+sorting: random
+num_workers: 4
+
+# stages related parameters
+# stage_one_epochs: 90
+lr_adam: 0.0005
+# lr_sgd: 0.000025
+
+# Feature parameters
+sample_rate: 16000
+n_fft: 400
+n_mels: 80
+
+# This setup works well for V100 32GB GPU, adapts it to your needs.
+# Or turn it off (but training speed will decrease)
+dynamic_batching: True
+max_batch_len: 900
+max_batch_len_val: 100 # we reduce it as the beam is much wider (VRAM)
+num_bucket: 200
+
+dynamic_batch_sampler:
+    max_batch_len: !ref <max_batch_len>
+    max_batch_len_val: !ref <max_batch_len_val>
+    num_buckets: !ref <num_bucket>
+    shuffle_ex: True # if true re-creates batches at each epoch shuffling examples.
+    batch_ordering: random
+    max_batch_ex: 128
+
+# Dataloader options
+train_dataloader_opts:
+    batch_size: !ref <batch_size>
+    shuffle: True
+    num_workers: !ref <num_workers>
+
+valid_dataloader_opts:
+    batch_size: 1
+
+test_dataloader_opts:
+    batch_size: 1
+
+####################### Model parameters ###########################
+# Transformer
+d_model: 512
+nhead: 8
+num_encoder_layers: 12
+num_decoder_layers: 6
+d_ffn: 2048
+transformer_dropout: 0.1
+activation: !name:torch.nn.GELU
+output_neurons: 5000
+
+# Outputs
+blank_index: 0
+label_smoothing: 0.0
+pad_index: 0
+bos_index: 1
+eos_index: 2
+
+# Decoding parameters
+min_decode_ratio: 0.0
+max_decode_ratio: 1.0
+valid_search_interval: 10
+valid_beam_size: 10
+test_beam_size: 66
+lm_weight: 0.60
+ctc_weight_decode: 0.40
+
+############################## models ################################
+
+CNN: !new:speechbrain.lobes.models.convolution.ConvolutionFrontEnd
+    input_shape: (8, 10, 80)
+    num_blocks: 2
+    num_layers_per_block: 1
+    out_channels: (64, 32)
+    kernel_sizes: (3, 3)
+    strides: (2, 2)
+    residuals: (False, False)
+
+Transformer: !new:speechbrain.lobes.models.transformer.TransformerASR.TransformerASRUnstable # yamllint disable-line rule:line-length
+    input_size: 640
+    tgt_vocab: !ref <output_neurons>
+    d_model: !ref <d_model>
+    nhead: !ref <nhead>
+    num_encoder_layers: !ref <num_encoder_layers>
+    num_decoder_layers: !ref <num_decoder_layers>
+    d_ffn: !ref <d_ffn>
+    dropout: !ref <transformer_dropout>
+    activation: !ref <activation>
+    encoder_module: conformer
+    attention_type: RelPosMHAXL
+    normalize_before: True
+    causal: False
+
+# This is the TransformerLM that is used according to the Huggingface repository
+# Visit the HuggingFace model corresponding to the pretrained_lm_tokenizer_path
+# For more details about the model!
+# NB: It has to match the pre-trained TransformerLM!!
+lm_model: !new:speechbrain.lobes.models.transformer.TransformerLM.TransformerLM # yamllint disable-line rule:line-length
+    vocab: !ref <output_neurons>
+    d_model: 768
+    nhead: 12
+    num_encoder_layers: 12
+    num_decoder_layers: 0
+    d_ffn: 3072
+    dropout: 0.0
+    activation: !name:torch.nn.GELU
+    normalize_before: False
+
+tokenizer: !new:sentencepiece.SentencePieceProcessor
+
+ctc_lin: !new:speechbrain.nnet.linear.Linear
+    input_size: !ref <d_model>
+    n_neurons: !ref <output_neurons>
+
+seq_lin: !new:speechbrain.nnet.linear.Linear
+    input_size: !ref <d_model>
+    n_neurons: !ref <output_neurons>
+
+normalize: !new:speechbrain.processing.features.InputNormalization
+    norm_type: global
+    update_until_epoch: 4
+
+modules:
+    CNN: !ref <CNN>
+    Transformer: !ref <Transformer>
+    seq_lin: !ref <seq_lin>
+    ctc_lin: !ref <ctc_lin>
+    normalize: !ref <normalize>
+
+model: !new:torch.nn.ModuleList
+    - [!ref <CNN>, !ref <Transformer>, !ref <seq_lin>, !ref <ctc_lin>]
+
+# define two optimizers here for two-stage training
+Adam: !name:torch.optim.Adam
+    lr: !ref <lr_adam>
+    betas: (0.9, 0.98)
+    eps: 0.000000001
+
+#SGD: !name:torch.optim.SGD
+#    lr: !ref <lr_sgd>
+#    momentum: 0.99
+#    nesterov: True
+
+valid_search: !new:speechbrain.decoders.S2STransformerBeamSearch
+    modules: [!ref <Transformer>, !ref <seq_lin>, !ref <ctc_lin>]
+    bos_index: !ref <bos_index>
+    eos_index: !ref <eos_index>
+    blank_index: !ref <blank_index>
+    min_decode_ratio: !ref <min_decode_ratio>
+    max_decode_ratio: !ref <max_decode_ratio>
+    beam_size: !ref <valid_beam_size>
+    ctc_weight: !ref <ctc_weight_decode>
+    using_eos_threshold: False
+    length_normalization: False
+
+
+test_search: !new:speechbrain.decoders.S2STransformerBeamSearch
+    modules: [!ref <Transformer>, !ref <seq_lin>, !ref <ctc_lin>]
+    bos_index: !ref <bos_index>
+    eos_index: !ref <eos_index>
+    blank_index: !ref <blank_index>
+    min_decode_ratio: !ref <min_decode_ratio>
+    max_decode_ratio: !ref <max_decode_ratio>
+    beam_size: !ref <test_beam_size>
+    ctc_weight: !ref <ctc_weight_decode>
+    lm_weight: !ref <lm_weight>
+    lm_modules: !ref <lm_model>
+    temperature: 1.15
+    temperature_lm: 1.15
+    using_eos_threshold: False
+    length_normalization: True
+
+log_softmax: !new:torch.nn.LogSoftmax
+    dim: -1
+
+ctc_cost: !name:speechbrain.nnet.losses.ctc_loss
+    blank_index: !ref <blank_index>
+    reduction: !ref <loss_reduction>
+
+seq_cost: !name:speechbrain.nnet.losses.kldiv_loss
+    label_smoothing: !ref <label_smoothing>
+    reduction: !ref <loss_reduction>
+
+noam_annealing: !new:speechbrain.nnet.schedulers.NoamScheduler
+    lr_initial: !ref <lr_adam>
+    n_warmup_steps: 35000
+
+checkpointer: !new:speechbrain.utils.checkpoints.Checkpointer
+    checkpoints_dir: !ref <save_folder>
+    recoverables:
+        model: !ref <model>
+        noam_scheduler: !ref <noam_annealing>
+        normalizer: !ref <normalize>
+        counter: !ref <epoch_counter>
+
+epoch_counter: !new:speechbrain.utils.epoch_loop.EpochCounter
+    limit: !ref <number_of_epochs>
+
+augmentation: !new:speechbrain.lobes.augment.SpecAugment
+    time_warp: True
+    time_warp_window: 5
+    time_warp_mode: bicubic
+    freq_mask: True
+    n_freq_mask: 2
+    time_mask: True
+    n_time_mask: 2
+    replace_with_zero: False
+    freq_mask_width: 30
+    time_mask_width: 40
+
+speed_perturb: !new:speechbrain.processing.speech_augmentation.SpeedPerturb
+    orig_freq: !ref <sample_rate>
+    speeds: [95, 100, 105]
+
+compute_features: !new:speechbrain.lobes.features.Fbank
+    sample_rate: !ref <sample_rate>
+    n_fft: !ref <n_fft>
+    n_mels: !ref <n_mels>
+
+train_logger: !new:speechbrain.utils.train_logger.FileTrainLogger
+    save_file: !ref <train_log>
+
+error_rate_computer: !name:speechbrain.utils.metric_stats.ErrorRateStats
+acc_computer: !name:speechbrain.utils.Accuracy.AccuracyStats
+
+# The pretrainer allows a mapping between pretrained files and instances that
+# are declared in the yaml. E.g here, we will download the file lm.ckpt
+# and it will be loaded into "lm" which is pointing to the <lm_model> defined
+# before.
+pretrainer: !new:speechbrain.utils.parameter_transfer.Pretrainer
+    collect_in: !ref <save_folder>
+    loadables:
+        lm: !ref <lm_model>
+        tokenizer: !ref <tokenizer>
+    paths:
+        lm: !ref <pretrained_lm_tokenizer_path>/lm.ckpt
+        tokenizer: !ref <pretrained_lm_tokenizer_path>/tokenizer.ckpt

--- a/recipes/LibriSpeech/ASR/transformer/train.py
+++ b/recipes/LibriSpeech/ASR/transformer/train.py
@@ -84,7 +84,7 @@ class ASR(sb.core.Brain):
 
         # output layer for seq2seq log-probabilities
         pred = self.modules.seq_lin(pred)
-        p_seq = self.hparams.log_softmax(pred)
+        p_seq = self.hparams.log_softmax(pred, dtype=torch.float32)
 
         # Compute outputs
         hyps = None

--- a/recipes/LibriSpeech/ASR/transformer/train.py
+++ b/recipes/LibriSpeech/ASR/transformer/train.py
@@ -399,6 +399,7 @@ def dataio_prepare(hparams):
             length_func=lambda x: x["duration"],
             shuffle=dynamic_hparams["shuffle_ex"],
             batch_ordering=dynamic_hparams["batch_ordering"],
+            max_batch_ex=dynamic_hparams["max_batch_ex"],
         )
 
         valid_batch_sampler = DynamicBatchSampler(

--- a/recipes/LibriSpeech/ASR/transformer/train.py
+++ b/recipes/LibriSpeech/ASR/transformer/train.py
@@ -84,7 +84,7 @@ class ASR(sb.core.Brain):
 
         # output layer for seq2seq log-probabilities
         pred = self.modules.seq_lin(pred)
-        p_seq = self.hparams.log_softmax(pred, dtype=torch.float32)
+        p_seq = self.hparams.log_softmax(pred)
 
         # Compute outputs
         hyps = None

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -243,6 +243,12 @@ def parse_arguments(arg_list=None):
         help="This flag enables training with automatic mixed-precision.",
     )
     parser.add_argument(
+        "--bfloat16_mix_prec",
+        default=None,
+        action="store_true",
+        help="This flag enables training with bfloat16 mixed-precision.",
+    )
+    parser.add_argument(
         "--max_grad_norm",
         type=float,
         help="Gradient norm will be clipped to this value, "
@@ -465,6 +471,7 @@ class Brain:
             "find_unused_parameters": False,
             "jit_module_keys": None,
             "auto_mix_prec": False,
+            "bfloat16_mix_prec": False,
             "max_grad_norm": 5.0,
             "nonfinite_patience": 3,
             "noprogressbar": False,
@@ -915,7 +922,9 @@ class Brain:
         if self.auto_mix_prec:
             with torch.cuda.amp.autocast():
                 outputs = self.compute_forward(batch, Stage.TRAIN)
-                loss = self.compute_objectives(outputs, batch, Stage.TRAIN)
+
+            # Losses are excluded from mixed precision to avoid instabilities
+            loss = self.compute_objectives(outputs, batch, Stage.TRAIN)
             with self.no_sync(not should_step):
                 self.scaler.scale(
                     loss / self.grad_accumulation_factor
@@ -928,8 +937,13 @@ class Brain:
                 self.zero_grad()
                 self.optimizer_step += 1
         else:
-            outputs = self.compute_forward(batch, Stage.TRAIN)
-            loss = self.compute_objectives(outputs, batch, Stage.TRAIN)
+            if self.bfloat16_mix_prec:
+                with torch.cuda.amp.autocast(dtype=torch.bfloat16):
+                    outputs = self.compute_forward(batch, Stage.TRAIN)
+                    loss = self.compute_objectives(outputs, batch, Stage.TRAIN)
+            else:
+                outputs = self.compute_forward(batch, Stage.TRAIN)
+                loss = self.compute_objectives(outputs, batch, Stage.TRAIN)
             with self.no_sync(not should_step):
                 (loss / self.grad_accumulation_factor).backward()
             if should_step:

--- a/speechbrain/lobes/models/transformer/TransformerASR.py
+++ b/speechbrain/lobes/models/transformer/TransformerASR.py
@@ -19,6 +19,308 @@ from speechbrain.nnet.activations import Swish
 from speechbrain.dataio.dataio import length_to_mask
 
 
+class TransformerASRUnstable(TransformerInterface):
+    """This is an implementation of transformer model for ASR.
+
+    The architecture is based on the paper "Attention Is All You Need":
+    https://arxiv.org/pdf/1706.03762.pdf
+
+    Arguments
+    ----------
+    tgt_vocab: int
+        Size of vocabulary.
+    input_size: int
+        Input feature size.
+    d_model : int, optional
+        Embedding dimension size.
+        (default=512).
+    nhead : int, optional
+        The number of heads in the multi-head attention models (default=8).
+    num_encoder_layers : int, optional
+        The number of sub-encoder-layers in the encoder (default=6).
+    num_decoder_layers : int, optional
+        The number of sub-decoder-layers in the decoder (default=6).
+    dim_ffn : int, optional
+        The dimension of the feedforward network model (default=2048).
+    dropout : int, optional
+        The dropout value (default=0.1).
+    activation : torch.nn.Module, optional
+        The activation function of FFN layers.
+        Recommended: relu or gelu (default=relu).
+    positional_encoding: str, optional
+        Type of positional encoding used. e.g. 'fixed_abs_sine' for fixed absolute positional encodings.
+    normalize_before: bool, optional
+        Whether normalization should be applied before or after MHA or FFN in Transformer layers.
+        Defaults to True as this was shown to lead to better performance and training stability.
+    kernel_size: int, optional
+        Kernel size in convolutional layers when Conformer is used.
+    bias: bool, optional
+        Whether to use bias in Conformer convolutional layers.
+    encoder_module: str, optional
+        Choose between Conformer and Transformer for the encoder. The decoder is fixed to be a Transformer.
+    conformer_activation: torch.nn.Module, optional
+        Activation module used after Conformer convolutional layers. E.g. Swish, ReLU etc. it has to be a torch Module.
+    attention_type: str, optional
+        Type of attention layer used in all Transformer or Conformer layers.
+        e.g. regularMHA or RelPosMHA.
+    max_length: int, optional
+        Max length for the target and source sequence in input.
+        Used for positional encodings.
+    causal: bool, optional
+        Whether the encoder should be causal or not (the decoder is always causal).
+        If causal the Conformer convolutional layer is causal.
+
+    Example
+    -------
+    >>> src = torch.rand([8, 120, 512])
+    >>> tgt = torch.randint(0, 720, [8, 120])
+    >>> net = TransformerASR(
+    ...     720, 512, 512, 8, 1, 1, 1024, activation=torch.nn.GELU
+    ... )
+    >>> enc_out, dec_out = net.forward(src, tgt)
+    >>> enc_out.shape
+    torch.Size([8, 120, 512])
+    >>> dec_out.shape
+    torch.Size([8, 120, 512])
+    """
+
+    def __init__(
+        self,
+        tgt_vocab,
+        input_size,
+        d_model=512,
+        nhead=8,
+        num_encoder_layers=6,
+        num_decoder_layers=6,
+        d_ffn=2048,
+        dropout=0.1,
+        activation=nn.ReLU,
+        positional_encoding="fixed_abs_sine",
+        normalize_before=False,
+        kernel_size: Optional[int] = 31,
+        bias: Optional[bool] = True,
+        encoder_module: Optional[str] = "transformer",
+        conformer_activation: Optional[nn.Module] = Swish,
+        attention_type: Optional[str] = "regularMHA",
+        max_length: Optional[int] = 5000,
+        causal: Optional[bool] = True,
+    ):
+        super().__init__(
+            d_model=d_model,
+            nhead=nhead,
+            num_encoder_layers=num_encoder_layers,
+            num_decoder_layers=num_decoder_layers,
+            d_ffn=d_ffn,
+            dropout=dropout,
+            activation=activation,
+            positional_encoding=positional_encoding,
+            normalize_before=normalize_before,
+            kernel_size=kernel_size,
+            bias=bias,
+            encoder_module=encoder_module,
+            conformer_activation=conformer_activation,
+            attention_type=attention_type,
+            max_length=max_length,
+            causal=causal,
+        )
+
+        self.custom_src_module = ModuleList(
+            Linear(
+                input_size=input_size,
+                n_neurons=d_model,
+                bias=True,
+                combine_dims=False,
+            ),
+            torch.nn.Dropout(dropout),
+        )
+        self.custom_tgt_module = ModuleList(
+            NormalizedEmbedding(d_model, tgt_vocab)
+        )
+
+        # reset parameters using xavier_normal_
+        self._init_params()
+
+    def forward(self, src, tgt, wav_len=None, pad_idx=0):
+        """
+        Arguments
+        ----------
+        src : torch.Tensor
+            The sequence to the encoder.
+        tgt : torch.Tensor
+            The sequence to the decoder.
+        wav_len: torch.Tensor, optional
+            Torch Tensor of shape (batch, ) containing the relative length to padded length for each example.
+        pad_idx : int, optional
+            The index for <pad> token (default=0).
+        """
+
+        # reshpae the src vector to [Batch, Time, Fea] is a 4d vector is given
+        if src.ndim == 4:
+            bz, t, ch1, ch2 = src.shape
+            src = src.reshape(bz, t, ch1 * ch2)
+
+        (
+            src_key_padding_mask,
+            tgt_key_padding_mask,
+            src_mask,
+            tgt_mask,
+        ) = self.make_masks(src, tgt, wav_len, pad_idx=pad_idx)
+
+        src = self.custom_src_module(src)
+        # add pos encoding to queries if are sinusoidal ones else
+        if self.attention_type == "RelPosMHAXL":
+            pos_embs_encoder = self.positional_encoding(src)
+        elif self.positional_encoding_type == "fixed_abs_sine":
+            src = src + self.positional_encoding(src)  # add the encodings here
+            pos_embs_encoder = None
+
+        encoder_out, _ = self.encoder(
+            src=src,
+            src_mask=src_mask,
+            src_key_padding_mask=src_key_padding_mask,
+            pos_embs=pos_embs_encoder,
+        )
+
+        tgt = self.custom_tgt_module(tgt)
+
+        if self.attention_type == "RelPosMHAXL":
+            # use standard sinusoidal pos encoding in decoder
+            tgt = tgt + self.positional_encoding_decoder(tgt)
+            # FIXME we use pos embs also on enc output
+            encoder_out = encoder_out + self.positional_encoding_decoder(
+                encoder_out
+            )
+            pos_embs_encoder = None  # self.positional_encoding(src)
+            pos_embs_target = None
+        elif self.positional_encoding_type == "fixed_abs_sine":
+            tgt = tgt + self.positional_encoding(tgt)
+            pos_embs_target = None
+            pos_embs_encoder = None
+
+        decoder_out, _, _ = self.decoder(
+            tgt=tgt,
+            memory=encoder_out,
+            memory_mask=src_mask,
+            tgt_mask=tgt_mask,
+            tgt_key_padding_mask=tgt_key_padding_mask,
+            memory_key_padding_mask=src_key_padding_mask,
+            pos_embs_tgt=pos_embs_target,
+            pos_embs_src=pos_embs_encoder,
+        )
+
+        return encoder_out, decoder_out
+
+    def make_masks(self, src, tgt, wav_len=None, pad_idx=0):
+        """This method generates the masks for training the transformer model.
+
+        Arguments
+        ---------
+        src : tensor
+            The sequence to the encoder (required).
+        tgt : tensor
+            The sequence to the decoder (required).
+        pad_idx : int
+            The index for <pad> token (default=0).
+        """
+        src_key_padding_mask = None
+        if wav_len is not None:
+            abs_len = torch.round(wav_len * src.shape[1])
+            src_key_padding_mask = ~length_to_mask(abs_len).bool()
+
+        tgt_key_padding_mask = get_key_padding_mask(tgt, pad_idx=pad_idx)
+
+        src_mask = None
+        tgt_mask = get_lookahead_mask(tgt)
+        return src_key_padding_mask, tgt_key_padding_mask, src_mask, tgt_mask
+
+    @torch.no_grad()
+    def decode(self, tgt, encoder_out, enc_len=None):
+        """This method implements a decoding step for the transformer model.
+
+        Arguments
+        ---------
+        tgt : torch.Tensor
+            The sequence to the decoder.
+        encoder_out : torch.Tensor
+            Hidden output of the encoder.
+        enc_len : torch.LongTensor
+            The actual length of encoder states.
+        """
+        tgt_mask = get_lookahead_mask(tgt)
+        src_key_padding_mask = None
+        if enc_len is not None:
+            src_key_padding_mask = (1 - length_to_mask(enc_len)).bool()
+
+        tgt = self.custom_tgt_module(tgt)
+        if self.attention_type == "RelPosMHAXL":
+            # we use fixed positional encodings in the decoder
+            tgt = tgt + self.positional_encoding_decoder(tgt)
+            encoder_out = encoder_out + self.positional_encoding_decoder(
+                encoder_out
+            )
+            # pos_embs_target = self.positional_encoding(tgt)
+            pos_embs_encoder = None  # self.positional_encoding(src)
+            pos_embs_target = None
+        elif self.positional_encoding_type == "fixed_abs_sine":
+            tgt = tgt + self.positional_encoding(tgt)  # add the encodings here
+            pos_embs_target = None
+            pos_embs_encoder = None
+
+        prediction, self_attns, multihead_attns = self.decoder(
+            tgt,
+            encoder_out,
+            tgt_mask=tgt_mask,
+            memory_key_padding_mask=src_key_padding_mask,
+            pos_embs_tgt=pos_embs_target,
+            pos_embs_src=pos_embs_encoder,
+        )
+        return prediction, multihead_attns[-1]
+
+    def encode(self, src, wav_len=None):
+        """
+        Encoder forward pass
+
+        Arguments
+        ----------
+        src : torch.Tensor
+            The sequence to the encoder.
+        wav_len: torch.Tensor, optional
+            Torch Tensor of shape (batch, ) containing the relative length to padded length for each example.
+        """
+        # reshape the src vector to [Batch, Time, Fea] if a 4d vector is given
+        if src.dim() == 4:
+            bz, t, ch1, ch2 = src.shape
+            src = src.reshape(bz, t, ch1 * ch2)
+
+        src_key_padding_mask = None
+        if wav_len is not None:
+            abs_len = torch.floor(wav_len * src.shape[1])
+            src_key_padding_mask = (
+                torch.arange(src.shape[1])[None, :].to(abs_len)
+                > abs_len[:, None]
+            )
+
+        src = self.custom_src_module(src)
+        if self.attention_type == "RelPosMHAXL":
+            pos_embs_source = self.positional_encoding(src)
+
+        elif self.positional_encoding_type == "fixed_abs_sine":
+            src = src + self.positional_encoding(src)
+            pos_embs_source = None
+
+        encoder_out, _ = self.encoder(
+            src=src,
+            src_key_padding_mask=src_key_padding_mask,
+            pos_embs=pos_embs_source,
+        )
+        return encoder_out
+
+    def _init_params(self):
+        for p in self.parameters():
+            if p.dim() > 1:
+                torch.nn.init.xavier_normal_(p)
+
+
 class TransformerASR(TransformerInterface):
     """This is an implementation of transformer model for ASR.
 

--- a/speechbrain/lobes/models/transformer/TransformerASR.py
+++ b/speechbrain/lobes/models/transformer/TransformerASR.py
@@ -102,7 +102,7 @@ class TransformerASR(TransformerInterface):
         encoder_module: Optional[str] = "transformer",
         conformer_activation: Optional[nn.Module] = Swish,
         attention_type: Optional[str] = "regularMHA",
-        max_length: Optional[int] = 2500,
+        max_length: Optional[int] = 5000,
         causal: Optional[bool] = True,
     ):
         super().__init__(

--- a/speechbrain/lobes/models/transformer/TransformerASR.py
+++ b/speechbrain/lobes/models/transformer/TransformerASR.py
@@ -187,9 +187,9 @@ class TransformerASR(TransformerInterface):
             # use standard sinusoidal pos encoding in decoder
             tgt = tgt + self.positional_encoding_decoder(tgt)
             # FIXME we use pos embs also on enc output
-            encoder_out = encoder_out + self.positional_encoding_decoder(
-                encoder_out
-            )
+            # encoder_out = encoder_out + self.positional_encoding_decoder(
+            #    encoder_out
+            # )
             pos_embs_encoder = None  # self.positional_encoding(src)
             pos_embs_target = None
         elif self.positional_encoding_type == "fixed_abs_sine":


### PR DESCRIPTION
We've been struggling with training larger conformers due to instability. This PR attempts at fixing this. In practice, for some reason, please @popcornell check, we were adding a sinusoidal pos emb to the encoder output before giving to the decoder. We don't do this for the standard transformer, so I removed it and trained a large model. 


**PRE-FIX TRAIN_LOG**
epoch: 1, lr: 3.59e-05, steps: 1797, optimizer: Adam - train loss: 3.06e+02 - valid loss: 2.09e+02, valid ACC: 1.83e-01                                                                                                                    
epoch: 2, lr: 7.19e-05, steps: 3594, optimizer: Adam - train loss: 2.54e+02 - valid loss: 1.69e+02, valid ACC: 2.58e-01                                                                                                                    
epoch: 3, lr: 1.08e-04, steps: 5391, optimizer: Adam - train loss: 1.66e+02 - valid loss: 66.64, valid ACC: 6.99e-01                                                                                                                       
epoch: 4, lr: 1.44e-04, steps: 7188, optimizer: Adam - train loss: 80.97 - valid loss: 33.55, valid ACC: 8.58e-01                                                                                                                          
epoch: 5, lr: 1.80e-04, steps: 8985, optimizer: Adam - train loss: 52.80 - valid loss: 23.88, valid ACC: 9.00e-01                                                                                                                          
epoch: 6, lr: 2.16e-04, steps: 10782, optimizer: Adam - train loss: 41.22 - valid loss: 19.67, valid ACC: 9.23e-01                                                                                                                         
epoch: 7, lr: 2.52e-04, steps: 12579, optimizer: Adam - train loss: 34.78 - valid loss: 16.37, valid ACC: 9.33e-01                                                                                                                         
epoch: 8, lr: 2.88e-04, steps: 14376, optimizer: Adam - train loss: 30.60 - valid loss: 15.25, valid ACC: 9.39e-01                                                                                                                         
epoch: 9, lr: 3.23e-04, steps: 16173, optimizer: Adam - train loss: 27.49 - valid loss: 13.32, valid ACC: 9.45e-01                                                                                                                         
epoch: 10, lr: 3.59e-04, steps: 17970, optimizer: Adam - train loss: 25.36 - valid loss: 12.12, valid ACC: 9.48e-01, valid WER: 6.76                                                                                                       
epoch: 11, lr: 3.95e-04, steps: 19767, optimizer: Adam - train loss: 23.71 - valid loss: 11.84, valid ACC: 9.50e-01                                                                                                                        
epoch: 12, lr: 4.31e-04, steps: 21564, optimizer: Adam - train loss: 22.71 - valid loss: 10.87, valid ACC: 9.52e-01                                                                                                                        
epoch: 13, lr: 4.67e-04, steps: 23361, optimizer: Adam - train loss: 21.46 - valid loss: 10.01, valid ACC: 9.54e-01                                                                                                                        
epoch: 14, lr: 4.98e-04, steps: 25158, optimizer: Adam - train loss: 20.59 - valid loss: 10.16, valid ACC: 9.55e-01                                                                                                                        
epoch: 15, lr: 4.82e-04, steps: 26955, optimizer: Adam - train loss: 19.34 - valid loss: 9.60, valid ACC: 9.57e-01                                                                                                                         
epoch: 16, lr: 4.66e-04, steps: 28752, optimizer: Adam - train loss: 17.85 - valid loss: 8.99, valid ACC: 9.60e-01                                                                                                                         
epoch: 17, lr: 4.52e-04, steps: 30549, optimizer: Adam - train loss: 16.33 - valid loss: 8.85, valid ACC: 9.62e-01                                                                                                                         
epoch: 18, lr: 4.40e-04, steps: 32346, optimizer: Adam - train loss: 15.22 - valid loss: 8.10, valid ACC: 9.64e-01                                                                                                                         
epoch: 19, lr: 4.28e-04, steps: 34143, optimizer: Adam - train loss: 14.33 - valid loss: 8.08, valid ACC: 9.65e-01                                                                                                                         
epoch: 20, lr: 4.17e-04, steps: 35940, optimizer: Adam - train loss: 13.48 - valid loss: 7.77, valid ACC: 9.66e-01, valid WER: 6.04                                                                                                        
epoch: 21, lr: 4.07e-04, steps: 37737, optimizer: Adam - train loss: 12.74 - valid loss: 8.06, valid ACC: 9.66e-01                                                                                                                         
epoch: 22, lr: 3.98e-04, steps: 39534, optimizer: Adam - train loss: 12.14 - valid loss: 7.56, valid ACC: 9.68e-01                                                                                                                         
epoch: 23, lr: 3.89e-04, steps: 41331, optimizer: Adam - train loss: 11.59 - valid loss: 7.79, valid ACC: 9.68e-01                                                                                                                         
epoch: 24, lr: 3.81e-04, steps: 43128, optimizer: Adam - train loss: 11.11 - valid loss: 7.39, valid ACC: 9.68e-01                                                                                                                         
epoch: 25, lr: 3.73e-04, steps: 44925, optimizer: Adam - train loss: 10.68 - valid loss: 7.27, valid ACC: 9.69e-01                                                                                                                         
epoch: 26, lr: 3.66e-04, steps: 46722, optimizer: Adam - train loss: 10.28 - valid loss: 7.51, valid ACC: 9.68e-01                                                                                                                         
epoch: 27, lr: 3.59e-04, steps: 48519, optimizer: Adam - train loss: 9.86 - valid loss: 6.90, valid ACC: 9.70e-01                                                                                                                          
epoch: 28, lr: 3.52e-04, steps: 50316, optimizer: Adam - train loss: 9.56 - valid loss: 7.27, valid ACC: 9.69e-01                                                                                                                          
epoch: 29, lr: 3.46e-04, steps: 52113, optimizer: Adam - train loss: 9.18 - valid loss: 7.06, valid ACC: 9.70e-01                                                                                                                          
epoch: 30, lr: 3.40e-04, steps: 53910, optimizer: Adam - train loss: 8.94 - valid loss: 7.38, valid ACC: 9.70e-01, valid WER: 8.63                                                                                                         
epoch: 31, lr: 3.35e-04, steps: 55707, optimizer: Adam - train loss: 8.63 - valid loss: 6.77, valid ACC: 9.72e-01
epoch: 32, lr: 3.30e-04, steps: 57504, optimizer: Adam - train loss: 8.44 - valid loss: 7.10, valid ACC: 9.70e-01
epoch: 33, lr: 3.25e-04, steps: 59301, optimizer: Adam - train loss: 8.17 - valid loss: 6.92, valid ACC: 9.71e-01
epoch: 34, lr: 3.20e-04, steps: 61098, optimizer: Adam - train loss: 7.98 - valid loss: 6.98, valid ACC: 9.71e-01
epoch: 35, lr: 3.15e-04, steps: 62895, optimizer: Adam - train loss: 7.83 - valid loss: 6.98, valid ACC: 9.71e-01
epoch: 36, lr: 3.11e-04, steps: 64692, optimizer: Adam - train loss: 7.61 - valid loss: 7.13, valid ACC: 9.71e-01
epoch: 37, lr: 3.07e-04, steps: 66489, optimizer: Adam - train loss: 7.37 - valid loss: 6.85, valid ACC: 9.72e-01
epoch: 38, lr: 3.03e-04, steps: 68286, optimizer: Adam - train loss: 7.25 - valid loss: 6.79, valid ACC: 9.72e-01
epoch: 39, lr: 2.99e-04, steps: 70083, optimizer: Adam - train loss: 7.12 - valid loss: 6.96, valid ACC: 9.71e-01
epoch: 40, lr: 2.95e-04, steps: 71880, optimizer: Adam - train loss: 7.00 - valid loss: 7.03, valid ACC: 9.72e-01, valid WER: 6.01

**POST-FIX TRAIN LOG:**
epoch: 1, lr: 3.59e-05, steps: 1797, optimizer: Adam - train loss: 3.07e+02 - valid loss: 2.09e+02, valid ACC: 1.79e-01                                                                                                                    
epoch: 2, lr: 7.19e-05, steps: 3594, optimizer: Adam - train loss: 2.57e+02 - valid loss: 1.86e+02, valid ACC: 2.12e-01                                                                                                                    
epoch: 3, lr: 1.08e-04, steps: 5391, optimizer: Adam - train loss: 2.01e+02 - valid loss: 96.83, valid ACC: 5.54e-01                                                                                                                       
epoch: 4, lr: 1.44e-04, steps: 7188, optimizer: Adam - train loss: 97.51 - valid loss: 37.82, valid ACC: 8.36e-01                                                                                                                          
epoch: 5, lr: 1.80e-04, steps: 8985, optimizer: Adam - train loss: 58.00 - valid loss: 24.42, valid ACC: 8.93e-01                                                                                                                          
epoch: 6, lr: 2.16e-04, steps: 10782, optimizer: Adam - train loss: 44.37 - valid loss: 18.93, valid ACC: 9.20e-01                                                                                                                         
epoch: 7, lr: 2.52e-04, steps: 12579, optimizer: Adam - train loss: 36.70 - valid loss: 16.06, valid ACC: 9.33e-01                                                                                                                         
epoch: 8, lr: 2.88e-04, steps: 14376, optimizer: Adam - train loss: 31.20 - valid loss: 13.82, valid ACC: 9.39e-01                                                                                                                         
epoch: 9, lr: 3.23e-04, steps: 16173, optimizer: Adam - train loss: 27.64 - valid loss: 12.43, valid ACC: 9.45e-01                                                                                                                         
epoch: 10, lr: 3.59e-04, steps: 17970, optimizer: Adam - train loss: 25.32 - valid loss: 11.77, valid ACC: 9.49e-01, valid WER: 6.33                                                                                                       
epoch: 11, lr: 3.95e-04, steps: 19767, optimizer: Adam - train loss: 23.50 - valid loss: 10.55, valid ACC: 9.53e-01                                                                                                                        
epoch: 12, lr: 4.31e-04, steps: 21564, optimizer: Adam - train loss: 22.25 - valid loss: 10.52, valid ACC: 9.53e-01                                                                                                                        
epoch: 13, lr: 4.67e-04, steps: 23361, optimizer: Adam - train loss: 20.92 - valid loss: 9.84, valid ACC: 9.55e-01                                                                                                                         
epoch: 14, lr: 4.98e-04, steps: 25158, optimizer: Adam - train loss: 20.06 - valid loss: 9.40, valid ACC: 9.57e-01                                                                                                                         
epoch: 15, lr: 4.82e-04, steps: 26955, optimizer: Adam - train loss: 18.82 - valid loss: 9.19, valid ACC: 9.60e-01                                                                                                                         
epoch: 16, lr: 4.66e-04, steps: 28752, optimizer: Adam - train loss: 17.32 - valid loss: 9.02, valid ACC: 9.61e-01
epoch: 17, lr: 4.52e-04, steps: 30549, optimizer: Adam - train loss: 15.80 - valid loss: 7.95, valid ACC: 9.64e-01
epoch: 18, lr: 4.40e-04, steps: 32346, optimizer: Adam - train loss: 14.76 - valid loss: 8.43, valid ACC: 9.64e-01
epoch: 19, lr: 4.28e-04, steps: 34143, optimizer: Adam - train loss: 13.90 - valid loss: 8.03, valid ACC: 9.65e-01
epoch: 20, lr: 4.17e-04, steps: 35940, optimizer: Adam - train loss: 13.06 - valid loss: 7.65, valid ACC: 9.67e-01, valid WER: 4.19
epoch: 21, lr: 4.07e-04, steps: 37737, optimizer: Adam - train loss: 12.36 - valid loss: 7.65, valid ACC: 9.67e-01
epoch: 22, lr: 3.98e-04, steps: 39534, optimizer: Adam - train loss: 11.79 - valid loss: 7.17, valid ACC: 9.69e-01
epoch: 23, lr: 3.89e-04, steps: 41331, optimizer: Adam - train loss: 11.22 - valid loss: 7.13, valid ACC: 9.69e-01
epoch: 24, lr: 3.81e-04, steps: 43128, optimizer: Adam - train loss: 10.69 - valid loss: 7.51, valid ACC: 9.70e-01
epoch: 25, lr: 3.73e-04, steps: 44925, optimizer: Adam - train loss: 10.25 - valid loss: 7.07, valid ACC: 9.70e-01
epoch: 26, lr: 3.66e-04, steps: 46722, optimizer: Adam - train loss: 9.89 - valid loss: 7.32, valid ACC: 9.70e-01
epoch: 27, lr: 3.59e-04, steps: 48519, optimizer: Adam - train loss: 9.48 - valid loss: 7.59, valid ACC: 9.70e-01
epoch: 28, lr: 3.52e-04, steps: 50316, optimizer: Adam - train loss: 9.19 - valid loss: 6.93, valid ACC: 9.71e-01
epoch: 29, lr: 3.46e-04, steps: 52113, optimizer: Adam - train loss: 8.88 - valid loss: 7.61, valid ACC: 9.71e-01
epoch: 30, lr: 3.40e-04, steps: 53910, optimizer: Adam - train loss: 8.63 - valid loss: 7.05, valid ACC: 9.71e-01, valid WER: 3.66
epoch: 31, lr: 3.35e-04, steps: 55707, optimizer: Adam - train loss: 8.32 - valid loss: 6.92, valid ACC: 9.72e-01
epoch: 32, lr: 3.30e-04, steps: 57504, optimizer: Adam - train loss: 8.09 - valid loss: 7.27, valid ACC: 9.71e-01
epoch: 33, lr: 3.25e-04, steps: 59301, optimizer: Adam - train loss: 7.86 - valid loss: 7.48, valid ACC: 9.71e-01
epoch: 34, lr: 3.20e-04, steps: 61098, optimizer: Adam - train loss: 7.66 - valid loss: 7.32, valid ACC: 9.72e-01
epoch: 35, lr: 3.15e-04, steps: 62895, optimizer: Adam - train loss: 7.51 - valid loss: 7.33, valid ACC: 9.72e-01
epoch: 36, lr: 3.11e-04, steps: 64692, optimizer: Adam - train loss: 7.29 - valid loss: 7.33, valid ACC: 9.72e-01
epoch: 37, lr: 3.07e-04, steps: 66489, optimizer: Adam - train loss: 7.09 - valid loss: 7.08, valid ACC: 9.73e-01
epoch: 38, lr: 3.03e-04, steps: 68286, optimizer: Adam - train loss: 6.99 - valid loss: 7.46, valid ACC: 9.72e-01
epoch: 39, lr: 2.99e-04, steps: 70083, optimizer: Adam - train loss: 6.89 - valid loss: 7.24, valid ACC: 9.72e-01
epoch: 40, lr: 2.95e-04, steps: 71880, optimizer: Adam - train loss: 6.77 - valid loss: 7.41, valid ACC: 9.73e-01, valid WER: 3.40

I also tested a conformer_small to see if removing this would affect the performance of previous model, and I got 2.5 which is equivalent to our current small conformer performance. 