### PR TITLE
fix bug returning indexerror in edit_distance.py:

### DIFF
--- a/speechbrain/utils/edit_distance.py
+++ b/speechbrain/utils/edit_distance.py
@@ -480,7 +480,7 @@ def wer_details_by_utterance(
         table = op_table(ref_tokens, hyp_tokens)
         ops = count_ops(table)
         # Take into account "" outputs as empty
-        if ref_tokens[0] == "" and hyp_tokens[0] == "":
+        if (not ref_tokens) or (ref_tokens[0] == "" ):
             num_ref_tokens = 0
         else:
             num_ref_tokens = len(ref_tokens)
@@ -489,7 +489,7 @@ def wer_details_by_utterance(
             {
                 "scored": True,
                 "hyp_empty": True
-                if len(hyp_tokens) == 0
+                if ((not hyp_tokens == 0) or (hyp_tokens[0] == ""))
                 else False,  # This also works for e.g. torch tensors
                 "num_edits": sum(ops.values()),
                 "num_ref_tokens": num_ref_tokens,

--- a/speechbrain/utils/edit_distance.py
+++ b/speechbrain/utils/edit_distance.py
@@ -480,7 +480,7 @@ def wer_details_by_utterance(
         table = op_table(ref_tokens, hyp_tokens)
         ops = count_ops(table)
         # Take into account "" outputs as empty
-        if (not ref_tokens) or (ref_tokens[0] == "" ):
+        if (not ref_tokens) or (ref_tokens[0] == ""):
             num_ref_tokens = 0
         else:
             num_ref_tokens = len(ref_tokens)


### PR DESCRIPTION
IndexError occurs where indexing into None or empty list is attempted in `wer_details_by_utterance()`:

`        if ref_tokens[0] == "" and hyp_tokens[0] == "":
`


Fix ensures `None, [], [""]` are all considered empty. 

I came across this bug using the `train_with_whisper.py` transfomer recipe when computing the character error rate (CER) metric in the case where the normalizer returns an empty transcript for ref or hyp.
I posted an Issue about this bug originally: see https://github.com/speechbrain/speechbrain/issues/1917, and @Adel-Moumen suggested I open a pull request for my fix, which I hope you find helpful!
