### PR TITLE
Added '--local-rank' alias to fix DDP with PyTorch 2.x

### DIFF
--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -198,7 +198,12 @@ def parse_arguments(arg_list=None):
         help="A file storing the configuration options for logging",
     )
     # if use_env = False in torch.distributed.lunch then local_rank arg is given
-    parser.add_argument("--local_rank", type=int, help="Rank on local machine")
+    parser.add_argument(
+        "--local_rank",
+        "--local-rank",  # alias required for PyTorch 2.x
+        type=int,
+        help="Rank on local machine",
+    )
     parser.add_argument(
         "--device",
         type=str,


### PR DESCRIPTION
# Contribution in a nutshell

As reported in #1897, DDP as applied for a training recipe would fail on my PyTorch 2.0 install. This adds an alias to the SB CLI that _also_ accepts the new `--local-rank` (in addition to `--local_rank`) and solves the issue.

# Scope
* [x] Fixes PyTorch 2.0 DDP training.

# Notes for reviewing (optional)
There should be no backward compatibility concerns, as this is only a new alias for a flag passed by pytorch.

# Pre-review
* [x] (if applicable) add an `extra_requirements.txt` file
* [x] (if applicable) add database preparation scripts & use symlinks for nested folders (to the level of task READMEs)
* [x] (if applicable) add a recipe test entry in the depending CSV file under: tests/recipes
* [x] create a fresh testing environment (install SpeechBrain from cloned repo branch of this PR)
* [x] (if applicable) run a recipe test for each yaml/your recipe dataset
* [x] check function comments: are there docstrings w/ arguments & returns? If you're not the verbose type, put a comment every three lines of code (better: every line)
* [x] use CI locally: `pre-commit run -a` to check linters; run `pytest tests/consistency`
* [x] (optional) run `tests/.run-doctests.sh` & `tests/.run-unittests.sh`
* [x] exhausted patience before clicking « Ready for review » in the merge box 🍄