### PR TITLE
Add implementation of "on_stage_end_on_main"

### DIFF
--- a/recipes/LibriSpeech/ASR/transformer/hparams/train_hf_whisper.yaml
+++ b/recipes/LibriSpeech/ASR/transformer/hparams/train_hf_whisper.yaml
@@ -23,8 +23,9 @@ normalized_transcripts: True
 test_only: False # Set it to True if you only want to  do the evaluation
 
 # Data files
-data_folder: !PLACEHOLDER # e,g./path/to/LibriSpeech
-train_splits: ["train-clean-100", "train-clean-360", "train-other-500"]
+data_folder: "/Users/N752624/Documents/Repositories/LibriSpeech" # !PLACEHOLDER # e,g./path/to/LibriSpeech
+#train_splits: ["train-clean-100", "train-clean-360", "train-other-500"]
+train_splits: ["train-clean-100"]
 dev_splits: ["dev-clean"]
 test_splits: ["test-clean", "test-other"]
 skip_prep: False

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -1422,7 +1422,7 @@ class Brain:
                 self.on_stage_end_on_main,
                 args=[Stage.TEST, avg_test_loss, None],
             )
-            self.on_stage_end(Stage.TEST, avg_test_loss)
+            self.on_stage_end(Stage.TEST, avg_test_loss, None)
 
         self.step = 0
         return avg_test_loss


### PR DESCRIPTION
# Contribution in a nutshell
There's a number of cases where one might want to run code in `on_stage_end(stage.VALID)` on the non-main process, where currently it only runs on main. A few examples:

* #2051 -- need this to synchronize early stopping across processes
* FSDP -- need this to synchronize the shards present on different processes in order to save a model
* For distributed validation computation for large validation sets

# Notes for reviewing
As currently written, this would require a small change in most recipes to ensure continued compatibility with DDP (they would continue to work as-is when single-threaded). The required change is to convert `on_stage_end` to `on_stage_end_on_main`, and if there's code for the train stage that would have to be moved to a new `on_stage_end` function. Reviewers should comment on if these changes are worth the effort.