### PR TITLE
[WIP] DDP recipe tests and fixes

### DIFF
--- a/recipes/SLURP/direct/hparams/train.yaml
+++ b/recipes/SLURP/direct/hparams/train.yaml
@@ -60,9 +60,7 @@ epoch_counter: !new:speechbrain.utils.epoch_loop.EpochCounter
     limit: !ref <number_of_epochs>
 
 # Models
-asr_model: !apply:speechbrain.pretrained.EncoderDecoderASR.from_hparams
-    source: speechbrain/asr-crdnn-rnnlm-librispeech
-    run_opts: {"device":"cuda:0"}
+asr_model_source: speechbrain/asr-crdnn-rnnlm-librispeech
 
 slu_enc: !new:speechbrain.nnet.containers.Sequential
     input_shape: [null, null, !ref <ASR_encoder_dim>]

--- a/recipes/SLURP/direct/train.py
+++ b/recipes/SLURP/direct/train.py
@@ -340,6 +340,14 @@ if __name__ == "__main__":
     run_on_main(hparams["pretrainer"].collect_files)
     hparams["pretrainer"].load_collected(device=run_opts["device"])
 
+    # Download pretrained ASR model
+    from speechbrain.pretrained import EncoderDecoderASR
+
+    hparams["asr_model"] = EncoderDecoderASR.from_hparams(
+        source=hparams["asr_model_source"],
+        run_opts={"device": run_opts["device"]},
+    )
+
     # Brain class initialization
     slu_brain = SLU(
         modules=hparams["modules"],

--- a/recipes/fluent-speech-commands/direct/hparams/train.yaml
+++ b/recipes/fluent-speech-commands/direct/hparams/train.yaml
@@ -56,9 +56,7 @@ epoch_counter: !new:speechbrain.utils.epoch_loop.EpochCounter
     limit: !ref <number_of_epochs>
 
 # Models
-asr_model: !apply:speechbrain.pretrained.EncoderDecoderASR.from_hparams
-    source: speechbrain/asr-crdnn-rnnlm-librispeech
-    run_opts: {"device":"cuda:0"}
+asr_model_source: speechbrain/asr-crdnn-rnnlm-librispeech
 
 slu_enc: !new:speechbrain.nnet.containers.Sequential
     input_shape: [null, null, !ref <ASR_encoder_dim>]

--- a/recipes/fluent-speech-commands/direct/train.py
+++ b/recipes/fluent-speech-commands/direct/train.py
@@ -322,6 +322,14 @@ if __name__ == "__main__":
     run_on_main(hparams["pretrainer"].collect_files)
     hparams["pretrainer"].load_collected(device=run_opts["device"])
 
+    # Download pretrained ASR model
+    from speechbrain.pretrained import EncoderDecoderASR
+
+    hparams["asr_model"] = EncoderDecoderASR.from_hparams(
+        source=hparams["asr_model_source"],
+        run_opts={"device": run_opts["device"]},
+    )
+
     # Brain class initialization
     slu_brain = SLU(
         modules=hparams["modules"],

--- a/recipes/timers-and-such/direct/hparams/train.yaml
+++ b/recipes/timers-and-such/direct/hparams/train.yaml
@@ -66,9 +66,7 @@ epoch_counter: !new:speechbrain.utils.epoch_loop.EpochCounter
     limit: !ref <number_of_epochs>
 
 # Models
-asr_model: !apply:speechbrain.pretrained.EncoderDecoderASR.from_hparams
-    source: speechbrain/asr-crdnn-rnnlm-librispeech
-    run_opts: {"device":"cuda:0"}
+asr_model_source: speechbrain/asr-crdnn-rnnlm-librispeech
 
 slu_enc: !new:speechbrain.nnet.containers.Sequential
     input_shape: [null, null, !ref <ASR_encoder_dim>]

--- a/recipes/timers-and-such/direct/train.py
+++ b/recipes/timers-and-such/direct/train.py
@@ -344,6 +344,14 @@ if __name__ == "__main__":
     run_on_main(hparams["pretrainer"].collect_files)
     hparams["pretrainer"].load_collected(device=run_opts["device"])
 
+    # Download pretrained ASR model
+    from speechbrain.pretrained import EncoderDecoderASR
+
+    hparams["asr_model"] = EncoderDecoderASR.from_hparams(
+        source=hparams["asr_model_source"],
+        run_opts={"device": run_opts["device"]},
+    )
+
     # Brain class initialization
     slu_brain = SLU(
         modules=hparams["modules"],

--- a/tests/recipes/README.md
+++ b/tests/recipes/README.md
@@ -16,6 +16,18 @@ If you like to test for all recipes belonging to one dataset:
 python -c 'from tests.utils.recipe_tests import run_recipe_tests; print("TEST FAILED!") if not(run_recipe_tests(filters_fields=["Dataset"], filters=[["CommonLanguage", "LibriSpeech"]], do_checks=False, run_opts="--device=cuda")) else print("TEST PASSED")'
 ```
 
+You can run the recipe on the CPU just by setting the run_opts properly:
+```
+python -c 'from tests.utils.recipe_tests import run_recipe_tests; print("TEST FAILED!") if not(run_recipe_tests(filters_fields=["Dataset"], filters=[["CommonLanguage", "LibriSpeech"]], do_checks=False, run_opts="--device=cpu")) else print("TEST PASSED")'
+```
+
+In some cases, you might want to test the recipe on a non-default GPU (e.g, cuda:1). Thia helps detecting issues in recipes where the device was hard-coded. You can do that simply with:
+
+```
+python -c 'from tests.utils.recipe_tests import run_recipe_tests; print("TEST FAILED!") if not(run_recipe_tests(filters_fields=["Dataset"], filters=[["CommonLanguage", "LibriSpeech"]], do_checks=False, run_opts="--device=cuda:0")) else print("TEST PASSED")'
+```
+
+
 To target a specific recipe (here by its hparam yaml):
 ```
 python -c 'from tests.utils.recipe_tests import run_recipe_tests; print("TEST FAILED!") if not(run_recipe_tests(filters_fields=["Hparam_file"], filters=[["recipes/TIMIT/ASR/transducer/hparams/train_wav2vec.yaml"]], do_checks=False, run_opts="--device=cuda")) else print("TEST PASSED")'


### PR DESCRIPTION
Ideally, we want our recipes to work with different devices. Ideally, they should work with:

- [ ] Single GPU (cuda:0)
- [ ] Single GPU (cuda:1) => This is to test if there are some recipes with cuda:0 hard-coded
- [ ] Single CPU
- [ ] Multiple GPUs on the same node
- [ ] Multiple CPUs on the same node
- [ ] Multiple GPUs on the different nodes
- [ ] Multiple CPUs on the different nodes

The goal of this PR is allow recipe tests to run on multiple GPUs and fix the issues that cause tests to fail.