### PR TITLE
Fix `speed_perturb` Transformer recipe

### DIFF
--- a/recipes/LibriSpeech/ASR/transformer/train.py
+++ b/recipes/LibriSpeech/ASR/transformer/train.py
@@ -349,7 +349,7 @@ def dataio_prepare(hparams):
     def audio_pipeline_train(wav):
         # Speed Perturb is done here so it is multi-threaded with the
         # workers of the dataloader (faster).
-        if hasattr(hparams, "speed_perturb"):
+        if "speed_perturb" in hparams:
             sig = sb.dataio.dataio.read_audio(wav)
 
             sig = hparams["speed_perturb"](sig.unsqueeze(0)).squeeze(0)


### PR DESCRIPTION
This PR aims at fixing the `speed_perturb` that was never used. 

Indeed, using:
```python
if hasattr('speed_perturb', hparams): 
    sig = sb.dataio.dataio.read_audio(wav)

    sig = hparams["speed_perturb"](sig.unsqueeze(0)).squeeze(0)
``` 
was always returning `False` even though we had `speed_perturb` in the hparams. The reason why is that `hasattr` is checking if the dict has a specific attribute (object attribute) while we are looking for a key which is not an attribute. 

The correct way to check is to do:
```python
if "speed_perturb" in hparams:
       sig = sb.dataio.dataio.read_audio(wav)

       sig = hparams["speed_perturb"](sig.unsqueeze(0)).squeeze(0)
```