### PR TITLE
Fix issue Jit/compile with Pretrainer

### DIFF
--- a/speechbrain/pretrained/interfaces.py
+++ b/speechbrain/pretrained/interfaces.py
@@ -315,7 +315,7 @@ class Pretrained(torch.nn.Module):
         compile_module_keys = set()
         if self.compile:
             if self.compile_module_keys is None:
-                compile_module_keys = set(self.modules)
+                compile_module_keys = set(self.mods)
             else:
                 compile_module_keys = set(self.compile_module_keys)
                 logger.warning(
@@ -327,7 +327,7 @@ class Pretrained(torch.nn.Module):
         jit_module_keys = set()
         if self.jit:
             if self.jit_module_keys is None:
-                jit_module_keys = set(self.modules)
+                jit_module_keys = set(self.mods)
             else:
                 jit_module_keys = set(self.jit_module_keys)
                 logger.warning(


### PR DESCRIPTION
This PR fix an issue with jit/compile when used with a Pretrainer class. 

Indeed, in #1947, we added a small mistake which was to use `self.modules` instead of `self.mods`. 

Note: I ran a compile/jit test with the `SpeakerRecognition` class. When using `"jit": True` this is failing due to:
>   File "/users/amoumen/machine_learning/issues/2109/speechbrain/speechbrain/lobes/models/ECAPA_TDNN.py", line 487
        xl = []
        for layer in self.blocks:
            try:
            ~~~ <--- HERE
                x = layer(x, lengths=lengths)
            except TypeError:

However, the class is `torch.compile` compliant. This is a small benchmark that I ran: 
```python
from speechbrain.pretrained import SpeakerRecognition
import torch 
import time 

n_jit_iters_warmup = 10
n_jit_iters = 100
compile_flags = [False, True]

for flag in compile_flags:
    run_opt_defaults = {
        "compile": flag
    }

    model = SpeakerRecognition.from_hparams(source="speechbrain/spkrec-ecapa-voxceleb", savedir="pretrained_models/spkrec-ecapa-voxceleb", run_opts=run_opt_defaults)

    # warmup for jit 
    for _ in range(n_jit_iters_warmup):
        score, prediction = model.verify_files("speechbrain/spkrec-ecapa-voxceleb/example1.wav", "speechbrain/spkrec-ecapa-voxceleb/example1.wav") # Different Speakers

    avg_time = 0
    for _ in range(n_jit_iters):
        torch.cuda.synchronize()
        time1 = time.time()
        score, prediction = model.verify_files("speechbrain/spkrec-ecapa-voxceleb/example1.wav", "speechbrain/spkrec-ecapa-voxceleb/example1.wav") # Different Speakers
        torch.cuda.synchronize()
        time2 = time.time()
        avg_time += time2 - time1

    print(f"Using `compile = {flag}` obtaining t = {(avg_time / n_jit_iters):4f}")
``` 

And I got the following output:
> Using `compile = False` obtaining t = 0.137022
Using `compile = True` obtaining t = 0.116514

`torch.compile` demonstrate a pretty nice speedup and is easier to use than `torch.jit` which can easily fail.

The benchmark is ran using an A100 40Gb.

CC: @mravanelli 
