### PR TITLE
[WIP] Fix recipe tests on CPU

### DIFF
--- a/recipes/Aishell1Mix/separation/train.py
+++ b/recipes/Aishell1Mix/separation/train.py
@@ -120,7 +120,7 @@ class Separation(sb.Brain):
         if self.hparams.num_spks == 3:
             targets.append(batch.s3_sig)
 
-        if self.auto_mix_prec:
+        if self.auto_mix_prec and "cuda" in self.device:
             with autocast():
                 predictions, targets = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN, noise
@@ -554,7 +554,6 @@ if __name__ == "__main__":
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
     with open(hparams_file) as fin:
         hparams = load_hyperpyyaml(fin, overrides)
-    run_opts["auto_mix_prec"] = hparams["auto_mix_prec"]
 
     # Initialize ddp (useful only for multi-GPU DDP training)
     sb.utils.distributed.ddp_init_group(run_opts)

--- a/recipes/BinauralWSJ0Mix/separation/train.py
+++ b/recipes/BinauralWSJ0Mix/separation/train.py
@@ -208,7 +208,7 @@ class Separation(sb.Brain):
         if "noise" in self.hparams.experiment_name:
             noise = batch.noise_sig[0]
 
-        if self.auto_mix_prec:
+        if self.auto_mix_prec and "cuda" in self.device:
             with autocast():
                 predictions, targets = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN, noise

--- a/recipes/CommonVoice/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/CommonVoice/ASR/CTC/train_with_wav2vec.py
@@ -92,7 +92,7 @@ class ASR(sb.core.Brain):
         # Managing automatic mixed precision
         # TOFIX: CTC fine-tuning currently is unstable
         # This is certainly due to CTC being done in fp16 instead of fp32
-        if self.auto_mix_prec:
+        if self.auto_mix_prec and "cuda" in self.device:
             with torch.cuda.amp.autocast():
                 with self.no_sync():
                     outputs = self.compute_forward(batch, sb.Stage.TRAIN)

--- a/recipes/CommonVoice/ASR/seq2seq/train_with_wav2vec.py
+++ b/recipes/CommonVoice/ASR/seq2seq/train_with_wav2vec.py
@@ -126,7 +126,7 @@ class ASR(sb.core.Brain):
 
     def fit_batch(self, batch):
         """Train the parameters given a single batch in input"""
-        if self.auto_mix_prec:
+        if self.auto_mix_prec and "cuda" in self.device:
 
             if not self.hparams.wav2vec2.freeze:
                 self.wav2vec_optimizer.zero_grad()

--- a/recipes/CommonVoice/self-supervised-learning/wav2vec2/train_hf_wav2vec2.py
+++ b/recipes/CommonVoice/self-supervised-learning/wav2vec2/train_hf_wav2vec2.py
@@ -84,7 +84,7 @@ class W2VBrain(sb.core.Brain):
         """Train the parameters given a single batch in input"""
 
         # Here we manage mixed precision
-        if self.auto_mix_prec:
+        if self.auto_mix_prec and "cuda" in self.device:
             with torch.cuda.amp.autocast():
                 predictions = self.compute_forward(batch, sb.Stage.TRAIN)
                 loss = self.compute_objectives(

--- a/recipes/DVoice/ASR/CTC/train_with_wav2vec2.py
+++ b/recipes/DVoice/ASR/CTC/train_with_wav2vec2.py
@@ -92,7 +92,7 @@ class ASR(sb.core.Brain):
         # Managing automatic mixed precision
         # TOFIX: CTC fine-tuning currently is unstable
         # This is certainly due to CTC being done in fp16 instead of fp32
-        if self.auto_mix_prec:
+        if self.auto_mix_prec and "cuda" in self.device:
             with torch.cuda.amp.autocast():
                 with self.no_sync():
                     outputs = self.compute_forward(batch, sb.Stage.TRAIN)

--- a/recipes/ESC50/interpret/hparams/l2i_cnn14.yaml
+++ b/recipes/ESC50/interpret/hparams/l2i_cnn14.yaml
@@ -47,8 +47,6 @@ sample_rate: 44100
 interpret_period: 1
 relevance_th: 0.2
 
-device: "cuda"
-
 # Feature parameters
 n_mels: 80
 left_frames: 0

--- a/recipes/ESC50/interpret/hparams/l2i_conv2dclassifier.yaml
+++ b/recipes/ESC50/interpret/hparams/l2i_conv2dclassifier.yaml
@@ -47,8 +47,6 @@ sample_rate: 16000
 interpret_period: 1
 relevance_th: 0.2
 
-device: "cuda"
-
 # Feature parameters
 n_mels: 80
 

--- a/recipes/ESC50/interpret/hparams/nmf.yaml
+++ b/recipes/ESC50/interpret/hparams/nmf.yaml
@@ -46,8 +46,6 @@ batch_size: 2
 lr: 0.0002
 sample_rate: 44100
 
-device: "cpu"
-
 shuffle: True
 dataloader_options:
     batch_size: !ref <batch_size>

--- a/recipes/ESC50/interpret/hparams/piq.yaml
+++ b/recipes/ESC50/interpret/hparams/piq.yaml
@@ -52,8 +52,6 @@ rec_loss_coef: 1
 use_mask_output: True
 mask_th: 0.35
 
-device: "cuda"
-
 # Feature parameters
 n_mels: 80
 

--- a/recipes/ESC50/interpret/train_l2i.py
+++ b/recipes/ESC50/interpret/train_l2i.py
@@ -654,9 +654,9 @@ if __name__ == "__main__":
         hparams["pretrained_esc50"].load_collected()
 
     # transfer the frozen parts to the model to the device
-    hparams["embedding_model"].to(hparams["device"])
-    hparams["classifier"].to(hparams["device"])
-    hparams["nmf_decoder"].to(hparams["device"])
+    hparams["embedding_model"].to(run_opts["device"])
+    hparams["classifier"].to(run_opts["device"])
+    hparams["nmf_decoder"].to(run_opts["device"])
     hparams["embedding_model"].eval()
 
     Interpreter_brain.fit(

--- a/recipes/ESC50/interpret/train_piq.py
+++ b/recipes/ESC50/interpret/train_piq.py
@@ -734,8 +734,8 @@ if __name__ == "__main__":
         run_on_main(hparams["pretrained_esc50"].collect_files)
         hparams["pretrained_esc50"].load_collected()
 
-    hparams["embedding_model"].to(hparams["device"])
-    hparams["classifier"].to(hparams["device"])
+    hparams["embedding_model"].to(run_opts["device"])
+    hparams["classifier"].to(run_opts["device"])
     hparams["embedding_model"].eval()
 
     Interpreter_brain.fit(

--- a/recipes/KsponSpeech/ASR/transformer/train.py
+++ b/recipes/KsponSpeech/ASR/transformer/train.py
@@ -159,7 +159,7 @@ class ASR(sb.core.Brain):
 
         should_step = self.step % self.grad_accumulation_factor == 0
         # Managing automatic mixed precision
-        if self.auto_mix_prec:
+        if self.auto_mix_prec and "cuda" in self.device:
             self.optimizer.zero_grad()
             with torch.cuda.amp.autocast():
                 outputs = self.compute_forward(batch, sb.Stage.TRAIN)

--- a/recipes/LibriMix/separation/train.py
+++ b/recipes/LibriMix/separation/train.py
@@ -122,7 +122,7 @@ class Separation(sb.Brain):
         if self.hparams.num_spks == 3:
             targets.append(batch.s3_sig)
 
-        if self.auto_mix_prec:
+        if self.auto_mix_prec and "cuda" in self.device:
             with autocast():
                 predictions, targets = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN, noise

--- a/recipes/LibriSpeech/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/LibriSpeech/ASR/CTC/train_with_wav2vec.py
@@ -127,7 +127,7 @@ class ASR(sb.Brain):
         should_step = self.step % self.grad_accumulation_factor == 0
 
         # Managing automatic mixed precision
-        if self.auto_mix_prec:
+        if self.auto_mix_prec and "cuda" in self.device:
             self.wav2vec_optimizer.zero_grad()
             self.model_optimizer.zero_grad()
             with torch.cuda.amp.autocast():

--- a/recipes/LibriSpeech/ASR/CTC/train_with_whisper.py
+++ b/recipes/LibriSpeech/ASR/CTC/train_with_whisper.py
@@ -94,7 +94,7 @@ class ASR(sb.Brain):
         should_step = self.step % self.grad_accumulation_factor == 0
 
         # Managing automatic mixed precision
-        if self.auto_mix_prec:
+        if self.auto_mix_prec and "cuda" in self.device:
             self.whisper_optimizer.zero_grad()
             self.model_optimizer.zero_grad()
             with torch.cuda.amp.autocast():

--- a/recipes/LibriSpeech/ASR/transducer/train.py
+++ b/recipes/LibriSpeech/ASR/transducer/train.py
@@ -194,7 +194,7 @@ class ASR(sb.Brain):
 
         with self.no_sync(not should_step):
             # Managing automatic mixed precision
-            if self.auto_mix_prec:
+            if self.auto_mix_prec and "cuda" in self.device:
                 with torch.autocast(torch.device(self.device).type):
                     outputs = self.compute_forward(batch, sb.Stage.TRAIN)
 

--- a/recipes/LibriSpeech/ASR/transformer/train.py
+++ b/recipes/LibriSpeech/ASR/transformer/train.py
@@ -239,7 +239,7 @@ class ASR(sb.core.Brain):
 
         should_step = self.step % self.grad_accumulation_factor == 0
         # Managing automatic mixed precision
-        if self.auto_mix_prec:
+        if self.auto_mix_prec and "cuda" in self.device:
             with torch.autocast(torch.device(self.device).type):
                 outputs = self.compute_forward(batch, sb.Stage.TRAIN)
 

--- a/recipes/LibriSpeech/self-supervised-learning/wav2vec2/train_sb_wav2vec2.py
+++ b/recipes/LibriSpeech/self-supervised-learning/wav2vec2/train_sb_wav2vec2.py
@@ -122,7 +122,7 @@ class W2V2Brain(sb.core.Brain):
     def fit_batch(self, batch):
         should_step = self.step % self.grad_accumulation_factor == 0
         # Managing automatic mixed precision
-        if self.auto_mix_prec:
+        if self.auto_mix_prec and "cuda" in self.device:
             with self.no_sync(not should_step):
                 with torch.cuda.amp.autocast():
                     outputs = self.compute_forward(batch, Stage.TRAIN)

--- a/recipes/REAL-M/sisnr-estimation/train.py
+++ b/recipes/REAL-M/sisnr-estimation/train.py
@@ -787,7 +787,7 @@ if __name__ == "__main__":
 
         separator_loaded = separator.from_hparams(
             source=separator_model,
-            run_opts={"device": "cuda"},
+            run_opts={"device": run_opts["device"]},
             savedir=separator_model,
         )
 

--- a/recipes/REAL-M/sisnr-estimation/train.py
+++ b/recipes/REAL-M/sisnr-estimation/train.py
@@ -174,7 +174,7 @@ class Separation(sb.Brain):
         if self.hparams.num_spks == 3:
             targets.append(batch.s3_sig)
 
-        if self.auto_mix_prec:
+        if self.auto_mix_prec and "cuda" in self.device:
             with autocast():
                 predictions, snrhat, snr, snr_compressed = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN, noise

--- a/recipes/Switchboard/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/Switchboard/ASR/CTC/train_with_wav2vec.py
@@ -119,7 +119,7 @@ class ASR(sb.core.Brain):
 
     def fit_batch(self, batch):
         """Train the parameters given a single batch in input"""
-        if self.auto_mix_prec:
+        if self.auto_mix_prec and "cuda" in self.device:
 
             if not self.hparams.wav2vec2.freeze:
                 self.wav2vec_optimizer.zero_grad()

--- a/recipes/Switchboard/ASR/transformer/train.py
+++ b/recipes/Switchboard/ASR/transformer/train.py
@@ -187,7 +187,7 @@ class ASR(sb.core.Brain):
 
         should_step = self.step % self.grad_accumulation_factor == 0
         # Managing automatic mixed precision
-        if self.auto_mix_prec:
+        if self.auto_mix_prec and "cuda" in self.device:
             self.optimizer.zero_grad()
             with torch.cuda.amp.autocast():
                 outputs = self.compute_forward(batch, sb.Stage.TRAIN)

--- a/recipes/TIMIT/ASR/seq2seq/train_with_wav2vec2.py
+++ b/recipes/TIMIT/ASR/seq2seq/train_with_wav2vec2.py
@@ -178,7 +178,7 @@ class ASR(sb.Brain):
         detached loss
         """
         # Managing automatic mixed precision
-        if self.auto_mix_prec:
+        if self.auto_mix_prec and "cuda" in self.device:
 
             self.wav2vec_optimizer.zero_grad()
             self.adam_optimizer.zero_grad()

--- a/recipes/TIMIT/ASR/transducer/train_wav2vec.py
+++ b/recipes/TIMIT/ASR/transducer/train_wav2vec.py
@@ -168,7 +168,7 @@ class ASR_Brain(sb.Brain):
         detached loss
         """
         # Managing automatic mixed precision
-        if self.auto_mix_prec:
+        if self.auto_mix_prec and "cuda" in self.device:
 
             self.wav2vec_optimizer.zero_grad()
             self.adam_optimizer.zero_grad()

--- a/recipes/WHAMandWHAMR/enhancement/train.py
+++ b/recipes/WHAMandWHAMR/enhancement/train.py
@@ -155,7 +155,7 @@ class Separation(sb.Brain):
         targets = [batch.s1_sig, batch.s2_sig]
         noise = batch.noise_sig[0]
 
-        if self.auto_mix_prec:
+        if self.auto_mix_prec and "cuda" in self.device:
             with autocast():
                 predictions, targets = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN, noise

--- a/recipes/WHAMandWHAMR/separation/train.py
+++ b/recipes/WHAMandWHAMR/separation/train.py
@@ -118,7 +118,7 @@ class Separation(sb.Brain):
         targets = [batch.s1_sig, batch.s2_sig]
         noise = batch.noise_sig[0]
 
-        if self.auto_mix_prec:
+        if self.auto_mix_prec and "cuda" in self.device:
             with autocast():
                 predictions, targets = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN, noise

--- a/recipes/WSJ0Mix/separation/train.py
+++ b/recipes/WSJ0Mix/separation/train.py
@@ -104,7 +104,7 @@ class Separation(sb.Brain):
         if self.hparams.num_spks == 3:
             targets.append(batch.s3_sig)
 
-        if self.auto_mix_prec:
+        if self.auto_mix_prec and "cuda" in self.device:
             with autocast():
                 predictions, targets = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN


### PR DESCRIPTION
In this PR. I've addressed an issue where certain recipe tests were failing when executed on CPU. The cause of this problem was that automatic mixed precision is designed to work exclusively on CUDA devices. To resolve this, I made the following modifications:

1. core.py: I added an additional check within the core.py file to ensure that automatic mixed precision only runs on CUDA devices, thus preventing the failures on CPU.

2. Recipe Modifications: I also had to make adjustments to all the recipes that were previously overriding the fit_batch function. Ideally, we aim to reduce the need for such overrides, and I believe that after merging pull request #2010, these modifications may no longer be necessary.

@Adel-Moumen, I recommend considering the changes made in this pull request, as they are related to the improvements proposed in pull request #2010. 