### PR TITLE
reverting an error added by HyperConformer (code from Samsung AI Cambridge)

### DIFF
--- a/speechbrain/lobes/models/transformer/TransformerASR.py
+++ b/speechbrain/lobes/models/transformer/TransformerASR.py
@@ -207,10 +207,6 @@ class TransformerASR(TransformerInterface):
         if self.attention_type == "RelPosMHAXL":
             # use standard sinusoidal pos encoding in decoder
             tgt = tgt + self.positional_encoding_decoder(tgt)
-            # FIXME we use pos embs also on enc output
-            encoder_out = encoder_out + self.positional_encoding_decoder(
-                encoder_out
-            )
             pos_embs_encoder = None  # self.positional_encoding(src)
             pos_embs_target = None
         elif (
@@ -285,10 +281,6 @@ class TransformerASR(TransformerInterface):
         if self.attention_type == "RelPosMHAXL":
             # we use fixed positional encodings in the decoder
             tgt = tgt + self.positional_encoding_decoder(tgt)
-            encoder_out = encoder_out + self.positional_encoding_decoder(
-                encoder_out
-            )
-            # pos_embs_target = self.positional_encoding(tgt)
             pos_embs_encoder = None  # self.positional_encoding(src)
             pos_embs_target = None
         elif (

--- a/speechbrain/lobes/models/transformer/TransformerASR.py
+++ b/speechbrain/lobes/models/transformer/TransformerASR.py
@@ -205,7 +205,6 @@ class TransformerASR(TransformerInterface):
         tgt = self.custom_tgt_module(tgt)
 
         if self.attention_type == "RelPosMHAXL":
-            # use standard sinusoidal pos encoding in decoder
             tgt = tgt + self.positional_encoding_decoder(tgt)
             pos_embs_encoder = None  # self.positional_encoding(src)
             pos_embs_target = None
@@ -279,7 +278,6 @@ class TransformerASR(TransformerInterface):
 
         tgt = self.custom_tgt_module(tgt)
         if self.attention_type == "RelPosMHAXL":
-            # we use fixed positional encodings in the decoder
             tgt = tgt + self.positional_encoding_decoder(tgt)
             pos_embs_encoder = None  # self.positional_encoding(src)
             pos_embs_target = None


### PR DESCRIPTION
This PR reverts an error that was introduced by this [PR](https://github.com/speechbrain/speechbrain/pull/1905). This error destroys the performance of all our conformer/transformer model for ASR, whatever the dataset. We are currently making sure that it works as expected now. CC @shucongzhang

- [x] Verify that the issue is fixed for the Tedlium PR

 


