### PR TITLE
Fix Resample instantiation to include device argument

### DIFF
--- a/recipes/Voicebank/voicebank_prepare.py
+++ b/recipes/Voicebank/voicebank_prepare.py
@@ -432,7 +432,7 @@ def download_vctk(destination, tmp_dir=None, device="cpu"):
         "clean_trainset_28spk_wav",
     ]
 
-    downsampler = Resample(orig_freq=48000, new_freq=16000)
+    downsampler = Resample(orig_freq=48000, new_freq=16000).to(device)
 
     for directory in dirs:
         logger.info("Resampling " + directory)


### PR DESCRIPTION
## What does this PR do?

This pull request fixes a runtime error that occurs when the `Resample` object from `torchaudio.transforms` is instantiated without being assigned to the specified device. The lack of device assignment can cause a mismatch when the downstream operations are performed on tensors residing on non-CPU devices (e.g., CUDA devices).

The change includes the addition of the `.to(device)` method call during the `Resample` object instantiation, ensuring that the object is created on the correct device as specified by the `device` argument in the `download_vctk` function.

No dependencies are added with this change, and the fix is isolated to the instantiation of the `Resample` object.


## Before submitting

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs) (You would mark this as complete if you added tests, otherwise explain why they are not necessary)
- [x] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request? (Mark this as complete if there are no breaking changes)
- [x] Does your code adhere to project-specific code style and conventions?

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [x] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [x] Review the self-review checklist to ensure the code is ready for review
