### PR TITLE
multi-speaker tacotron2 enhancements

### DIFF
--- a/recipes/LibriTTS/README.md
+++ b/recipes/LibriTTS/README.md
@@ -20,7 +20,9 @@ Training time required on NVIDIA A100 GPU using LibriTTS train-clean-100 and tra
 
 The training logs are available [here](https://www.dropbox.com/sh/ti2vk7sce8f9fgd/AABcDGWCrBvLX_ZQs76mlJRYa?dl=0).
 
-The pre-trained model with an easy-inference interface is available on [HuggingFace](https://huggingface.co/speechbrain/tts-mstacotron2-libritts).
+For now, enhancements are needed for traning the model from scratch when train-clean-360 is included. Inference can be effectuated with `clone_voice_char_input` function in the MSTacotron2 interface.
+
+The pre-trained model (a model fine-tuned from LJSpeech tacotron2) with an easy-inference interface is available on [HuggingFace](https://huggingface.co/speechbrain/tts-mstacotron2-libritts).
 
 **Please Note**: The current model effectively captures speaker identities. Nevertheless, the synthesized speech quality exhibits some metallic characteristics and may include artifacts like overly long pauses.
 We are actively working to enhancing the model and will release updates as soon as improvements are achieved. We warmly welcome contributions from the community to collaboratively make the model even better!

--- a/recipes/LibriTTS/TTS/mstacotron2/hparams/train.yaml
+++ b/recipes/LibriTTS/TTS/mstacotron2/hparams/train.yaml
@@ -14,14 +14,14 @@ __set_seed: !apply:torch.manual_seed [!ref <seed>]
 output_folder: !ref ./results/tacotron2/<seed>
 save_folder: !ref <output_folder>/save
 train_log: !ref <output_folder>/train_log.txt
-epochs: 500
+epochs: 700
 keep_checkpoint_interval: 50
 use_tensorboard: False
 
 # Vocoder is used to covert the intermediate mel-spectrogram into the final waveform
 log_audio_samples: True
-vocoder: speechbrain/tts-hifigan-libritts-22050Hz
-vocoder_savedir: tmpdir_vocoder
+vocoder: speechbrain/tts-hifigan-libritts-16kHz
+vocoder_savedir: tmpdir_vocoder_16k
 
 ###################################
 # Progress Samples                #
@@ -38,7 +38,7 @@ progress_sample_path: !ref <output_folder>/samples
 
 # The interval, in epochs. For instance, if it is set to 5,
 # progress samples will be output every 5 epochs
-progress_samples_interval: 1
+progress_samples_interval: 10
 
 # The sample size for raw batch samples saved in batch.pth
 # (useful mostly for model debugging)
@@ -63,7 +63,7 @@ test_speaker_embeddings_pickle: !ref <save_folder>/test_speaker_embeddings.pickl
 skip_prep: False
 splits: ["train", "valid", "test"]
 
-#train_split: ["train-clean-100", "train-clean-360"]
+# train_split: ["train-clean-100", "train-clean-360"]
 train_split: ["train-clean-100"]
 valid_split: ["dev-clean"]
 test_split: ["test-clean"]
@@ -72,10 +72,12 @@ test_split: ["test-clean"]
 # The cleaners to be used (applicable to nvidia only)
 text_cleaners: ['english_cleaners']
 
+# Avoid audios longer than x seconds
+avoid_if_longer_than: 10.0
 ################################
 # Audio Parameters             #
 ################################
-sample_rate: 22050
+sample_rate: 16000
 hop_length: 256
 win_length: 1024
 n_mel_channels: 80
@@ -106,11 +108,11 @@ spk_emb_encoder: speechbrain/spkrec-ecapa-voxceleb
 ################################
 learning_rate: 0.001
 weight_decay: 0.000006
-batch_size: 64 #minimum 2
+batch_size: 32 #minimum 2
 mask_padding: True
 guided_attention_sigma: 0.2
-guided_attention_weight: 75.0
-guided_attention_weight_half_life: 10.
+guided_attention_weight: 25.0
+guided_attention_weight_half_life: 25.
 guided_attention_hard_stop: 50
 gate_loss_weight: 1.0
 spk_emb_loss_weight: 1.0
@@ -250,15 +252,10 @@ epoch_counter: !new:speechbrain.utils.epoch_loop.EpochCounter
 train_logger: !new:speechbrain.utils.train_logger.FileTrainLogger
   save_file: !ref <train_log>
 
-# Learning rate annealing function
-lr_annealing: !new:speechbrain.nnet.schedulers.IntervalScheduler
-  intervals:
-    - steps: 6000
-      lr: 0.0005
-    - steps: 8000
-      lr: 0.0003
-    - steps: 10000
-      lr: 0.0001
+# # Learning rate annealing function
+lr_annealing: !new:speechbrain.nnet.schedulers.NoamScheduler
+  lr_initial: !ref <learning_rate>
+  n_warmup_steps: 4000
 
 # Checkpointer
 checkpointer: !new:speechbrain.utils.checkpoints.Checkpointer

--- a/recipes/LibriTTS/libritts_prepare.py
+++ b/recipes/LibriTTS/libritts_prepare.py
@@ -195,7 +195,7 @@ def create_json(wav_list, json_file, sample_rate, model_name=None):
 
         # Reads the signal
         signal, sig_sr = torchaudio.load(wav_file)
-        duration = signal.shape[1]/sig_sr
+        duration = signal.shape[1] / sig_sr
         # Manipulates path to get relative path and uttid
         path_parts = wav_file.split(os.path.sep)
         uttid, _ = os.path.splitext(path_parts[-1])

--- a/recipes/LibriTTS/libritts_prepare.py
+++ b/recipes/LibriTTS/libritts_prepare.py
@@ -15,6 +15,7 @@ import torchaudio
 import torch
 from tqdm import tqdm
 from speechbrain.pretrained import GraphemeToPhoneme
+from speechbrain.utils.text_to_sequence import _g2p_keep_punctuations
 
 logger = logging.getLogger(__name__)
 LIBRITTS_URL_PREFIX = "https://www.openslr.org/resources/60/"
@@ -194,7 +195,7 @@ def create_json(wav_list, json_file, sample_rate, model_name=None):
 
         # Reads the signal
         signal, sig_sr = torchaudio.load(wav_file)
-
+        duration = signal.shape[1]/sig_sr
         # Manipulates path to get relative path and uttid
         path_parts = wav_file.split(os.path.sep)
         uttid, _ = os.path.splitext(path_parts[-1])
@@ -226,17 +227,17 @@ def create_json(wav_list, json_file, sample_rate, model_name=None):
         json_dict[uttid] = {
             "uttid": uttid,
             "wav": relative_path,
+            "duration": duration,
             "spk_id": spk_id,
             "label": normalized_text,
             "segment": True if "train" in json_file else False,
         }
 
-        # Tacotron2 specific data preparation
-        if model_name == "Tacotron2":
-            # Computes phoneme labels using SpeechBrain G2P for Tacotron2
-            label_phoneme_list = g2p(normalized_text)
-            label_phoneme = " ".join(label_phoneme_list)
-            json_dict[uttid].update({"label_phoneme": label_phoneme})
+        # Characters are used for Tacotron2, phonemes may be needed for other models
+        if model_name != "Tacotron2":
+            # Computes phoneme labels using SpeechBrain G2P and keeps the punctuations
+            phonemes = _g2p_keep_punctuations(g2p, normalized_text)
+            json_dict[uttid].update({"label_phoneme": phonemes})
 
     # Writes the dictionary to the json file
     with open(json_file, mode="w") as json_f:


### PR DESCRIPTION
## What does this PR do?
Hi @mravanelli @pradnya-git-dev, as discussed, this PR contains some enhancements of the multi-speaker tacotron2 (#2120) based on my experiments.

The modifications are:
- [x] Use characters instead of phonemes (which shows better alignments with our tacotron)
- [x] Do 16k generation instead of 22k with the 16k hifi-gan pretrained
- [x] Limit the maximum audio length to 10 seconds
- [ ] Train with more speakers (add train-clean-360 into training set)
- [ ] Make MS-Tacotron2 a child class of Tacotron2
- [ ] Update the interface and the model
- [ ] recipe tests

