### PR TITLE
Update the input channel dimension of MFA of ECAPA-TDNN

### DIFF
--- a/speechbrain/lobes/models/ECAPA_TDNN.py
+++ b/speechbrain/lobes/models/ECAPA_TDNN.py
@@ -448,7 +448,7 @@ class ECAPA_TDNN(torch.nn.Module):
 
         # Multi-layer feature aggregation
         self.mfa = TDNNBlock(
-            channels[-1],
+            channels[-2] * (len(channels) - 2),
             channels[-1],
             kernel_sizes[-1],
             dilations[-1],


### PR DESCRIPTION
This updated code enhances the scalability of the ECAPA-TDNN model.
The current code is designed to function with an ECAPA-TDNN configuration featuring 512 intermediate channels and 3 SE-Res2Blocks.
However, as demonstrated in https://arxiv.org/pdf/2010.11255.pdf, the ECAPA-TDNN architecture should possess the flexibility to accommodate a wider range of intermediate channels and SE-Res2Blocks.
The updated code has the capability of implementing the ECAPA-TDNN with 2048 intermediate channels and 4 SE-Res2Blocks by modifying part of the YAML file. ('channels: [512, 512, 512, 512, 1536]' -> 'channels: [2048, 2048, 2048, 2048, 2048, 1536]')
