### PR TITLE
#992 vadget speech prob file does not respect cuda

### DIFF
--- a/speechbrain/pretrained/interfaces.py
+++ b/speechbrain/pretrained/interfaces.py
@@ -1243,7 +1243,6 @@ class VAD(Pretrained):
         super().__init__(*args, **kwargs)
         self.time_resolution = self.hparams.time_resolution
         self.sample_rate = self.hparams.sample_rate
-        self.device = self.hparams.device
 
     def get_speech_prob_file(
         self,


### PR DESCRIPTION
This PR fix #992. 

The issue was related to this line: https://github.com/speechbrain/speechbrain/blob/develop/speechbrain/pretrained/interfaces.py#L1246 basically, we were forcing our VAD model to be on `self.hparams.device` which was an issue as it was bypassing the `run_opt` potential `device` value. 

Removing this line is solving the issue. Now, passing a `run_opts` in the init of VAD is working as expect, no cuda error. 

## How to test it?
```python
from speechbrain.pretrained import VAD

run_opts = {'device': 'cuda'}

VAD = VAD.from_hparams(source="speechbrain/vad-crdnn-libriparty", savedir="pretrained_models/vad-crdnn-libriparty", run_opts=run_opts)
boundaries = VAD.get_speech_prob_file("/speechbrain/tests/samples/ASR/spk1_snt1.wav")
print(boundaries)
```

## Results
Before:
> File "/users/amoumen/.conda/envs/992/lib/python3.9/site-packages/torch/nn/functional.py", line 2515, in layer_norm
    return torch.layer_norm(input, normalized_shape, weight, bias, eps, torch.backends.cudnn.enabled)
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cpu and cuda:0! (when checking argument for argument weight in method wrapper_CUDA__native_layer_norm)

After (with the fix):
>tensor([[[0.9997],
         [0.9999],
         [0.9998],
         [0.9997],
         [0.9996],
         [0.9995],
         [0.9991],
         [0.9991],
         [0.9996],
         [0.9998],
         [0.9998],
         [0.9999],
         [1.0000],
         [1.0000],
         [1.0000],
         [1.0000],
         [1.0000],
         [1.0000],
         [1.0000],
         [1.0000],
         [0.9999],
         [0.9999],
         [0.9999],
         [1.0000],
         [1.0000],
         [1.0000],
         [0.9999],
         [0.9999],
         [0.9999],
         [0.9999],
         [0.9999],
         [0.9999],
         [0.9999],
         [0.9999],
         [1.0000],
         [1.0000],
         [0.9999],
         [0.9999],
         [0.9999],
         [0.9999],
         [0.9999],

         [0.9599],
         [0.9590],
         [0.9571],
         [0.9514],
         [0.9432],
         [0.9375],
         [0.9345],
         [0.9338],
         [0.9336],
         [0.9328],
         [0.9329],
         [0.9343],
         [0.9377],
         [0.9421],
         [0.9466],
         [0.9516],
         [0.9576],
         [0.9581],
         [0.9498],
         [0.9348],
         [0.9326],
         [0.9305],
         [0.9310],
         [0.9318],
         [0.9338],
         [0.9358],
         [0.9395],
         [0.9444],
         [0.9457],
         [0.9527],
         [0.9563],
         [0.9572],
         [0.9608],
         [0.9616],
         [0.9597],
         [0.9558],
         [0.9578],
         [0.9599],
         [0.9589],
         [0.9563],
         [0.9538],
         [0.9522],
         [0.9497],
         [0.9470],
         [0.9439],
         [0.9409],
         [0.9394],
         [0.9386],
         [0.9376],
         [0.9352],
         [0.9325],
         [0.9305],
         [0.9288],
         [0.9282],
         [0.9297],
         [0.9315],
         [0.9361],
         [0.9386],
         [0.9362],

         [0.8411],
         [0.8491],
         [0.8595],
         [0.8668],
         [0.8734],
         [0.8804],
         [0.8869],
         [0.8948],
         [0.9009],
         [0.9041],
         [0.9087],
         [0.9117],
         [0.9127],
         [0.9073],
         [0.9058],
         [0.9048],
         [0.8978],
         [0.8864],
         [0.8583],
         [0.8382],
         [0.8362],
         [0.8412],
         [0.8334],
         [0.8246],
         [0.8188],
         [0.8130],
         [0.8100],
         [0.8072],
         [0.8050],
         [0.8033],
         [0.8022],
         [0.8023],
         [0.8069],
         [0.8137],
         [0.8224],
         [0.8317],
         [0.8406],
         [0.8502],
         [0.8570],
         [0.8611],
         [0.8646],
         [0.8667],
         [0.8692],
         [0.8710],
         [0.8725],
         [0.8740],
         [0.8748],
         [0.8770],
         [0.8773],
         [0.8722],
         [0.8677],
         [0.8680],
         [0.8589],
         [0.8360],
         [0.8240],
         [0.7979],
         [0.7686],
         [0.7543],
         [0.7025]]], device='cuda:0')

## Note
It works also when setting `device` to be `cpu` or without `run_optt`.