### PR TITLE
Fixing multiple device bug : Update interfaces.py

### DIFF
--- a/speechbrain/pretrained/interfaces.py
+++ b/speechbrain/pretrained/interfaces.py
@@ -1457,7 +1457,14 @@ class VAD(Pretrained):
         # Fix edge cases (when a speech starts in the last frames)
         if (prob_th == 1).nonzero().shape[0] % 2 == 1:
             prob_th = torch.cat(
-                (prob_th, torch.Tensor([1.0]).unsqueeze(0).unsqueeze(2).to(self.device)), dim=1
+                (
+                    prob_th,
+                    torch.Tensor([1.0])
+                    .unsqueeze(0)
+                    .unsqueeze(2)
+                    .to(self.device),
+                ),
+                dim=1,
             )
 
         # Where prob_th is 1 there is a change

--- a/speechbrain/pretrained/interfaces.py
+++ b/speechbrain/pretrained/interfaces.py
@@ -1457,7 +1457,7 @@ class VAD(Pretrained):
         # Fix edge cases (when a speech starts in the last frames)
         if (prob_th == 1).nonzero().shape[0] % 2 == 1:
             prob_th = torch.cat(
-                (prob_th, torch.Tensor([1.0]).unsqueeze(0).unsqueeze(2)), dim=1
+                (prob_th, torch.Tensor([1.0]).unsqueeze(0).unsqueeze(2).to(self.device)), dim=1
             )
 
         # Where prob_th is 1 there is a change


### PR DESCRIPTION
Fixing Error :
expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument tensors in method wrapper_CUDA_cat)

# Contribution in a nutshell
Fixing bug in codebase. 

# Notes for reviewing 
 When this part of code is activated, it tries to use both cuda and cpu if we have used cuda in hyperparams. This is because, this part of code has hardcoded with cpu and only runs with cpu. So this fix will take care of this issue.

