### PR TITLE
Add `parallel_map`, parallelize CommonVoice data preparation

### DIFF
--- a/recipes/CommonVoice/common_voice_prepare.py
+++ b/recipes/CommonVoice/common_voice_prepare.py
@@ -271,7 +271,10 @@ def create_csv(
         accented_letters=accented_letters,
     )
 
-    with open(csv_file, mode="w", encoding="utf-8") as csv_f:
+    # Stream into a .tmp file, and rename it to the real path at the end.
+    csv_file_tmp = csv_file + ".tmp"
+
+    with open(csv_file_tmp, mode="w", encoding="utf-8") as csv_f:
         csv_writer = csv.writer(
             csv_f, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL
         )
@@ -292,6 +295,8 @@ def create_csv(
                     row.words,
                 ]
             )
+
+    os.replace(csv_file_tmp, csv_file)
 
     # Final prints
     msg = "%s successfully created!" % (csv_file)

--- a/recipes/CommonVoice/common_voice_prepare.py
+++ b/recipes/CommonVoice/common_voice_prepare.py
@@ -268,7 +268,7 @@ def create_csv(
         process_line,
         data_folder=data_folder,
         language=language,
-        accented_letters=accented_letters
+        accented_letters=accented_letters,
     )
 
     with open(csv_file, mode="w", encoding="utf-8") as csv_f:
@@ -283,7 +283,15 @@ def create_csv(
                 continue
 
             total_duration += row.duration
-            csv_writer.writerow([row.snt_id, str(row.duration), row.mp3_path, row.spk_id, row.words])
+            csv_writer.writerow(
+                [
+                    row.snt_id,
+                    str(row.duration),
+                    row.mp3_path,
+                    row.spk_id,
+                    row.words,
+                ]
+            )
 
     # Final prints
     msg = "%s successfully created!" % (csv_file)

--- a/recipes/CommonVoice/common_voice_prepare.py
+++ b/recipes/CommonVoice/common_voice_prepare.py
@@ -8,13 +8,16 @@ Luca Della Libera 2022
 Pooneh Mousavi 2022
 """
 
+from dataclasses import dataclass
 import os
 import csv
 import re
 import logging
 import torchaudio
 import unicodedata
-from tqdm.contrib import tzip
+import functools
+
+from speechbrain.utils.parallel import parallel_map
 
 logger = logging.getLogger(__name__)
 
@@ -152,6 +155,76 @@ def skip(save_csv_train, save_csv_dev, save_csv_test):
     return skip
 
 
+@dataclass
+class CVRow:
+    snt_id: str
+    duration: float
+    mp3_path: str
+    spk_id: str
+    words: str
+
+
+def process_line(line, data_folder, language, accented_letters):
+    # Path is at indice 1 in Common Voice tsv files. And .mp3 files
+    # are located in datasets/lang/clips/
+    mp3_path = data_folder + "/clips/" + line.split("\t")[1]
+    file_name = mp3_path.split(".")[-2].split("/")[-1]
+    spk_id = line.split("\t")[0]
+    snt_id = file_name
+
+    # Setting torchaudio backend to sox-io (needed to read mp3 files)
+    if torchaudio.get_audio_backend() != "sox_io":
+        logger.warning("This recipe needs the sox-io backend of torchaudio")
+        logger.warning("The torchaudio backend is changed to sox_io")
+        torchaudio.set_audio_backend("sox_io")
+
+    # Reading the signal (to retrieve duration in seconds)
+    if os.path.isfile(mp3_path):
+        info = torchaudio.info(mp3_path)
+    else:
+        msg = "\tError loading: %s" % (str(len(file_name)))
+        logger.info(msg)
+        return None
+
+    duration = info.num_frames / info.sample_rate
+
+    # Getting transcript
+    words = line.split("\t")[2]
+
+    # Unicode Normalization
+    words = unicode_normalisation(words)
+
+    # !! Language specific cleaning !!
+    words = language_specific_preprocess(language, words)
+
+    # Remove accents if specified
+    if not accented_letters:
+        words = strip_accents(words)
+        words = words.replace("'", " ")
+        words = words.replace("’", " ")
+
+    # Remove multiple spaces
+    words = re.sub(" +", " ", words)
+
+    # Remove spaces at the beginning and the end of the sentence
+    words = words.lstrip().rstrip()
+
+    # Getting chars
+    chars = words.replace(" ", "_")
+    chars = " ".join([char for char in chars][:])
+
+    # Remove too short sentences (or empty):
+    if language in ["ja", "ch"]:
+        if len(chars) < 3:
+            return None
+    else:
+        if len(words.split(" ")) < 3:
+            return None
+
+    # Composition of the csv_line
+    return CVRow(snt_id, duration, mp3_path, spk_id, words)
+
+
 def create_csv(
     orig_tsv_file, csv_file, data_folder, accented_letters=False, language="en"
 ):
@@ -179,7 +252,7 @@ def create_csv(
 
     # We load and skip the header
     loaded_csv = open(orig_tsv_file, "r").readlines()[1:]
-    nb_samples = str(len(loaded_csv))
+    nb_samples = len(loaded_csv)
 
     msg = "Preparing CSV files for %s samples ..." % (str(nb_samples))
     logger.info(msg)
@@ -188,85 +261,29 @@ def create_csv(
     msg = "Creating csv lists in %s ..." % (csv_file)
     logger.info(msg)
 
-    csv_lines = [["ID", "duration", "wav", "spk_id", "wrd"]]
-
-    # Start processing lines
+    # Process and write lines
     total_duration = 0.0
-    for line in tzip(loaded_csv):
 
-        line = line[0]
+    line_processor = functools.partial(
+        process_line,
+        data_folder=data_folder,
+        language=language,
+        accented_letters=accented_letters
+    )
 
-        # Path is at indice 1 in Common Voice tsv files. And .mp3 files
-        # are located in datasets/lang/clips/
-        mp3_path = data_folder + "/clips/" + line.split("\t")[1]
-        file_name = mp3_path.split(".")[-2].split("/")[-1]
-        spk_id = line.split("\t")[0]
-        snt_id = file_name
-
-        # Setting torchaudio backend to sox-io (needed to read mp3 files)
-        if torchaudio.get_audio_backend() != "sox_io":
-            logger.warning("This recipe needs the sox-io backend of torchaudio")
-            logger.warning("The torchaudio backend is changed to sox_io")
-            torchaudio.set_audio_backend("sox_io")
-
-        # Reading the signal (to retrieve duration in seconds)
-        if os.path.isfile(mp3_path):
-            info = torchaudio.info(mp3_path)
-        else:
-            msg = "\tError loading: %s" % (str(len(file_name)))
-            logger.info(msg)
-            continue
-
-        duration = info.num_frames / info.sample_rate
-        total_duration += duration
-
-        # Getting transcript
-        words = line.split("\t")[2]
-
-        # Unicode Normalization
-        words = unicode_normalisation(words)
-
-        # !! Language specific cleaning !!
-        words = language_specific_preprocess(language, words)
-
-        # Remove accents if specified
-        if not accented_letters:
-            words = strip_accents(words)
-            words = words.replace("'", " ")
-            words = words.replace("’", " ")
-
-        # Remove multiple spaces
-        words = re.sub(" +", " ", words)
-
-        # Remove spaces at the beginning and the end of the sentence
-        words = words.lstrip().rstrip()
-
-        # Getting chars
-        chars = words.replace(" ", "_")
-        chars = " ".join([char for char in chars][:])
-
-        # Remove too short sentences (or empty):
-        if language in ["ja", "ch"]:
-            if len(chars) < 3:
-                continue
-        else:
-            if len(words.split(" ")) < 3:
-                continue
-
-        # Composition of the csv_line
-        csv_line = [snt_id, str(duration), mp3_path, spk_id, str(words)]
-
-        # Adding this line to the csv_lines list
-        csv_lines.append(csv_line)
-
-    # Writing the csv lines
     with open(csv_file, mode="w", encoding="utf-8") as csv_f:
         csv_writer = csv.writer(
             csv_f, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL
         )
 
-        for line in csv_lines:
-            csv_writer.writerow(line)
+        csv_writer.writerow(["ID", "duration", "wav", "spk_id", "wrd"])
+
+        for row in parallel_map(line_processor, loaded_csv):
+            if row is None:
+                continue
+
+            total_duration += row.duration
+            csv_writer.writerow([row.snt_id, str(row.duration), row.mp3_path, row.spk_id, row.words])
 
     # Final prints
     msg = "%s successfully created!" % (csv_file)

--- a/speechbrain/utils/parallel.py
+++ b/speechbrain/utils/parallel.py
@@ -1,0 +1,156 @@
+"""Parallel processing tools to help speed up certain tasks like data
+preprocessing.
+
+Authors
+ * Sylvain de Langen 2023
+"""
+
+import itertools
+import multiprocessing
+from collections import deque
+from concurrent.futures import Executor, ProcessPoolExecutor
+from threading import Condition
+from typing import Any, Callable, Iterable, Optional
+
+import pandas as pd
+from tqdm.auto import tqdm
+
+
+def _chunk_process_wrapper(fn, chunk):
+    return list(map(fn, chunk))
+
+def parallel_map(
+    fn: Callable[[Any], None],
+    source: Iterable[Any],
+    process_count: int = multiprocessing.cpu_count(),
+    chunk_size: int = 8,
+    queue_size: int = 128,
+    executor: Optional[Executor] = None,
+    progress_bar: bool = True,
+):
+    """Maps iterable items with a function, processing chunks of items in
+    parallel with multiple processes and displaying progress with tqdm.
+
+    Processed elements will always be returned in the original, correct order.
+    Unlike `ProcessPoolExecutor.map`, elements are produced AND consumed lazily.
+
+    Arguments
+    ---------
+    fn
+        The function that is called for every element in the source list.
+        The output is an iterator over the source list after fn(elem) is called.
+
+    source: Iterable
+        Iterator whose elements are passed through the mapping function.
+
+    process_count: int
+        The number of processes to spawn. Ignored if a custom executor is
+        provided.
+        For CPU-bound tasks, it is generally not useful to exceed logical core
+        count.
+        For IO-bound tasks, it may make sense to as to limit the amount of time
+        spent in iowait.
+
+    chunk_size: int
+        How many elements are fed to the worker processes at once. A value of 8
+        is generally fine. Low values may increase overhead and reduce CPU
+        occupancy.
+
+    queue_size: int
+        Number of chunks to be waited for on the main process at a time.
+        Low values increase the chance of the queue being starved, forcing
+        workers to idle.
+        Very high values may cause high memory usage, especially if the source
+        iterable yields large objects.
+
+    executor: Optional[Executor]
+        Allows providing an existing executor (preferably a
+        ProcessPoolExecutor). If None (the default), a process pool will be
+        spawned for this mapping task and will be shut down after.
+
+    progress_bar: bool
+        Whether to show a tqdm progress bar.
+    """
+    known_len = len(source) if hasattr(source, "__len__") else None
+    source_it = iter(source)
+
+    futures = deque()
+    cv = Condition()
+    just_finished_count = 0
+
+    if progress_bar:
+        pbar = tqdm(
+            total=known_len,
+            smoothing=0.02, # higher smoothing
+        )
+    else:
+        pbar = None
+
+    def bump_processed_count(future):
+        nonlocal just_finished_count
+
+        # update progress bar with the length of the output as the progress bar
+        # is over element count, not chunk count.
+        if pbar is not None:
+            pbar.update(len(future.result()))
+
+        # wake up dispatcher thread to refill the queue
+        with cv:
+            just_finished_count += 1
+            cv.notify()
+
+    def _map_all(executor: Executor):
+        nonlocal just_finished_count
+
+        def _enqueue_job():
+            # immediately deplete the input stream of chunk_size elems (or less)
+            chunk = list(itertools.islice(source_it, chunk_size))
+
+            # empty chunk? then we finished iterating over the input stream
+            if len(chunk) == 0:
+                return False
+
+            future = executor.submit(_chunk_process_wrapper, fn, chunk)
+            future.add_done_callback(bump_processed_count)
+            futures.append(future)
+
+            return True
+
+        # initial queue fill
+        for _ in range(queue_size):
+            if not _enqueue_job():
+                break
+
+        # consume & requeue logic
+        while len(futures) != 0:
+            with cv:
+                # wait for new work to be ready. if `cv.notify` was called by a
+                # worker _after_ the `with cv` block, then we should not wait!
+                # a new wakeup may never actually happen (or later, when a
+                # different worker finishes).
+                while just_finished_count == 0:
+                    cv.wait()
+
+                # avoid data race on just_finished_count, we're still guarded by
+                # the lock here.
+                to_queue_count = just_finished_count
+                just_finished_count = 0
+
+            # try to enqueue as many jobs as there were just finished.
+            # when the input is finished, the queue will not be refilled.
+            for _ in range(to_queue_count):
+                _enqueue_job()
+
+            # as we must yield in order, try to deplete as much futures from the
+            # start of the list as are currently available.
+            while len(futures) != 0 and futures[0].done():
+                yield from futures.popleft().result()
+
+        if pbar is not None:
+            pbar.close()
+
+    if executor is not None:
+        yield from _map_all(executor)
+    else:
+        with ProcessPoolExecutor(max_workers=process_count) as pool:
+            yield from _map_all(pool)

--- a/speechbrain/utils/parallel.py
+++ b/speechbrain/utils/parallel.py
@@ -83,7 +83,7 @@ def parallel_map(
     else:
         pbar = None
 
-    def bump_processed_count(future):
+    def _bump_processed_count(future):
         nonlocal just_finished_count
 
         # update progress bar with the length of the output as the progress bar
@@ -108,7 +108,7 @@ def parallel_map(
                 return False
 
             future = executor.submit(_chunk_process_wrapper, fn, chunk)
-            future.add_done_callback(bump_processed_count)
+            future.add_done_callback(_bump_processed_count)
             futures.append(future)
 
             return True

--- a/speechbrain/utils/parallel.py
+++ b/speechbrain/utils/parallel.py
@@ -136,7 +136,8 @@ def parallel_map(
             # try to enqueue as many jobs as there were just finished.
             # when the input is finished, the queue will not be refilled.
             for _ in range(to_queue_count):
-                _enqueue_job()
+                if not _enqueue_job():
+                    break
 
             # as we must yield in order, try to deplete as much futures from the
             # start of the list as are currently available.

--- a/speechbrain/utils/parallel.py
+++ b/speechbrain/utils/parallel.py
@@ -27,6 +27,7 @@ def parallel_map(
     queue_size: int = 128,
     executor: Optional[Executor] = None,
     progress_bar: bool = True,
+    progress_bar_kwargs: dict = {"smoothing": 0.02},
 ):
     """Maps iterable items with a function, processing chunks of items in
     parallel with multiple processes and displaying progress with tqdm.
@@ -70,6 +71,11 @@ def parallel_map(
 
     progress_bar: bool
         Whether to show a tqdm progress bar.
+
+    progress_bar_kwargs: dict
+        A dict of keyword arguments that is forwarded to tqdm when
+        `progress_bar == True`. Allows overriding the defaults or e.g.
+        specifying `total` when it cannot be inferred from the source iterable.
     """
     known_len = len(source) if hasattr(source, "__len__") else None
     source_it = iter(source)
@@ -79,7 +85,9 @@ def parallel_map(
     just_finished_count = 0
 
     if progress_bar:
-        pbar = tqdm(total=known_len, smoothing=0.02,)  # higher smoothing
+        tqdm_final_kwargs = {"total": known_len}
+        tqdm_final_kwargs.update(progress_bar_kwargs)
+        pbar = tqdm(**tqdm_final_kwargs)
     else:
         pbar = None
 

--- a/speechbrain/utils/parallel.py
+++ b/speechbrain/utils/parallel.py
@@ -19,6 +19,7 @@ from tqdm.auto import tqdm
 def _chunk_process_wrapper(fn, chunk):
     return list(map(fn, chunk))
 
+
 def parallel_map(
     fn: Callable[[Any], None],
     source: Iterable[Any],
@@ -79,10 +80,7 @@ def parallel_map(
     just_finished_count = 0
 
     if progress_bar:
-        pbar = tqdm(
-            total=known_len,
-            smoothing=0.02, # higher smoothing
-        )
+        pbar = tqdm(total=known_len, smoothing=0.02,)  # higher smoothing
     else:
         pbar = None
 

--- a/speechbrain/utils/parallel.py
+++ b/speechbrain/utils/parallel.py
@@ -12,7 +12,6 @@ from concurrent.futures import Executor, ProcessPoolExecutor
 from threading import Condition
 from typing import Any, Callable, Iterable, Optional
 
-import pandas as pd
 from tqdm.auto import tqdm
 
 

--- a/tests/unittests/test_parallel.py
+++ b/tests/unittests/test_parallel.py
@@ -1,0 +1,47 @@
+import pytest
+
+from speechbrain.utils.parallel import parallel_map
+
+small_test_input = [1, 2, 3, 4, 5, 6] * 5
+small_test_expected = [2, 4, 6, 8, 10, 12] * 5
+
+
+def small_test_func(x):
+    return x * 2
+
+
+def raise_error(x):
+    raise ValueError("dummy error")
+
+
+def test_parallel_map():
+    # test different chunk sizes
+    for test_chunk_size in [1, 2, 4, 8, 16, 32, 64, 128]:
+        small_test_output = list(parallel_map(
+            small_test_func,
+            small_test_input,
+            process_count=2,
+            chunk_size=test_chunk_size
+        ))
+
+        assert \
+            small_test_output == small_test_expected, \
+            f"chunk_size={test_chunk_size}"
+
+    # test whether pbar off works properly
+    small_test_output = list(parallel_map(
+        small_test_func,
+        small_test_input,
+        progress_bar=False
+    ))
+
+    # test whether exceptions are forwarded properly
+    with pytest.raises(ValueError):
+        small_test_output = list(parallel_map(
+            raise_error,
+            small_test_input,
+            progress_bar=False
+        ))
+
+    # test edge case: empty input
+    assert list(parallel_map(small_test_func, [])) == []

--- a/tests/unittests/test_parallel.py
+++ b/tests/unittests/test_parallel.py
@@ -45,4 +45,4 @@ def test_parallel_map():
     assert list(parallel_map(small_test_func, [])) == []
 
     # trivial test for tqdm kwargs
-    parallel_map(small_test_func, small_test_input, tqdm_kwargs={})
+    parallel_map(small_test_func, small_test_input, progress_bar_kwargs={})

--- a/tests/unittests/test_parallel.py
+++ b/tests/unittests/test_parallel.py
@@ -43,3 +43,6 @@ def test_parallel_map():
 
     # test edge case: empty input
     assert list(parallel_map(small_test_func, [])) == []
+
+    # trivial test for tqdm kwargs
+    parallel_map(small_test_func, small_test_input, tqdm_kwargs={})

--- a/tests/unittests/test_parallel.py
+++ b/tests/unittests/test_parallel.py
@@ -17,31 +17,29 @@ def raise_error(x):
 def test_parallel_map():
     # test different chunk sizes
     for test_chunk_size in [1, 2, 4, 8, 16, 32, 64, 128]:
-        small_test_output = list(parallel_map(
-            small_test_func,
-            small_test_input,
-            process_count=2,
-            chunk_size=test_chunk_size
-        ))
+        small_test_output = list(
+            parallel_map(
+                small_test_func,
+                small_test_input,
+                process_count=2,
+                chunk_size=test_chunk_size,
+            )
+        )
 
-        assert \
-            small_test_output == small_test_expected, \
-            f"chunk_size={test_chunk_size}"
+        assert (
+            small_test_output == small_test_expected
+        ), f"chunk_size={test_chunk_size}"
 
     # test whether pbar off works properly
-    small_test_output = list(parallel_map(
-        small_test_func,
-        small_test_input,
-        progress_bar=False
-    ))
+    small_test_output = list(
+        parallel_map(small_test_func, small_test_input, progress_bar=False)
+    )
 
     # test whether exceptions are forwarded properly
     with pytest.raises(ValueError):
-        small_test_output = list(parallel_map(
-            raise_error,
-            small_test_input,
-            progress_bar=False
-        ))
+        small_test_output = list(
+            parallel_map(raise_error, small_test_input, progress_bar=False)
+        )
 
     # test edge case: empty input
     assert list(parallel_map(small_test_func, [])) == []


### PR DESCRIPTION
Supersedes #1602. This adds a `speechbrain.utils.parallel` import which provides `parallel_map`. Its main goal is to allow transforming elements from a list using a function, in a way that is executed in parallel. Elements are guaranteed to be returned in order, which makes this generally fairly usable. By default, a progress bar is shown.

By default, a process pool is used. I found that for certain tasks, `ThreadPoolExecutor` has unacceptable overhead, even when using its `.map` method. When the GIL is an issue, process pools appear to simply perform much better.

This does not require adding a new dependency to SpeechBrain and generally differs in some ways compared to most alternatives, in ways that seem somewhat beneficial. For one, `parallel_map` uses a (configurable) queue for dispatching jobs from the main thread. Furthermore, it will not attempt consuming the entire input stream at once, like `.map` would. It will also generate the output in-order, and not all at once.  
The hope here is to keep it flexible and viable for a wider range of usecases, including cases where it would not be acceptable to have the entire input or output live in memory at once.

The main design rationale is to:
1. Fill a queue (n=128 by default) of futures which are invoked jobs in the process pool, where every job operates over a chunk of the input.
2. Attach a conditional variable signal to the future to wake up the main scheduler thread.
3. When the main thread is woken up by the condition variable, re-enqueue as many jobs as were finished (in order to maintain the queue size) -- as long as there is enough input data.
4. If the first future in the queue is ready, get its result and yield it to the calling function. Keep going as long as we have ready futures in the front. This ensures in-order yielding even if the chunks are processed out-of-order across processes.
5. Loop back to step 2 until there isn't any future left to yield.

As it stands, this is a single function and is not integrated into things like the dynamic item dataset. I was discussing this in #1602 but I am not certain whether this would be necessary for data preparation.

This was tested with a real recipe, CommonVoice, for which the new data preparation steps are included in this PR. The observed performance improvement appears to scale with core count (in a case where the data preparation step was CPU bound). Will conflict with #1934, which will need to be fixed once either of the PRs are merged.