### PR TITLE
Updating early stopping for more intuitive use

### DIFF
--- a/recipes/LibriSpeech/G2P/train.py
+++ b/recipes/LibriSpeech/G2P/train.py
@@ -533,10 +533,7 @@ class G2PBrain(sb.Brain):
                 if self.hparams.enable_metrics:
                     self._write_reports(epoch, final=False)
 
-            if self.epoch_counter.should_stop(
-                current=epoch, current_metric=per,
-            ):
-                self.epoch_counter.current = self.epoch_counter.limit
+            self.epoch_counter.update_metric(per)
 
         if stage == sb.Stage.TEST:
             test_stats = {"loss": stage_loss}

--- a/speechbrain/utils/epoch_loop.py
+++ b/speechbrain/utils/epoch_loop.py
@@ -91,11 +91,19 @@ class EpochCounterWithStopper(EpochCounter):
     >>> epoch_counter = EpochCounterWithStopper(limit, limit_to_stop, limit_warmup, direction)
     >>> for epoch in epoch_counter:
     ...     # Run training...
-    ...     # Track a validation metric,
+    ...     # Track a validation metric, (insert calculation here)
     ...     current_valid_metric = 0
-    ...     # get the current valid metric (get current_valid_metric)
-    ...     if epoch_counter.should_stop(current_metric=current_valid_metric):
-    ...         epoch_counter.current = epoch_counter.limit  # skipping unpromising epochs
+    ...     # Update epoch counter so that we stop at the appropriate time
+    ...     epoch_counter.update_metric(current_valid_metric)
+    ...     print(epoch)
+    1
+    2
+    3
+    4
+    5
+    6
+    7
+    8
     """
 
     def __init__(self, limit, limit_to_stop, limit_warmup, direction):

--- a/speechbrain/utils/epoch_loop.py
+++ b/speechbrain/utils/epoch_loop.py
@@ -94,8 +94,7 @@ class EpochCounterWithStopper(EpochCounter):
     ...     # Track a validation metric,
     ...     current_valid_metric = 0
     ...     # get the current valid metric (get current_valid_metric)
-    ...     if epoch_counter.should_stop(current=epoch,
-    ...                                  current_metric=current_valid_metric,):
+    ...     if epoch_counter.should_stop(current_metric=current_valid_metric):
     ...         epoch_counter.current = epoch_counter.limit  # skipping unpromising epochs
     """
 
@@ -104,6 +103,7 @@ class EpochCounterWithStopper(EpochCounter):
         self.limit_to_stop = limit_to_stop
         self.limit_warmup = limit_warmup
         self.direction = direction
+        self.should_stop = False
 
         self.best_limit = 0
         self.min_delta = 1e-6
@@ -113,21 +113,36 @@ class EpochCounterWithStopper(EpochCounter):
         if self.limit_warmup < 0:
             raise ValueError("Stopper 'limit_warmup' must be >= 0")
         if self.direction == "min":
-            self.th, self.sign = float("inf"), 1
+            self.best_score, self.sign = float("inf"), 1
         elif self.direction == "max":
-            self.th, self.sign = -float("inf"), -1
+            self.best_score, self.sign = -float("inf"), -1
         else:
             raise ValueError("Stopper 'direction' must be 'min' or 'max'")
 
-    def should_stop(self, current, current_metric):
-        """Returns True is training should stop (based on the performance
-        metrics)."""
-        should_stop = False
-        if current > self.limit_warmup:
+    def __next__(self):
+        """Stop iteration if we've reached the condition."""
+        if self.should_stop:
+            raise StopIteration
+        else:
+            return super().__next__()
+
+    def update_metric(self, current_metric):
+        """Update the state to reflect most recent value of the relevant metric.
+
+        NOTE: Should be called only once per validation loop.
+        
+        Arguments
+        ---------
+        current_metric : float
+            The metric used to make a stopping decision.
+        """
+        if self.current > self.limit_warmup:
             if self.sign * current_metric < self.sign * (
-                (1 - self.min_delta) * self.th
+                (1 - self.min_delta) * self.best_score
             ):
-                self.best_limit = current
-                self.th = current_metric
-            should_stop = (current - self.best_limit) >= self.limit_to_stop
-        return should_stop
+                self.best_limit = self.current
+                self.best_score = current_metric
+            self.should_stop = (self.current - self.best_limit) >= self.limit_to_stop
+            if self.should_stop:
+                logger.info(f"{self.current - self.best_limit} epochs without improvement.")
+                logger.info(f"Patience of {self.limit_to_stop} is exhausted, stopping.")

--- a/speechbrain/utils/epoch_loop.py
+++ b/speechbrain/utils/epoch_loop.py
@@ -138,7 +138,7 @@ class EpochCounterWithStopper(EpochCounter):
         """Update the state to reflect most recent value of the relevant metric.
 
         NOTE: Should be called only once per validation loop.
-        
+
         Arguments
         ---------
         current_metric : float
@@ -150,7 +150,11 @@ class EpochCounterWithStopper(EpochCounter):
             ):
                 self.best_limit = self.current
                 self.best_score = current_metric
-            self.should_stop = (self.current - self.best_limit) >= self.limit_to_stop
+
+            epochs_without_improvement = self.current - self.best_limit
+            self.should_stop = epochs_without_improvement >= self.limit_to_stop
             if self.should_stop:
-                logger.info(f"{self.current - self.best_limit} epochs without improvement.")
-                logger.info(f"Patience of {self.limit_to_stop} is exhausted, stopping.")
+                logger.info(
+                    f"{epochs_without_improvement} epochs without improvement.\n"
+                    f"Patience of {self.limit_to_stop} is exhausted, stopping."
+                )


### PR DESCRIPTION
# Contribution in a nutshell
This addresses issue #1914 . Early stopping was already available with `EpochCounterWithStopper` but the use was quite unintuitive. I've updated to be more intuitive and updated the single recipe that used it.