### PR TITLE
Fix broken CUDA check in TransducerLoss forward

### DIFF
--- a/speechbrain/nnet/loss/transducer_loss.py
+++ b/speechbrain/nnet/loss/transducer_loss.py
@@ -340,7 +340,7 @@ class TransducerLoss(Module):
     def forward(self, logits, labels, T, U):
         """Computes the transducer loss."""
         # Transducer.apply function take log_probs tensor.
-        if logits.device == labels.device == T.device == U.device == "cuda":
+        if all(t.is_cuda for t in (logits, labels, T, U)):
             log_probs = logits.log_softmax(-1)
             return self.loss(
                 log_probs, labels, T, U, self.blank, self.reduction


### PR DESCRIPTION
The previous check was incorrect because .device does not return a `str` but a PyTorch device object, hence the check was incorrect.

Fixes #1928; the provided repro now successfully runs on GPU and changing any of the tensors to CPU correctly errors out.