### PR TITLE
Parallelize LibriSpeech data preparation

### DIFF
--- a/recipes/LibriSpeech/librispeech_prepare.py
+++ b/recipes/LibriSpeech/librispeech_prepare.py
@@ -15,15 +15,12 @@ from collections import Counter
 from dataclasses import dataclass
 import functools
 import logging
-import torchaudio
-from typing import List
-from tqdm.contrib import tzip
 from speechbrain.utils.data_utils import download_file, get_all_files
 from speechbrain.dataio.dataio import (
     load_pkl,
     save_pkl,
     merge_csvs,
-    read_audio_info
+    read_audio_info,
 )
 from speechbrain.utils.parallel import parallel_map
 
@@ -288,7 +285,7 @@ def process_line(wav_file, text_dict) -> LSRow:
         spk_id=spk_id,
         duration=duration,
         file_path=wav_file,
-        words=wrds
+        words=wrds,
     )
 
 
@@ -328,10 +325,7 @@ def create_csv(
     csv_lines = [["ID", "duration", "wav", "spk_id", "wrd"]]
 
     snt_cnt = 0
-    line_processor = functools.partial(
-        process_line,
-        text_dict=text_dict
-    )
+    line_processor = functools.partial(process_line, text_dict=text_dict)
     # Processing all the wav files in wav_lst
     for row in parallel_map(line_processor, wav_lst, chunk_size=8192):
         csv_line = [
@@ -339,7 +333,7 @@ def create_csv(
             str(row.duration),
             row.file_path,
             row.spk_id,
-            row.words
+            row.words,
         ]
 
         # Appending current file to the csv_lines list
@@ -350,7 +344,6 @@ def create_csv(
         # parallel_map guarantees element ordering so we're OK
         if snt_cnt == select_n_sentences:
             break
-
 
     # Writing the csv_lines
     with open(csv_file, mode="w") as csv_f:

--- a/recipes/LibriSpeech/librispeech_prepare.py
+++ b/recipes/LibriSpeech/librispeech_prepare.py
@@ -12,15 +12,20 @@ import os
 import csv
 import random
 from collections import Counter
+from dataclasses import dataclass
+import functools
 import logging
 import torchaudio
+from typing import List
 from tqdm.contrib import tzip
 from speechbrain.utils.data_utils import download_file, get_all_files
 from speechbrain.dataio.dataio import (
     load_pkl,
     save_pkl,
     merge_csvs,
+    read_audio_info
 )
+from speechbrain.utils.parallel import parallel_map
 
 logger = logging.getLogger(__name__)
 OPT_FILE = "opt_librispeech_prepare.pkl"
@@ -260,6 +265,33 @@ def split_lexicon(data_folder, split_ratio):
         f.writelines(test_lines)
 
 
+@dataclass
+class LSRow:
+    snt_id: str
+    spk_id: str
+    duration: float
+    file_path: str
+    words: str
+
+
+def process_line(wav_file, text_dict) -> LSRow:
+    snt_id = wav_file.split("/")[-1].replace(".flac", "")
+    spk_id = "-".join(snt_id.split("-")[0:2])
+    wrds = text_dict[snt_id]
+    wrds = " ".join(wrds.split("_"))
+
+    info = read_audio_info(wav_file)
+    duration = info.num_frames / info.sample_rate
+
+    return LSRow(
+        snt_id=snt_id,
+        spk_id=spk_id,
+        duration=duration,
+        file_path=wav_file,
+        words=wrds
+    )
+
+
 def create_csv(
     save_folder, wav_lst, text_dict, split, select_n_sentences,
 ):
@@ -296,32 +328,29 @@ def create_csv(
     csv_lines = [["ID", "duration", "wav", "spk_id", "wrd"]]
 
     snt_cnt = 0
+    line_processor = functools.partial(
+        process_line,
+        text_dict=text_dict
+    )
     # Processing all the wav files in wav_lst
-    for wav_file in tzip(wav_lst):
-        wav_file = wav_file[0]
-
-        snt_id = wav_file.split("/")[-1].replace(".flac", "")
-        spk_id = "-".join(snt_id.split("-")[0:2])
-        wrds = text_dict[snt_id]
-
-        signal, fs = torchaudio.load(wav_file)
-        signal = signal.squeeze(0)
-        duration = signal.shape[0] / SAMPLERATE
-
+    for row in parallel_map(line_processor, wav_lst, chunk_size=8192):
         csv_line = [
-            snt_id,
-            str(duration),
-            wav_file,
-            spk_id,
-            str(" ".join(wrds.split("_"))),
+            row.snt_id,
+            str(row.duration),
+            row.file_path,
+            row.spk_id,
+            row.words
         ]
 
-        #  Appending current file to the csv_lines list
+        # Appending current file to the csv_lines list
         csv_lines.append(csv_line)
+
         snt_cnt = snt_cnt + 1
 
+        # parallel_map guarantees element ordering so we're OK
         if snt_cnt == select_n_sentences:
             break
+
 
     # Writing the csv_lines
     with open(csv_file, mode="w") as csv_f:

--- a/recipes/LibriSpeech/librispeech_prepare.py
+++ b/recipes/LibriSpeech/librispeech_prepare.py
@@ -327,6 +327,8 @@ def create_csv(
     snt_cnt = 0
     line_processor = functools.partial(process_line, text_dict=text_dict)
     # Processing all the wav files in wav_lst
+    # FLAC metadata reading is already fast, so we set a high chunk size
+    # to limit main thread CPU bottlenecks
     for row in parallel_map(line_processor, wav_lst, chunk_size=8192):
         csv_line = [
             row.snt_id,


### PR DESCRIPTION
# Contribution in a nutshell

Nyoom:

```
librispeech_prepare - Data_preparation...
librispeech_prepare - Creating csv lists in  results/CRDNN_BPE_960h_LM/2602/train-clean-100.csv...
100%|██████████| 28539/28539 [00:01<00:00, 19374.00it/s]
librispeech_prepare - Creating csv lists in  results/CRDNN_BPE_960h_LM/2602/train-clean-360.csv...
100%|██████████| 104014/104014 [00:03<00:00, 30984.93it/s]
librispeech_prepare - Creating csv lists in  results/CRDNN_BPE_960h_LM/2602/train-other-500.csv...
100%|██████████| 148688/148688 [00:05<00:00, 29710.59it/s]
librispeech_prepare - Creating csv lists in  results/CRDNN_BPE_960h_LM/2602/dev-clean.csv...
100%|██████████| 2703/2703 [00:00<00:00, 2764.83it/s]
librispeech_prepare - Creating csv lists in  results/CRDNN_BPE_960h_LM/2602/test-clean.csv...
100%|██████████| 2620/2620 [00:00<00:00, 2676.63it/s]
librispeech_prepare - Creating csv lists in  results/CRDNN_BPE_960h_LM/2602/test-other.csv...
100%|██████████| 2939/2939 [00:01<00:00, 2937.20it/s]
speechbrain.dataio.dataio - results/CRDNN_BPE_960h_LM/2602/train.csv is created.
```

Those are the results of data preparation where the data is *local* to the compute node, with 24 threads allocated (but realistically, it doesn't manage to saturate them, because the steps are way fast enough).

Note that the progress bar doesn't include some of the steps involved, most notably crawling the files, which can be _slow_ on NFS. Still, this is a major improvement in my testing.

See commit message for a couple more details.

# Scope
* [x] Parallelize LibriSpeech CSV building
* [x] Use `torchaudio.load` (through SB's `read_audio_metadata`) to greatly speed up the processing step

# Notes for reviewing (optional)

The `diff` between the prepared `train.csv` files between this PR and without the PR is identical on my system.

# Pre-review
* [x] create a fresh testing environment (install SpeechBrain from cloned repo branch of this PR)
* [x] use CI locally: `pre-commit run -a` to check linters; run `pytest tests/consistency`