### PR TITLE
Fix multi-node DDP training

### DIFF
--- a/speechbrain/utils/distributed.py
+++ b/speechbrain/utils/distributed.py
@@ -81,16 +81,16 @@ def run_on_main(
 
 
 def if_main_process():
-    """Checks if the current process is the main process and authorized to run
-    I/O commands. In DDP mode, the main process is the one with RANK == 0.
-    In standard mode, the process will not have `RANK` Unix var and will be
+    """Checks if the current process is the main local process and authorized to run
+    I/O commands. In DDP mode, the main local process is the one with LOCAL_RANK == 0.
+    In standard mode, the process will not have `LOCAL_RANK` Unix var and will be
     authorized to run the I/O commands.
     """
-    if "RANK" in os.environ:
-        if os.environ["RANK"] == "":
+    if "LOCAL_RANK" in os.environ:
+        if os.environ["LOCAL_RANK"] == "":
             return False
         else:
-            if int(os.environ["RANK"]) == 0:
+            if int(os.environ["LOCAL_RANK"]) == 0:
                 return True
             return False
     return True


### PR DESCRIPTION
**NOTE**: requires further testing.

`speechbrain.utils.distributed.if_main_process` defines the main process as the one with global rank (`RANK` environment variable) equal to 0. This works when using DDP on a single node, because the global rank of each process is the same as the local rank within the node. However, this fails when using multiple nodes. Indeed, I/O operations like data preparation, fitting SentencePiece tokenizer, etc. are run only on the master node (where the process with global rank 0 runs), but not on the worker nodes (where processes with global rank > 0 run). Therefore intermediate artifacts such as the data manifest files and SentencePiece checkpoint are created only on the master node but not on the worker nodes, which makes the processes on worker nodes fail (e.g. `FileNotFoundError`). Checking against the local rank (`LOCAL_RANK` environment variable) should fix the issue (this way I/O operations are run on the main process of each node).
![pytorch-ddp](https://github.com/speechbrain/speechbrain/assets/34525085/47a83a5f-19ca-419c-892a-6d279aa2d331)
[https://github.com/YunchaoYang/Blogs/issues/3](https://github.com/YunchaoYang/Blogs/issues/3)