### PR TITLE
Add `read_audio_info`, fix improper MP3 metadata read on CommonVoice/DVoice

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -24,6 +24,9 @@ jobs:
             - name: Install libsndfile
               run: |
                   sudo apt-get install -y libsndfile1
+            - name: Install ffmpeg
+              run: |
+                  sudo apt-get install -y ffmpeg
             - name: Display Python version
               run: python -c "import sys; print(sys.version)"
             - name: Full dependencies

--- a/recipes/CommonVoice/common_voice_prepare.py
+++ b/recipes/CommonVoice/common_voice_prepare.py
@@ -18,6 +18,7 @@ import unicodedata
 import functools
 
 from speechbrain.utils.parallel import parallel_map
+from speechbrain.dataio.dataio import read_audio_info
 
 logger = logging.getLogger(__name__)
 
@@ -180,7 +181,7 @@ def process_line(line, data_folder, language, accented_letters):
 
     # Reading the signal (to retrieve duration in seconds)
     if os.path.isfile(mp3_path):
-        info = torchaudio.info(mp3_path)
+        info = read_audio_info(mp3_path)
     else:
         msg = "\tError loading: %s" % (str(len(file_name)))
         logger.info(msg)

--- a/recipes/DVoice/dvoice_prepare.py
+++ b/recipes/DVoice/dvoice_prepare.py
@@ -19,6 +19,7 @@ import pandas as pd
 from tqdm import tqdm
 import numpy as np
 import glob
+from speechbrain.dataio.dataio import read_audio_info
 
 logger = logging.getLogger(__name__)
 
@@ -195,7 +196,7 @@ def alffa_public_prepare(language, data_folder):
         for j in range(len(wavs)):
             if wavs[j].split("/")[-1] == file_name + ".wav":
                 wav = wavs[j]
-                info = torchaudio.info(wav)
+                info = read_audio_info(wav)
                 duration = info.num_frames / info.sample_rate
                 dic = {
                     "wav": wavs[j].replace(data_folder + "/", ""),
@@ -254,7 +255,7 @@ def swahili_prepare(data_folder):
         for j in range(len(wavs_alffa)):
             if wavs_alffa[j].split("/")[-1] == file_name + ".wav":
                 wav = wavs_alffa[j]
-                info = torchaudio.info(wav)
+                info = read_audio_info(wav)
                 duration = info.num_frames / info.sample_rate
                 dic = {
                     "wav": wavs_alffa[j].replace(data_folder + "/", ""),

--- a/speechbrain/dataio/dataio.py
+++ b/speechbrain/dataio/dataio.py
@@ -186,7 +186,16 @@ def read_audio_info(path) -> "torchaudio.backend.common.AudioMetaData":
     the processing time.
     """
 
-    info = torchaudio.info(path)
+    _path_no_ext, path_ext = os.path.splitext(path)
+
+    if path_ext == ".mp3":
+        # Additionally, certain affected versions of torchaudio fail to
+        # autodetect mp3.
+        # HACK: here, we check for the file extension to force mp3 detection,
+        # which prevents an error from occuring in torchaudio.
+        info = torchaudio.info(path, format="mp3")
+    else:
+        info = torchaudio.info(path)
 
     # Certain file formats, such as MP3, do not provide a reliable way to
     # query file duration from metadata (when there is any).

--- a/speechbrain/dataio/dataio.py
+++ b/speechbrain/dataio/dataio.py
@@ -160,6 +160,55 @@ def load_data_csv(csv_path, replacements={}):
     return result
 
 
+def read_audio_info(path) -> "torchaudio.backend.common.AudioMetaData":
+    """Retrieves audio metadata from a file path. Behaves identically to
+    torchaudio.info, but attempts to fix metadata (such as frame count) that is
+    otherwise broken with certain torchaudio version and codec combinations.
+
+    Note that this may cause full file traversal in certain cases!
+
+    Arguments
+    ----------
+    path : str
+        Path to the audio file to examine.
+
+    Returns
+    -------
+    torchaudio.backend.common.AudioMetaData
+        Same value as returned by `torchaudio.info`, but may eventually have
+        `num_frames` corrected if it otherwise would have been `== 0`.
+
+    NOTE
+    ----
+    Some codecs, such as MP3, require full file traversal for accurate length
+    information to be retrieved.
+    In these cases, you may as well read the entire audio file to avoid doubling
+    the processing time.
+    """
+
+    info = torchaudio.info(path)
+
+    # Certain file formats, such as MP3, do not provide a reliable way to
+    # query file duration from metadata (when there is any).
+    # For MP3, certain versions of torchaudio began returning num_frames == 0.
+    #
+    # https://github.com/speechbrain/speechbrain/issues/1925
+    # https://github.com/pytorch/audio/issues/2524
+    #
+    # Accomodate for these cases here: if `num_frames == 0` then maybe something
+    # has gone wrong.
+    # If some file really had `num_frames == 0` then we are not doing harm
+    # double-checking anyway. If I am wrong and you are reading this comment
+    # because of it: sorry
+    if info.num_frames == 0:
+        channels_data, sample_rate = torchaudio.load(path, normalize=False)
+
+        info.num_frames = channels_data.size(1)
+        info.sample_rate = sample_rate  # because we might as well
+
+    return info
+
+
 def read_audio(waveforms_obj):
     """General audio loading, based on a custom notation.
 

--- a/tests/unittests/test_data_io.py
+++ b/tests/unittests/test_data_io.py
@@ -2,6 +2,28 @@ import torch
 import os
 
 
+def test_read_audio_info(tmpdir, device):
+    from speechbrain.dataio.dataio import read_audio_info, write_audio
+
+    test_waveform = torch.rand(32000, device=device)
+
+    for ext in ["wav", "ogg", "mp3"]:
+        audio_path = os.path.join(tmpdir, f"test.{ext}")
+        write_audio(audio_path, test_waveform.cpu(), 16000)
+        info = read_audio_info(audio_path)
+
+        # NOTE: This wide check is introduced for codecs that cannot handle
+        # exact frame counts, such as mp3, which appears to operate over chunks
+        # of 384 frames.
+        # This remains an exact read of the metadata, however, which is what we
+        # want to test and is the reason for `read_audio_info` to exist (see
+        # comments there).
+        assert (
+            32000 <= info.num_frames <= 35000
+        ), f"expected consistent len for codec {ext}"
+        assert info.sample_rate == 16000
+
+
 def test_read_audio(tmpdir, device):
     from speechbrain.dataio.dataio import read_audio, write_audio
 


### PR DESCRIPTION
Fixes #1925.

This PR introduces a `dataio` function `read_audio_info` which, for the most part, behaves identically to `torchaudio.info`. However, because certain `torchaudio` versions have a "bug" which makes it so that `num_frames` is not populated with MP3 (which was solved in very recent versions), this function additionally decodes the file to obtain the frame count.  
This is slow, but this is what newer torchaudio does anyway(? might be ffmpeg now), as there doesn't seem to be a perfectly consistent way to achieve this with MP3.

Data preparation was tested over for CommonVoice, but not for DVoice, which also uses MP3. However, because these steps are very similar, there should be no reason for it to fail.

A test was also added to verify whether it appears to function properly (and also does so for mp3+ogg+wav for good measure).

Recent versions of torchaudio offload MP3 handling to ffmpeg, so this PR also adds a ffmpeg install step for the CI (it does not touch requirements files and such, as it is often system provided). This could be split to a different PR if required.