### PR TITLE
Add wrappers for Encodec and Vocos vocoders

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -26,11 +26,15 @@ except ModuleNotFoundError:
 try:
     from transformers import Wav2Vec2Model  # noqa: F401
 except ModuleNotFoundError:
-    collect_ignore.append("speechbrain/lobes/models/huggingface_transformers/wav2vec2.py")
+    collect_ignore.append(
+        "speechbrain/lobes/models/huggingface_transformers/wav2vec2.py"
+    )
 try:
     from transformers import WhisperModel  # noqa: F401
 except ModuleNotFoundError:
-    collect_ignore.append("speechbrain/lobes/models/huggingface_transformers/whisper.py")
+    collect_ignore.append(
+        "speechbrain/lobes/models/huggingface_transformers/whisper.py"
+    )
 try:
     import sacrebleu  # noqa: F401
 except ModuleNotFoundError:

--- a/conftest.py
+++ b/conftest.py
@@ -35,3 +35,9 @@ try:
     import sacrebleu  # noqa: F401
 except ModuleNotFoundError:
     collect_ignore.append("speechbrain/utils/bleu.py")
+try:
+    import vocos  # noqa: F401
+except ModuleNotFoundError:
+    collect_ignore.append(
+        "speechbrain/lobes/models/huggingface_transformers/vocos.py"
+    )

--- a/conftest.py
+++ b/conftest.py
@@ -26,11 +26,11 @@ except ModuleNotFoundError:
 try:
     from transformers import Wav2Vec2Model  # noqa: F401
 except ModuleNotFoundError:
-    collect_ignore.append("speechbrain/lobes/models/huggingface_wav2vec.py")
+    collect_ignore.append("speechbrain/lobes/models/huggingface_transformers/wav2vec2.py")
 try:
     from transformers import WhisperModel  # noqa: F401
 except ModuleNotFoundError:
-    collect_ignore.append("speechbrain/lobes/models/huggingface_whisper.py")
+    collect_ignore.append("speechbrain/lobes/models/huggingface_transformers/whisper.py")
 try:
     import sacrebleu  # noqa: F401
 except ModuleNotFoundError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,3 @@ torch>=1.9.0
 torchaudio>=1.9.0
 tqdm>=4.42.0
 transformers>=4.30.0
-vocos>=0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ torch>=1.9.0
 torchaudio>=1.9.0
 tqdm>=4.42.0
 transformers>=4.30.0
+vocos>=0.1.0

--- a/speechbrain/lobes/models/huggingface_transformers/__init__.py
+++ b/speechbrain/lobes/models/huggingface_transformers/__init__.py
@@ -20,4 +20,3 @@ from .wav2vec2 import *  # noqa
 from .wavlm import *  # noqa
 from .whisper import *  # noqa
 from .encodec import *  # noqa
-from .vocos import *  # noqa

--- a/speechbrain/lobes/models/huggingface_transformers/__init__.py
+++ b/speechbrain/lobes/models/huggingface_transformers/__init__.py
@@ -6,6 +6,7 @@ This subpackage gathers higher level blocks, or "lobes" for HuggingFace Transfor
 # Transformers is required for this package.
 try:
     import transformers  # noqa
+    import vocos  # noqa
 except ImportError:
     MSG = "Please install transformers from HuggingFace.\n"
     MSG += "E.G. run: pip install transformers \n"
@@ -18,3 +19,5 @@ from .huggingface import *  # noqa
 from .wav2vec2 import *  # noqa
 from .wavlm import *  # noqa
 from .whisper import *  # noqa
+from .encodec import *  # noqa
+from .vocos import *  # noqa

--- a/speechbrain/lobes/models/huggingface_transformers/encodec.py
+++ b/speechbrain/lobes/models/huggingface_transformers/encodec.py
@@ -52,6 +52,20 @@ class Encodec(nn.Module):
                 param.requires_grad = False
 
     def forward(self, inputs, lengths):
+        """Encodes the input audio as tokens
+
+        Arguments
+        ---------
+        inputs : torch.Tensor
+            a (Batch X Samples) tensor of audio
+        length : torch.Tensor
+            a tensor of relative lengths
+
+        Returns
+        -------
+        tokens : torch.Tensor
+            a (Batch X Tokens) tensor of audio tokens
+        """
         return self.encode(inputs, lengths)
 
     def encode(self, inputs, length):

--- a/speechbrain/lobes/models/huggingface_transformers/encodec.py
+++ b/speechbrain/lobes/models/huggingface_transformers/encodec.py
@@ -1,0 +1,96 @@
+"""This lobe enables the integration of huggingface pretrained encodec.
+
+Repository: https://huggingface.co/docs/transformers/v4.31.0/en/model_doc/encodec
+Paper: https://arxiv.org/abs/2210.13438
+
+Authors
+ * Artem Ploujnikov 2023
+"""
+
+from torch import nn
+from speechbrain.dataio.dataio import length_to_mask
+
+try:
+    from transformers import EncodecModel
+except ImportError:
+    MSG = "Please install transformers from HuggingFace to use Encodec\n"
+    MSG += "E.G. run: pip install transformers"
+    raise ImportError(MSG)
+
+
+DEFAULT_SAMPLE_RATE = 24000
+
+
+class Encodec(nn.Module):
+    """An wrapper for the HuggingFace encodec model
+
+    Arguments
+    ---------
+    source : str
+        a HuggingFace repository identifier or a path
+    save_path : str
+        the location where the pretrained model will be saved
+    sample_rate : int
+        the audio sampling rate
+    freeze : bool
+        whether the model will be frozen (e.g. not trainable if used
+        as part of training another model)"""
+
+    def __init__(
+        self, source, save_path=None, sample_rate=None, freeze=True,
+    ):
+        super().__init__()
+        self.source = source
+        self.save_path = save_path
+        self.freeze = freeze
+        self.model = EncodecModel.from_pretrained(source, cache_dir=save_path)
+        if not sample_rate:
+            sample_rate = DEFAULT_SAMPLE_RATE
+        self.sample_rate = sample_rate
+        if self.freeze:
+            for param in self.model.parameters():
+                param.requires_grad = False
+
+    def forward(self, inputs, lengths):
+        return self.encode(inputs, lengths)
+
+    def encode(self, inputs, length):
+        """Encodes the input audio as tokens
+
+        Arguments
+        ---------
+        inputs : torch.Tensor
+            a (Batch X Samples) tensor of audio
+        length : torch.Tensor
+            a tensor of relative lengths
+
+        Returns
+        -------
+        tokens : torch.Tensor
+            a (Batch X Tokens) tensor of audio tokens
+        """
+        max_len = inputs.size(1)
+        mask = length_to_mask(length * max_len, max_len)
+        result = self.model.encode(inputs, mask)
+        return result["audio_codes"].squeeze(0).transpose(-1, -2)
+
+    def decode(self, tokens, length):
+        """Decodes audio from tokens
+
+        Arguments
+        ---------
+        tokens : torch.Tensor
+            a tensor of tokens
+        length : torch.Tensor
+            a tensor of relative lengths
+
+        Returns
+        -------
+        audio : torch.Tensor
+            the audio
+        """
+        max_len = tokens.size(1)
+        mask = length_to_mask(length * max_len, max_len)
+        return self.model.decode(
+            tokens.unsqueeze(0).transpose(-1, -2), [None], mask
+        )

--- a/speechbrain/lobes/models/huggingface_transformers/encodec.py
+++ b/speechbrain/lobes/models/huggingface_transformers/encodec.py
@@ -66,7 +66,7 @@ class Encodec(HFTransformersInterface):
             sample_rate = DEFAULT_SAMPLE_RATE
         self.sample_rate = sample_rate
         if self.freeze:
-            logger.warning("huggingface_GPT - GPT  is frozen.")
+            logger.warning("huggingface_Encodec - Encodec is frozen.")
             for param in self.model.parameters():
                 param.requires_grad = False
 

--- a/speechbrain/lobes/models/huggingface_transformers/encodec.py
+++ b/speechbrain/lobes/models/huggingface_transformers/encodec.py
@@ -54,11 +54,17 @@ class Encodec(HFTransformersInterface):
     >>> model = Encodec(model_hub, save_path)
     >>> audio = torch.randn(4, 1000)
     >>> length = torch.tensor([1.0, .5, .75, 1.0])
-    >>> tokens = model.encode(audio, length)
+    >>> tokens, emb = model.encode(audio, length)
     >>> tokens.shape
     torch.Size([4, 4, 2])
+    >>> emb.shape
+    torch.Size([4, 4, 2, 128])
     >>> rec = model.decode(tokens, length)
-    >>>
+    >>> rec.shape
+    torch.Size([4, 1, 1280])
+    >>> rec_emb = model.decode_emb(emb, length)
+    >>> rec_emb.shape
+    torch.Size([4, 1, 1280])
     """
 
     def __init__(

--- a/speechbrain/lobes/models/huggingface_transformers/vocos.py
+++ b/speechbrain/lobes/models/huggingface_transformers/vocos.py
@@ -1,0 +1,87 @@
+"""This lobe enables the integration of huggingface pretrained
+Vocos model.
+
+Repository: https://huggingface.co/charactr/vocos-encodec-24khz
+Paper: https://arxiv.org/pdf/2306.00814.pdf
+
+Authors
+ * Artem Ploujnikov 2023
+"""
+
+import torch
+from torch import nn
+from speechbrain.dataio.dataio import length_to_mask
+
+try:
+    from vocos import Vocos as VocosModel
+except ImportError:
+    MSG = "Please install vocos to use the Vocos model\n"
+    MSG += "E.G. run: pip install vocos"
+    raise ImportError(MSG)
+
+
+DEFAULT_SAMPLE_RATE = 24000
+BANDWIDTHS = [1.5, 3.0, 6.0, 12.0]
+
+
+class Vocos(nn.Module):
+    """An wrapper for the HuggingFace Vocos model
+
+    Arguments
+    ---------
+    source : str
+        a HuggingFace repository identifier or a path
+    revision : str
+        the model revision
+    bandwidth : int
+        the bandwidth values
+        Supported:
+        1.5, 3.0, 6.0, 12.0
+    freeze : bool
+        whether or not parameters should be
+        frozen
+    """
+
+    def __init__(
+        self, source, revision=None, bandwidth=1.5, freeze=True,
+    ):
+        super().__init__()
+        self.source = source
+        self.model = VocosModel.from_pretrained(source, revision)
+        self.freeze = freeze
+        self.bandwidth = bandwidth
+        self.bandwidth_id = (
+            (torch.tensor(BANDWIDTHS) - bandwidth).abs().argmin().item()
+        )
+        if self.freeze:
+            for param in self.model.parameters():
+                param.requires_grad = False
+
+    def forward(self, inputs, lengths):
+        """Converts vocodec tokens to audio
+
+        Arguments
+        ---------
+        inputs : torch.Tensor
+            A tensor of Vocodec tokens
+        lengths : torch.Tensor
+            A 1-D tensor of relative lengths
+
+        Returns
+        -------
+        wavs : torch.Tensor
+            A (Batch x Length) tensor of raw waveforms
+        lengths : torch.Tensor
+            Relative lengths
+        """
+        features = self.model.codes_to_features(inputs.permute(2, 0, 1))
+        wavs = self.model.decode(
+            features,
+            bandwidth_id=torch.tensor(
+                [self.bandwidth_id], device=inputs.device
+            ),
+        )
+        mask = length_to_mask(
+            lengths * wavs.size(1), max_len=wavs.size(1), device=wavs.device
+        )
+        return wavs * mask, lengths

--- a/speechbrain/lobes/models/huggingface_transformers/vocos.py
+++ b/speechbrain/lobes/models/huggingface_transformers/vocos.py
@@ -47,17 +47,17 @@ class Vocos(nn.Module):
     Arguments
     ---------
     source : str
-        a HuggingFace repository identifier or a path
+        A HuggingFace repository identifier or a path
     save_path : str
-        the location where the pretrained model will be saved
+        The location where the pretrained model will be saved
     revision : str
-        the model revision
-    bandwidth : int
-        the bandwidth values
+        The model revision
+    bandwidth : float
+        The bandwidth value
         Supported:
         1.5, 3.0, 6.0, 12.0
     freeze : bool
-        whether or not parameters should be
+        Whether or not parameters should be
         frozen
 
     Example

--- a/speechbrain/lobes/models/huggingface_transformers/vocos.py
+++ b/speechbrain/lobes/models/huggingface_transformers/vocos.py
@@ -1,6 +1,10 @@
 """This lobe enables the integration of huggingface pretrained
 Vocos model.
 
+Vocos is a vocoder trained on top of EnCodec tokens. While
+EnCodec itself can be used for a lossy reconstruction of speech,
+a vocoder, such as Vocos, can be used to improve the quality.
+
 Repository: https://huggingface.co/charactr/vocos-encodec-24khz
 Paper: https://arxiv.org/pdf/2306.00814.pdf
 
@@ -117,12 +121,12 @@ class Vocos(nn.Module):
         return model
 
     def forward(self, inputs, length):
-        """Converts vocodec tokens to audio
+        """Converts EnCodec tokens to audio
 
         Arguments
         ---------
         inputs : torch.Tensor
-            A tensor of Vocodec tokens
+            A tensor of EnCodec tokens
         length : torch.Tensor
             A 1-D tensor of relative lengths
 

--- a/speechbrain/lobes/models/huggingface_transformers/vocos.py
+++ b/speechbrain/lobes/models/huggingface_transformers/vocos.py
@@ -70,12 +70,7 @@ class Vocos(nn.Module):
     """
 
     def __init__(
-        self,
-        source,
-        save_path,
-        revision=None,
-        bandwidth=1.5,
-        freeze=True,
+        self, source, save_path, revision=None, bandwidth=1.5, freeze=True,
     ):
         super().__init__()
         self.source = source
@@ -106,7 +101,7 @@ class Vocos(nn.Module):
             repo_id=self.source,
             filename="pytorch_model.bin",
             revision=self.revision,
-            cache_dir=self.save_path
+            cache_dir=self.save_path,
         )
         model = VocosModel.from_hparams(config_path)
         state_dict = torch.load(model_path, map_location="cpu")

--- a/speechbrain/lobes/models/huggingface_transformers/vocos.py
+++ b/speechbrain/lobes/models/huggingface_transformers/vocos.py
@@ -59,7 +59,8 @@ class Vocos(nn.Module):
     Example
     -------
     >>> model_hub = "charactr/vocos-encodec-24khz"
-    >>> model = Vocos(model_hub)
+    >>> save_path = "savedir"
+    >>> model = Vocos(model_hub, save_path)
     >>> tokens = torch.randint(1024, (4, 10, 2))
     >>> length = torch.tensor([1.0, 0.5, 0.75, 1.0])
     >>> audio, out_length = model(tokens, length)

--- a/speechbrain/lobes/models/huggingface_transformers/vocos.py
+++ b/speechbrain/lobes/models/huggingface_transformers/vocos.py
@@ -4,6 +4,14 @@ Vocos model.
 Repository: https://huggingface.co/charactr/vocos-encodec-24khz
 Paper: https://arxiv.org/pdf/2306.00814.pdf
 
+TODO: There is an open feature request to add this model to
+HuggingFace Transformers.
+
+If this is impemented, it will be possible to make this model
+inherit from HFTransformersInterface
+
+https://github.com/huggingface/transformers/issues/25123
+
 Authors
  * Artem Ploujnikov 2023
 """

--- a/tests/.run-doctests.sh
+++ b/tests/.run-doctests.sh
@@ -5,5 +5,5 @@ set -e -u -o pipefail
 # > pytest --doctest-modules speechbrain/
 # However, we take this more complex approach to avoid testing files not
 # tracked by git. We filter out tests that require optional dependencies.
-avoid="transducer_loss.py\|fairseq_wav2vec.py\|huggingface_wav2vec.py\|bleu.py\|ctc_segmentation.py\|check_url.py\|huggingface_whisper.py\|language_model.py"
+avoid="transducer_loss.py\|fairseq_wav2vec.py\|huggingface_wav2vec.py\|bleu.py\|ctc_segmentation.py\|check_url.py\|huggingface_whisper.py\|language_model.py\|vocos.py"
 git ls-files speechbrain | grep -e "\.py$" | grep -v $avoid | xargs pytest --doctest-modules


### PR DESCRIPTION
Introduce wrappers for the following pretrained models:
* Encodec
  * **Repository:**: https://huggingface.co/docs/transformers/v4.31.0/en/model_doc/encodec
  * **Paper:**:  https://arxiv.org/abs/2210.13438
* Vocos
  *  **Repository:** https://huggingface.co/charactr/vocos-encodec-24khz. 
  * **Paper:** https://arxiv.org/pdf/2306.00814.pdf
