### PR TITLE
workflows fix

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -23,14 +23,17 @@ jobs:
                   python-version: ${{ matrix.python-version }}
             - name: Install libsndfile
               run: |
+                  sudo apt-get update
                   sudo apt-get install -y libsndfile1
             - name: Install ffmpeg
               run: |
+                  sudo apt-get update
                   sudo apt-get install -y ffmpeg
             - name: Display Python version
               run: python -c "import sys; print(sys.version)"
             - name: Full dependencies
               run: |
+                  sudo apt-get update
                   pip install -r requirements.txt
                   pip install --editable .
                   pip install ctc-segmentation


### PR DESCRIPTION
Fix CI/CD workflow following https://github.com/actions/runner-images/issues/7452.

> E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/i/intel-media-driver/intel-media-va-driver_22.3.1%2bdfsg1-1ubuntu1_amd64.deb  404  Not Found [IP: 40.119.46.219 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?

The fix is solving the pb. (as you can see the checks passed!)

Btw: 
> Note: Always run sudo apt-get update before installing a package. In case the apt index is stale, this command fetches and re-indexes any available packages, which helps prevent package installation failures.