### PR TITLE
Fix issues unstable

### DIFF
--- a/recipes/LibriSpeech/ASR/seq2seq/hparams/train_BPE_5000.yaml
+++ b/recipes/LibriSpeech/ASR/seq2seq/hparams/train_BPE_5000.yaml
@@ -80,7 +80,7 @@ valid_dataloader_opts:
    batch_size: !ref <batch_size>
 
 test_dataloader_opts:
-   batch_size: !ref <batch_size>
+   batch_size: 1
 
 # Model parameters
 activation: !name:torch.nn.LeakyReLU
@@ -242,7 +242,12 @@ coverage_scorer: !new:speechbrain.decoders.scorer.CoverageScorer
 transformerlm_scorer: !new:speechbrain.decoders.scorer.TransformerLMScorer
    language_model: !ref <lm_model>
 
-scorer: !new:speechbrain.decoders.scorer.ScorerBuilder
+valid_scorer: !new:speechbrain.decoders.scorer.ScorerBuilder
+   full_scorers: [!ref <coverage_scorer>]
+   weights:
+      coverage: !ref <coverage_penalty>
+
+test_scorer: !new:speechbrain.decoders.scorer.ScorerBuilder
    full_scorers: [
       !ref <transformerlm_scorer>,
       !ref <coverage_scorer>]
@@ -266,6 +271,7 @@ valid_search: !new:speechbrain.decoders.S2SRNNBeamSearcher
    using_max_attn_shift: !ref <using_max_attn_shift>
    max_attn_shift: !ref <max_attn_shift>
    temperature: !ref <temperature>
+   scorer: !ref <valid_scorer>
 
 test_search: !new:speechbrain.decoders.S2SRNNBeamSearcher
    embedding: !ref <emb>
@@ -281,7 +287,7 @@ test_search: !new:speechbrain.decoders.S2SRNNBeamSearcher
    max_attn_shift: !ref <max_attn_shift>
    using_eos_threshold: !ref <using_eos_threshold>
    temperature: !ref <temperature>
-   scorer: !ref <scorer>
+   scorer: !ref <test_scorer>
 
 lr_annealing: !new:speechbrain.nnet.schedulers.NewBobScheduler
    initial_value: !ref <lr>

--- a/recipes/LibriSpeech/ASR/transformer/hparams/transformer.yaml
+++ b/recipes/LibriSpeech/ASR/transformer/hparams/transformer.yaml
@@ -219,8 +219,13 @@ transformerlm_scorer: !new:speechbrain.decoders.scorer.TransformerLMScorer
     language_model: !ref <lm_model>
     temperature: 1.15
 
-scorer: !new:speechbrain.decoders.scorer.ScorerBuilder
-    full_scorers: [!ref <transformerlm_scorer>, !ref <ctc_scorer>]
+valid_scorer: !new:speechbrain.decoders.scorer.ScorerBuilder 
+    full_scorers: [!ref <ctc_scorer>]
+    weights:
+        ctc: !ref <ctc_weight_decode>
+
+test_scorer: !new:speechbrain.decoders.scorer.ScorerBuilder
+    full_scorers: [!ref <ctc_scorer>, !ref <transformerlm_scorer>] 
     weights:
         ctc: !ref <ctc_weight_decode>
         transformerlm: !ref <lm_weight>
@@ -234,6 +239,7 @@ valid_search: !new:speechbrain.decoders.S2STransformerBeamSearcher
     beam_size: !ref <valid_beam_size>
     using_eos_threshold: False
     length_normalization: False
+    scorer: !ref <valid_scorer>
 
 test_search: !new:speechbrain.decoders.S2STransformerBeamSearcher
     modules: [!ref <Transformer>, !ref <seq_lin>]
@@ -245,7 +251,7 @@ test_search: !new:speechbrain.decoders.S2STransformerBeamSearcher
     temperature: 1.15
     using_eos_threshold: False
     length_normalization: True
-    scorer: !ref <scorer>
+    scorer: !ref <test_scorer>
 
 log_softmax: !new:torch.nn.LogSoftmax
     dim: -1

--- a/recipes/LibriSpeech/ASR/transformer/hparams/transformer.yaml
+++ b/recipes/LibriSpeech/ASR/transformer/hparams/transformer.yaml
@@ -219,13 +219,13 @@ transformerlm_scorer: !new:speechbrain.decoders.scorer.TransformerLMScorer
     language_model: !ref <lm_model>
     temperature: 1.15
 
-valid_scorer: !new:speechbrain.decoders.scorer.ScorerBuilder 
+valid_scorer: !new:speechbrain.decoders.scorer.ScorerBuilder
     full_scorers: [!ref <ctc_scorer>]
     weights:
         ctc: !ref <ctc_weight_decode>
 
 test_scorer: !new:speechbrain.decoders.scorer.ScorerBuilder
-    full_scorers: [!ref <ctc_scorer>, !ref <transformerlm_scorer>] 
+    full_scorers: [!ref <ctc_scorer>, !ref <transformerlm_scorer>]
     weights:
         ctc: !ref <ctc_weight_decode>
         transformerlm: !ref <lm_weight>

--- a/templates/speech_recognition/ASR/train.yaml
+++ b/templates/speech_recognition/ASR/train.yaml
@@ -93,8 +93,8 @@ emb_size: 128
 dec_neurons: 1024
 output_neurons: 1000  # Number of tokens (same as LM)
 blank_index: 0
-bos_index: 1
-eos_index: 2
+bos_index: 0
+eos_index: 0
 
 # Decoding parameters
 min_decode_ratio: 0.0
@@ -265,7 +265,7 @@ rnnlm_scorer: !new:speechbrain.decoders.scorer.RNNLMScorer
 # into full_scorers list would be too heavy. partial_scorers are more
 # efficient because they score on pruned tokens at little cost of
 # performance drop. For other scorers, please see the speechbrain.decoders.scorer.
-scorer: !new:speechbrain.decoders.scorer.ScorerBuilder
+test_scorer: !new:speechbrain.decoders.scorer.ScorerBuilder
     scorer_beam_scale: 1.5
     full_scorers: [
         !ref <rnnlm_scorer>,
@@ -275,6 +275,11 @@ scorer: !new:speechbrain.decoders.scorer.ScorerBuilder
         rnnlm: !ref <lm_weight>
         coverage: !ref <coverage_penalty>
         ctc: !ref <ctc_weight_decode>
+
+valid_scorer:  !new:speechbrain.decoders.scorer.ScorerBuilder
+    full_scorers: [!ref <coverage_scorer>]
+    weights:
+        coverage: !ref <coverage_penalty>
 
 # Beamsearch is applied on the top of the decoder. For a description of
 # the other parameters, please see the speechbrain.decoders.S2SRNNBeamSearcher.
@@ -294,6 +299,7 @@ valid_search: !new:speechbrain.decoders.S2SRNNBeamSearcher
     using_max_attn_shift: !ref <using_max_attn_shift>
     max_attn_shift: !ref <max_attn_shift>
     temperature: !ref <temperature>
+    scorer: !ref <valid_scorer>
 
 # The final decoding on the test set can be more computationally demanding.
 # In this case, we use the LM + CTC probabilities during decoding as well,
@@ -312,7 +318,7 @@ test_search: !new:speechbrain.decoders.S2SRNNBeamSearcher
     using_max_attn_shift: !ref <using_max_attn_shift>
     max_attn_shift: !ref <max_attn_shift>
     temperature: !ref <temperature>
-    scorer: !ref <scorer>
+    scorer: !ref <test_scorer>
 
 # This function manages learning rate annealing over the epochs.
 # We here use the NewBoB algorithm, that anneals the learning rate if

--- a/templates/speech_recognition/ASR/train.yaml
+++ b/templates/speech_recognition/ASR/train.yaml
@@ -276,7 +276,7 @@ test_scorer: !new:speechbrain.decoders.scorer.ScorerBuilder
         coverage: !ref <coverage_penalty>
         ctc: !ref <ctc_weight_decode>
 
-valid_scorer:  !new:speechbrain.decoders.scorer.ScorerBuilder
+valid_scorer: !new:speechbrain.decoders.scorer.ScorerBuilder
     full_scorers: [!ref <coverage_scorer>]
     weights:
         coverage: !ref <coverage_penalty>


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

-->

@mravanelli pointed out in private some issues with unstable. The first one was related to the full_inference tests that were failing. The second one was related to the ASR template that wasn't converging to good performances.

**Issue 1.** The first issue is related to the batch_size in `seq2seq` recipe that was different from 1, hence leading to different results. 
The results:
> (1/3) Running test for full_inference_row_02...
        download_file('https://www.openslr.org/resources/12/test-clean.tar.gz', 'tests/download/test-clean.tar.gz', unpack=True, dest_unpack='tests/download/LibriSpeech',write_permissions=True)
tests/download/test-clean.tar.gz exists. Skipping download
Extracting tests/download/test-clean.tar.gz to tests/download/LibriSpeech
        download_file('https://www.dropbox.com/sh/wy6ktfdxqt0dmou/AABY4ty3zy3xPef0zwRx949Oa?dl=1', 'tests/download/LibriSpeech_ASR_transformer.zip', unpack=True, dest_unpack='tests/download/LibriSpeech_ASR_transformer', write_permissions=True)
tests/download/LibriSpeech_ASR_transformer.zip exists. Skipping download
Extracting tests/download/LibriSpeech_ASR_transformer.zip to tests/download/LibriSpeech_ASR_transformer
                Running an Inference Test.
        ... 52.63s
        ...checking files & performance...
(2/3) Running test for full_inference_row_03...
        download_file('https://www.openslr.org/resources/12/test-clean.tar.gz', 'tests/download/test-clean.tar.gz', unpack=True, dest_unpack='tests/download/LibriSpeech', write_permissions=True)
tests/download/test-clean.tar.gz exists. Skipping download
Extracting tests/download/test-clean.tar.gz to tests/download/LibriSpeech
        download_file('https://www.dropbox.com/sh/vs1os5mwh4necp0/AAAs7rMl4IO4N4s__BbVon6qa?dl=1', 'tests/download/LibriSpeech_ASR_seq2seq.zip', unpack=True, dest_unpack='tests/download/LibriSpeech_ASR_seq2seq', write_permissions=True)
tests/download/LibriSpeech_ASR_seq2seq.zip exists. Skipping download
Extracting tests/download/LibriSpeech_ASR_seq2seq.zip to tests/download/LibriSpeech_ASR_seq2seq
                Running an Inference Test.
        ... 71.98s
        ...checking files & performance...
(3/3) Running test for full_inference_row_04...
        download_file('https://www.openslr.org/resources/12/test-clean.tar.gz', 'tests/download/test-clean.tar.gz', unpack=True, dest_unpack='tests/download/LibriSpeech', write_permissions=True)
tests/download/test-clean.tar.gz exists. Skipping download
Extracting tests/download/test-clean.tar.gz to tests/download/LibriSpeech
        download_file('https://www.dropbox.com/sh/al3qzi1b4cgvvfo/AAAWf0b-uMIPcfaU3DgjPcbMa?dl=1', 'tests/download/LibriSpeech_ASR_CTC_wav2vec.zip', unpack=True, dest_unpack='tests/download/LibriSpeech_ASR_CTC_wav2vec', write_permissions=True)
tests/download/LibriSpeech_ASR_CTC_wav2vec.zip exists. Skipping download
Extracting tests/download/LibriSpeech_ASR_CTC_wav2vec.zip to tests/download/LibriSpeech_ASR_CTC_wav2vec
                Running an Inference Test.
        ... 56.94s
        ...checking files & performance...
TEST PASSED

**Issue 2.** The second issue was due to the bos/eos/blank token index. They were different from the pretrained LM models. 

The results: 

develop branch:
> speechbrain.utils.epoch_loop - Going into epoch 1
100%|█████████████████████████████████████████████████████████████████| 190/190 [03:08<00:00,  1.01it/s, train_loss=0.945]
100%|███████████████████████████████████████████████████████████████████████████████████| 137/137 [01:43<00:00,  1.33it/s]
speechbrain.utils.train_logger - epoch: 1, lr: 1.00e+00 - train loss: 9.45e-01 - valid loss: 1.23, valid CER: 35.42, valid WER: 39.14
speechbrain.utils.checkpoints - Saved an end-of-epoch checkpoint in results/CRDNN_BPE_960h_LM/2602/save/CKPT+2023-10-21+12-02-55+00
speechbrain.utils.epoch_loop - Going into epoch 2
100%|█████████████████████████████████████████████████████████████████| 190/190 [03:02<00:00,  1.04it/s, train_loss=0.726]
100%|███████████████████████████████████████████████████████████████████████████████████| 137/137 [02:17<00:00,  1.00s/it]
speechbrain.nnet.schedulers - Changing lr from 1 to 0.8
speechbrain.utils.train_logger - epoch: 2, lr: 1.00e+00 - train loss: 7.26e-01 - valid loss: 1.27, valid CER: 1.54e+02, valid WER: 1.54e+02
speechbrain.utils.checkpoints - Saved an end-of-epoch checkpoint in results/CRDNN_BPE_960h_LM/2602/save/CKPT+2023-10-21+12-08-30+00
speechbrain.utils.epoch_loop - Going into epoch 3
100%|█████████████████████████████████████████████████████████████████| 190/190 [03:03<00:00,  1.04it/s, train_loss=0.678]
100%|███████████████████████████████████████████████████████████████████████████████████| 137/137 [02:48<00:00,  1.23s/it]
speechbrain.nnet.schedulers - Changing lr from 0.8 to 0.64
speechbrain.utils.train_logger - epoch: 3, lr: 8.00e-01 - train loss: 6.78e-01 - valid loss: 1.29, valid CER: 2.19e+02, valid WER: 2.18e+02
speechbrain.utils.checkpoints - Saved an end-of-epoch checkpoint in results/CRDNN_BPE_960h_LM/2602/save/CKPT+2023-10-21+12-14-37+00
speechbrain.utils.checkpoints - Deleted checkpoint in results/CRDNN_BPE_960h_LM/2602/save/CKPT+2023-10-21+12-08-30+00
speechbrain.utils.epoch_loop - Going into epoch 4
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 190/190 [03:02<00:00,  1.04it/s, train_loss=0.655]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 137/137 [02:08<00:00,  1.07it/s]
speechbrain.utils.train_logger - epoch: 4, lr: 6.40e-01 - train loss: 6.55e-01 - valid loss: 1.25, valid CER: 84.22, valid WER: 87.76
speechbrain.utils.checkpoints - Saved an end-of-epoch checkpoint in results/CRDNN_BPE_960h_LM/2602/save/CKPT+2023-10-21+12-20-02+00
speechbrain.utils.checkpoints - Deleted checkpoint in results/CRDNN_BPE_960h_LM/2602/save/CKPT+2023-10-21+12-14-37+00

unstable
> 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 137/137 [01:56<00:00,  1.18it/s]
speechbrain.utils.train_logger - epoch: 1, lr: 1.00e+00 - train loss: 9.45e-01 - valid loss: 1.23, valid CER: 35.95, valid WER: 39.63
speechbrain.utils.checkpoints - Saved an end-of-epoch checkpoint in results/CRDNN_BPE_960h_LM/2602/save/CKPT+2023-10-21+12-27-54+00
speechbrain.utils.epoch_loop - Going into epoch 2
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 190/190 [03:04<00:00,  1.03it/s, train_loss=0.726]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 137/137 [02:06<00:00,  1.08it/s]
speechbrain.nnet.schedulers - Changing lr from 1 to 0.8
speechbrain.utils.train_logger - epoch: 2, lr: 1.00e+00 - train loss: 7.26e-01 - valid loss: 1.27, valid CER: 1.63e+02, valid WER: 1.64e+02
speechbrain.utils.checkpoints - Saved an end-of-epoch checkpoint in results/CRDNN_BPE_960h_LM/2602/save/CKPT+2023-10-21+12-33-20+00
speechbrain.utils.epoch_loop - Going into epoch 3
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 190/190 [03:06<00:00,  1.02it/s, train_loss=0.679]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 137/137 [02:28<00:00,  1.08s/it]
speechbrain.nnet.schedulers - Changing lr from 0.8 to 0.64
speechbrain.utils.train_logger - epoch: 3, lr: 8.00e-01 - train loss: 6.79e-01 - valid loss: 1.29, valid CER: 2.09e+02, valid WER: 2.08e+02
speechbrain.utils.checkpoints - Saved an end-of-epoch checkpoint in results/CRDNN_BPE_960h_LM/2602/save/CKPT+2023-10-21+12-39-09+00
speechbrain.utils.checkpoints - Deleted checkpoint in results/CRDNN_BPE_960h_LM/2602/save/CKPT+2023-10-21+12-33-20+00
speechbrain.utils.epoch_loop - Going into epoch 4
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 190/190 [03:06<00:00,  1.02it/s, train_loss=0.654]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 137/137 [01:47<00:00,  1.28it/s]
speechbrain.utils.train_logger - epoch: 4, lr: 6.40e-01 - train loss: 6.54e-01 - valid loss: 1.24, valid CER: 74.95, valid WER: 77.42
speechbrain.utils.checkpoints - Saved an end-of-epoch checkpoint in results/CRDNN_BPE_960h_LM/2602/save/CKPT+2023-10-21+12-44-18+00

Note on inference tests: We download the pretrained models in a folder called `tests/download` which is different from `tests/tmp`, so this is hard to really understand what is going on. Indeed, inside of the `tests/download/name_of_the_pretrained_folder` you will obtain a `stderr.txt` and `stdout.txt` files which should be located in `tests/tmp`. These files gives us important informations on our model: in my case, the pretrained model was as the beginning failing the inference tests because I had an issue with my CUDA version and torch version. The inference_tests automatically used the old wer value obtained on the full test set of LibriSpeech as we are only reading the last row in `train_log.txt`. Maybe we should remove the train_log.txt before running the inference tests to avoid using the old wer value.  

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
