### PR TITLE
Fix unnecessary warning in train logger

### DIFF
--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -512,7 +512,7 @@ class Brain:
             sys.version_info.major == PYTHON_VERSION_MAJOR
             and sys.version_info.minor >= PYTHON_VERSION_MINOR
         ):
-            logger.warn(
+            logger.warning(
                 "Detected Python "
                 + str(sys.version_info.major)
                 + "."
@@ -598,7 +598,7 @@ class Brain:
                         "--distributed_launch=True --distributed_backend=nccl"
                     )
                 else:
-                    logger.warn(
+                    logger.warning(
                         "To use DDP, please add "
                         "sb.utils.distributed.ddp_init_group() into your exp.py"
                     )
@@ -996,10 +996,10 @@ class Brain:
             self.nonfinite_count += 1
 
             # Print helpful debug info
-            logger.warn(f"Loss is {loss}.")
+            logger.warning(f"Loss is {loss}.")
             for p in self.modules.parameters():
                 if not torch.isfinite(p).all():
-                    logger.warn("Parameter is not finite: " + str(p))
+                    logger.warning("Parameter is not finite: " + str(p))
 
             # Check if patience is exhausted
             if self.nonfinite_count > self.nonfinite_patience:
@@ -1010,7 +1010,9 @@ class Brain:
                     "torch.autograd.detect_anomaly():\n\tbrain.fit(...)"
                 )
             else:
-                logger.warn("Patience not yet exhausted, ignoring this batch.")
+                logger.warning(
+                    "Patience not yet exhausted, ignoring this batch."
+                )
                 return False
 
         # Clip gradient norm

--- a/speechbrain/tokenizers/SentencePiece.py
+++ b/speechbrain/tokenizers/SentencePiece.py
@@ -370,13 +370,13 @@ class SentencePiece:
                     fannotation_file.close()
                 logger.info("recover words from: " + annotation_file)
                 if len(wrong_recover_list) > 0:
-                    logger.warn(
+                    logger.warning(
                         "Wrong recover words: " + str(len(wrong_recover_list))
                     )
-                    logger.warn(
+                    logger.warning(
                         "Tokenizer vocab size: " + str(self.sp.vocab_size())
                     )
-                    logger.warn(
+                    logger.warning(
                         "accuracy recovering words: "
                         + str(
                             1

--- a/speechbrain/utils/hpopt.py
+++ b/speechbrain/utils/hpopt.py
@@ -68,7 +68,7 @@ def hpopt_mode(mode):
     """
 
     def f(cls):
-        """"Call the function that registers and returns the reporter class"""
+        """ "Call the function that registers and returns the reporter class"""
         _hpopt_modes[mode] = cls
         return cls
 
@@ -269,11 +269,13 @@ def get_reporter(mode, *args, **kwargs):
     """
     reporter_cls = _hpopt_modes.get(mode)
     if reporter_cls is None:
-        logger.warn(f"hpopt_mode {mode} is not supported, reverting to generic")
+        logger.warning(
+            f"hpopt_mode {mode} is not supported, reverting to generic"
+        )
         reporter_cls = _hpopt_modes[DEFAULT_REPORTER]
     reporter = reporter_cls(*args, **kwargs)
     if not reporter.is_available:
-        logger.warn("Reverting to a generic reporter")
+        logger.warning("Reverting to a generic reporter")
         reporter_cls = _hpopt_modes[DEFAULT_REPORTER]
         reporter = reporter_cls(*args, **kwargs)
     return reporter

--- a/speechbrain/utils/torch_audio_backend.py
+++ b/speechbrain/utils/torch_audio_backend.py
@@ -16,7 +16,7 @@ def check_torchaudio_backend():
     """
     current_system = platform.system()
     if current_system == "Windows":
-        logger.warn(
+        logger.warning(
             "The torchaudio backend is switched to 'soundfile'. Note that 'sox_io' is not supported on Windows."
         )
         torchaudio.set_audio_backend("soundfile")

--- a/speechbrain/utils/train_logger.py
+++ b/speechbrain/utils/train_logger.py
@@ -404,7 +404,7 @@ def plot_spectrogram(spectrogram, ap=None, fig_size=(16, 10), output_fig=False):
         import matplotlib.pyplot as plt
 
     except ImportError:
-        logger.warn("matplotlib is not available - cannot log figures")
+        logger.warning("matplotlib is not available - cannot log figures")
         return None
 
     spectrogram = spectrogram.detach().cpu().numpy().squeeze()

--- a/speechbrain/utils/train_logger.py
+++ b/speechbrain/utils/train_logger.py
@@ -224,7 +224,7 @@ def _get_image_saver():
 
         return torchvision.utils.save_image
     except ImportError:
-        logger.warn("torchvision is not available - cannot save figures")
+        logger.warning("torchvision is not available - cannot save figures")
         return None
 
 


### PR DESCRIPTION
This code uses a deprecated call to `logger.warn` which is superseded by `logger.warning`