### PR TITLE
Update example_asr_ctc_experiment_quaternion_net.py

### DIFF
--- a/tests/integration/ASR_CTC/example_asr_ctc_experiment_quaternion_net.py
+++ b/tests/integration/ASR_CTC/example_asr_ctc_experiment_quaternion_net.py
@@ -139,7 +139,7 @@ def main(device="cpu"):
     ctc_brain.evaluate(valid_data)
 
     # Check if model overfits for integration test
-    assert ctc_brain.train_loss < 1.1
+    assert ctc_brain.train_loss < 1.0
 
 
 if __name__ == "__main__":

--- a/tests/integration/ASR_CTC/example_asr_ctc_experiment_quaternion_net.py
+++ b/tests/integration/ASR_CTC/example_asr_ctc_experiment_quaternion_net.py
@@ -139,7 +139,7 @@ def main(device="cpu"):
     ctc_brain.evaluate(valid_data)
 
     # Check if model overfits for integration test
-    assert ctc_brain.train_loss < 1.0
+    assert ctc_brain.train_loss < 1.1
 
 
 if __name__ == "__main__":

--- a/tests/integration/ASR_CTC/hyperparams_quaternion_net.yaml
+++ b/tests/integration/ASR_CTC/hyperparams_quaternion_net.yaml
@@ -4,7 +4,7 @@ seed: 1234
 __set_seed: !apply:torch.manual_seed [!ref <seed>]
 
 # Training params
-N_epochs: 25
+N_epochs: 30
 lr: 0.002
 dataloader_options:
     batch_size: 1


### PR DESCRIPTION
Many of our commits/pr are failing because of one test `example_asr_ctc_eperiment_quaternion_net.py` (see: https://github.com/speechbrain/speechbrain/actions/runs/5333670949/jobs/9669427038 & https://github.com/speechbrain/speechbrain/actions/runs/5313378966/jobs/9619194045 for instance ; thanks @TParcollet 👁️👁️). 

I tried to run the test locally on two different machines and got the following logs for the epoch 24:
Machine A (v100s)
> Epoch 24 complete
Train loss: 0.94
Stage.VALID loss: 6.10
Stage.VALID PER: 85.45
100%|████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 23.32it/s]
Stage.TEST loss: 6.10
Stage.TEST PER: 85.45

Machine B (a100)
> Epoch 24 complete
Train loss: 1.29
Stage.VALID loss: 6.80
Stage.VALID PER: 87.27
100%|████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 32.51it/s]
Stage.TEST loss: 6.80
Stage.TEST PER: 87.27
Traceback (most recent call last):
  File "/users/amoumen/machine_learning/pr/fix-test-suits/speechbrain/tests/integration/ASR_CTC/example_asr_ctc_experiment_quaternion_net.py", line 146, in <module>
    main()
  File "/users/amoumen/machine_learning/pr/fix-test-suits/speechbrain/tests/integration/ASR_CTC/example_asr_ctc_experiment_quaternion_net.py", line 142, in main
    assert ctc_brain.train_loss < 1.0
AssertionError

Basically, same code and seeds, with two different machines leads to different results. 

I propose to increase the number of epochs to tackle down this issue. I tried to increase it from `25` to `30` on the machine B and got a loss of 0.61 which is indeed effective against this issue. Idk if it will generalise for every machines but we can try to increase the number of epochs or the loss constraint directly latter on.

Logs:
> Epoch 29 complete
Train loss: 0.61
Stage.VALID loss: 6.44
Stage.VALID PER: 96.36
100%|████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 32.11it/s]
Stage.TEST loss: 6.44
Stage.TEST PER: 96.36