### PR TITLE
replacements applied only on wav column

### DIFF
--- a/speechbrain/dataio/dataio.py
+++ b/speechbrain/dataio/dataio.py
@@ -143,16 +143,17 @@ def load_data_csv(csv_path, replacements={}):
             if data_id in result:
                 raise ValueError(f"Duplicate id: {data_id}")
             # Replacements:
-            for key, value in row.items():
-                try:
-                    row[key] = variable_finder.sub(
-                        lambda match: str(replacements[match[1]]), value
-                    )
-                except KeyError:
-                    raise KeyError(
-                        f"The item {value} requires replacements "
-                        "which were not supplied."
-                    )
+            try:
+                data_wav = row["wav"]
+                row["wav"] = variable_finder.sub(
+                    lambda match: str(replacements[match[1]]), data_wav
+                )
+            except KeyError:
+                raise KeyError(
+                    f"The item {data_wav} requires replacements "
+                    "which were not supplied."
+                )
+
             # Duration:
             if "duration" in row:
                 row["duration"] = float(row["duration"])


### PR DESCRIPTION
The "load_data_csv" function aims to replace all occurrences of variables (begin with the symbol $) with their corresponding values across all columns of the CSV file.

The problem is that the function can mistakenly identify a variable when it was just a word (a word that starting with $ and followed by a few characters). And these misinterpretations can frequently occur when the text undergoes transliteration.

Therefore, I propose to limit the application of this substitution exclusively to the row "wav".