### PR TITLE
Orion: Fix the trial_id issue in the tutorial

### DIFF
--- a/templates/hyperparameter_optimization_speaker_id/train.py
+++ b/templates/hyperparameter_optimization_speaker_id/train.py
@@ -294,7 +294,9 @@ if __name__ == "__main__":
     with hp.hyperparameter_optimization(objective_key="error") as hp_ctx:
 
         # Reading command line arguments
-        hparams_file, run_opts, overrides = hp_ctx.parse_arguments(sys.argv[1:])
+        hparams_file, run_opts, overrides = hp_ctx.parse_arguments(
+            sys.argv[1:], pass_trial_id=False
+        )
 
         # Initialize ddp (useful only for multi-GPU DDP training).
         sb.utils.distributed.ddp_init_group(run_opts)


### PR DESCRIPTION
# Contribution in a nutshell
Hey, this could help our community 🌱

# Scope
* [ ] Fix the Orion tutorial

# Notes for reviewing (optional)
This change has these implication which might need attention over here; —how should we tackle this?

# Pre-review
* [x] (if applicable) add an `extra_requirements.txt` file
  * Not applicable 
* [x] (if applicable) add database preparation scripts & use symlinks for nested folders (to the level of task READMEs)
  * Not applicable 
* [x] (if applicable) add a recipe test entry in the depending CSV file under: tests/recipes
  * Not applicable 
* [x] create a fresh testing environment (install SpeechBrain from cloned repo branch of this PR)
* [x] (if applicable) run a recipe test for each yaml/your recipe dataset
* [x] check function comments: are there docstrings w/ arguments & returns? If you're not the verbose type, put a comment every three lines of code (better: every line)
* [x] use CI locally: `pre-commit run -a` to check linters; run `pytest tests/consistency`
* [ ] (optional) run `tests/.run-doctests.sh` & `tests/.run-unittests.sh`
* [ ] exhausted patience before clicking « Ready for review » in the merge box 🍄

---

Note: when merged, we desire to include your PR title in our contributions list, check out one of our past version releases
—https://github.com/speechbrain/speechbrain/releases/tag/v0.5.14

Tip: below, on the « Create Pull Request » use the drop-down to select: « Create Draft Pull Request » – your PR will be in draft mode until you declare it « Ready for review »

