### PR TITLE
Change needed in Whisper fine-tuning recipe to accommodate transformers4.30.0

### DIFF
--- a/speechbrain/lobes/models/huggingface_whisper.py
+++ b/speechbrain/lobes/models/huggingface_whisper.py
@@ -245,7 +245,10 @@ class HuggingFaceWhisper(nn.Module):
         magnitudes = stft[..., :-1].abs() ** 2
 
         filters = self._mel_filters
-        mel_spec = filters.transpose(0, 1) @ magnitudes
+        # Fix dependency issues with transformers>=4.29 in a backward compatible way
+        if filters.shape[-1] != magnitudes.shape[-2]:
+            filters = filters.T.to(dtype=magnitudes.dtype)
+        mel_spec = filters @ magnitudes
 
         log_spec = torch.clamp(mel_spec, min=1e-10).log10()
         log_spec = torch.maximum(

--- a/speechbrain/lobes/models/huggingface_whisper.py
+++ b/speechbrain/lobes/models/huggingface_whisper.py
@@ -104,7 +104,8 @@ class HuggingFaceWhisper(nn.Module):
         self._hop_length = feature_extractor.hop_length
         self._n_samples = feature_extractor.n_samples
         self.register_buffer(
-            "_mel_filters", torch.as_tensor(feature_extractor.mel_filters)
+            "_mel_filters",
+            torch.as_tensor(feature_extractor.mel_filters, dtype=torch.float32),
         )
 
         self.model = WhisperModel.from_pretrained(source, cache_dir=save_path)
@@ -244,7 +245,7 @@ class HuggingFaceWhisper(nn.Module):
         magnitudes = stft[..., :-1].abs() ** 2
 
         filters = self._mel_filters
-        mel_spec = filters @ magnitudes
+        mel_spec = filters.transpose(0, 1) @ magnitudes
 
         log_spec = torch.clamp(mel_spec, min=1e-10).log10()
         log_spec = torch.maximum(

--- a/speechbrain/lobes/models/huggingface_whisper.py
+++ b/speechbrain/lobes/models/huggingface_whisper.py
@@ -103,10 +103,18 @@ class HuggingFaceWhisper(nn.Module):
         self._n_fft = feature_extractor.n_fft
         self._hop_length = feature_extractor.hop_length
         self._n_samples = feature_extractor.n_samples
+        # The following breaking changes were introduced in transformers>=4.29:
+        # 1) mel_filters.shape = (..., feature_extractor.feature_size) instead of (feature_extractor.feature_size, ...)
+        # 2) mel_filters.dtype = float64 instead of float32
+        # The following code fixes the issue in a backward compatible way
+        mel_filters = feature_extractor.mel_filters
+        if mel_filters.shape[0] != feature_extractor.feature_size:
+            mel_filters = mel_filters.T
+        assert mel_filters.shape[0] == feature_extractor.feature_size
         self.register_buffer(
-            "_mel_filters",
-            torch.as_tensor(feature_extractor.mel_filters, dtype=torch.float32),
+            "_mel_filters", torch.as_tensor(mel_filters, dtype=torch.float32)
         )
+        #################################################################
 
         self.model = WhisperModel.from_pretrained(source, cache_dir=save_path)
 
@@ -245,9 +253,6 @@ class HuggingFaceWhisper(nn.Module):
         magnitudes = stft[..., :-1].abs() ** 2
 
         filters = self._mel_filters
-        # Fix dependency issues with transformers>=4.29 in a backward compatible way
-        if filters.shape[-1] != magnitudes.shape[-2]:
-            filters = filters.T.to(dtype=magnitudes.dtype)
         mel_spec = filters @ magnitudes
 
         log_spec = torch.clamp(mel_spec, min=1e-10).log10()


### PR DESCRIPTION
# Change needed in Whisper fine-tuning recipe to accommodate the latest release of `transformers>4.30`
Hi SB team,
I initiate a PR where I perform minor fixes  in the main whisper fine-tuning script to accommodate changes in the latest  Pytorch release of 2.0. 
After the most recent pull of develop branch and latest torch version I have been experiencing this issue.

## To reproduce this issue (choose any dataset)

```bash
(sb_env) [root@serv-3338 transformer]# python train_with_whisper.py --debug hparams/train_hf_whisper.yaml --seed 101 --model_version tiny
speechbrain.core - Beginning experiment!
speechbrain.core - Experiment folder: results/train_whisper/101
rescuespeech_prepare - ../../csv_files/Task_ASR/train.csv already exists, skipping data preparation!
rescuespeech_prepare - ../../csv_files/Task_ASR/dev.csv already exists, skipping data preparation!
rescuespeech_prepare - ../../csv_files/Task_ASR/test.csv already exists, skipping data preparation!
speechbrain.utils.train_logger - Training on input type: : clean_wav
speechbrain.core - Info: auto_mix_prec arg from hparam file is used
speechbrain.core - Info: ckpt_interval_minutes arg from hparam file is used
speechbrain.core - Since debug mode is active, switching checkpointer output to temporary directory: /tmp/tmp9847_aub
speechbrain.core - 37.8M trainable parameters in ASR
speechbrain.utils.checkpoints - Would load a checkpoint here, but none found yet.
speechbrain.utils.epoch_loop - Going into epoch 1
  0%|                                                                                                                                                                                                               | 0/653 [00:07<?, ?it/s]
speechbrain.core - Exception:
Traceback (most recent call last):
  File "/netscratch/sagar/thesis/speechbrain/recipes/RescueSpeech/ASR/transformer/train_with_whisper.py", line 323, in <module>
    asr_brain.fit(
  File "/netscratch/sagar/thesis/speechbrain/speechbrain/core.py", line 1238, in fit
    self._fit_train(train_set=train_set, epoch=epoch, enable=enable)
  File "/netscratch/sagar/thesis/speechbrain/speechbrain/core.py", line 1091, in _fit_train
    loss = self.fit_batch(batch)
  File "/netscratch/sagar/thesis/speechbrain/speechbrain/core.py", line 959, in fit_batch
    outputs = self.compute_forward(batch, Stage.TRAIN)
  File "/netscratch/sagar/thesis/speechbrain/recipes/RescueSpeech/ASR/transformer/train_with_whisper.py", line 53, in compute_forward
    enc_out, logits, _ = self.modules.whisper(wavs, bos_tokens)
  File "/netscratch/sagar/thesis/sb_env/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/netscratch/sagar/thesis/speechbrain/speechbrain/lobes/models/huggingface_whisper.py", line 166, in forward
    out_encoder = self.forward_encoder(wav)
  File "/netscratch/sagar/thesis/speechbrain/speechbrain/lobes/models/huggingface_whisper.py", line 189, in forward_encoder
    return self._get_encoder_states(wav)
  File "/netscratch/sagar/thesis/speechbrain/speechbrain/lobes/models/huggingface_whisper.py", line 200, in _get_encoder_states
    mel = self._get_mel(wav)
  File "/netscratch/sagar/thesis/speechbrain/speechbrain/lobes/models/huggingface_whisper.py", line 217, in _get_mel
    mels = self._log_mel_spectrogram(mels)
  File "/netscratch/sagar/thesis/speechbrain/speechbrain/lobes/models/huggingface_whisper.py", line 247, in _log_mel_spectrogram
    mel_spec = filters @ magnitudes
RuntimeError: Expected size for first two dimensions of batch2 tensor to be: [2, 80] but got: [2, 201].

```
with `torch==2.0.0`. The detailed `env.log` is 
```
SpeechBrain system description
==============================
Python version:
3.10.6 (main, Jun  5 2023, 22:14:15) [GCC 7.5.0]
==============================
Installed Python packages:
appdirs==1.4.4
attrs==23.1.0
black==19.10b0
certifi==2023.5.7
cfgv==3.3.1
charset-normalizer==3.1.0
click==8.0.4
cmake==3.26.3
distlib==0.3.6
entrypoints==0.3
filelock==3.12.0
flake8==3.7.9
fsspec==2023.5.0
huggingface-hub==0.15.1
HyperPyYAML==1.2.1
identify==2.5.24
idna==3.4
Jinja2==3.1.2
joblib==1.2.0
lit==16.0.5.post0
MarkupSafe==2.1.3
mccabe==0.6.1
more-itertools==9.1.0
mpmath==1.3.0
networkx==3.1
nodeenv==1.8.0
numpy==1.24.3
nvidia-cublas-cu11==11.10.3.66
nvidia-cuda-cupti-cu11==11.7.101
nvidia-cuda-nvrtc-cu11==11.7.99
nvidia-cuda-runtime-cu11==11.7.99
nvidia-cudnn-cu11==8.5.0.96
nvidia-cufft-cu11==10.9.0.58
nvidia-curand-cu11==10.2.10.91
nvidia-cusolver-cu11==11.4.0.1
nvidia-cusparse-cu11==11.7.4.91
nvidia-nccl-cu11==2.14.3
nvidia-nvtx-cu11==11.7.91
packaging==23.1
pathspec==0.11.1
Pillow==9.5.0
platformdirs==3.5.1
pluggy==0.13.1
pre-commit==3.3.2
py==1.11.0
pycodestyle==2.5.0
pyflakes==2.1.1
pytest==5.4.1
PyYAML==6.0
regex==2023.6.3
requests==2.31.0
ruamel.yaml==0.17.28
ruamel.yaml.clib==0.2.7
scipy==1.8.1
sentencepiece==0.1.99
-e /netscratch/sagar/thesis/speechbrain
sympy==1.12
tokenizers==0.13.3
toml==0.10.2
torch==2.0.0
torchaudio==2.0.1
torchvision==0.15.1
tqdm==4.65.0
transformers==4.29.2
triton==2.0.0
typed-ast==1.5.4
typing_extensions==4.6.3
urllib3==2.0.2
virtualenv==20.23.0
wcwidth==0.2.6
yamllint==1.23.0
==============================
Could not get git revision==============================
CUDA version:
11.7
```
### NOTE
This issue does not occur (hence, not reproducible) in `torch==1.11.0+cu113`


The changes I propose have been tested with the exact version as mentioned above in the `env.log`. Following these changes, the error mentioned above vanishes.

thank you

---

Note: when merged, we desire to include your PR title in our contributions list, check out one of our past version releases
—https://github.com/speechbrain/speechbrain/releases/tag/v0.5.14

Tip: below, on the « Create Pull Request » use the drop-down to select: « Create Draft Pull Request » – your PR will be in draft mode until you declare it « Ready for review »

