### PR TITLE
Make lobes use fp32 when AMP is active

### DIFF
--- a/speechbrain/lobes/features.py
+++ b/speechbrain/lobes/features.py
@@ -14,6 +14,7 @@ from speechbrain.processing.features import (
     Deltas,
     ContextWindow,
 )
+from speechbrain.utils.autocast import fwd_default_precision
 from speechbrain.nnet.CNN import GaborConv1d
 from speechbrain.nnet.normalization import PCEN
 from speechbrain.nnet.pooling import GaussianLowpassPooling
@@ -127,6 +128,7 @@ class Fbank(torch.nn.Module):
             left_frames=left_frames, right_frames=right_frames,
         )
 
+    @fwd_default_precision(torch.float32)
     def forward(self, wav):
         """Returns a set of features generated from the input waveforms.
 
@@ -260,6 +262,7 @@ class MFCC(torch.nn.Module):
             left_frames=left_frames, right_frames=right_frames,
         )
 
+    @fwd_default_precision(torch.float32)
     def forward(self, wav):
         """Returns a set of mfccs generated from the input waveforms.
 
@@ -387,6 +390,7 @@ class Leaf(torch.nn.Module):
             self.compression = None
         self.skip_transpose = skip_transpose
 
+    @fwd_default_precision(torch.float32)
     def forward(self, x):
         """
         Returns the learned LEAF features

--- a/speechbrain/utils/autocast.py
+++ b/speechbrain/utils/autocast.py
@@ -1,0 +1,71 @@
+"""This module implements utilities and abstractions for use with
+`torch.autocast`, i.e. Automatic Mixed Precision.
+
+Authors
+ * Sylvain de Langen 2023
+"""
+import functools
+from typing import Callable, Optional
+import torch
+
+
+def fwd_default_precision(
+    fwd: Optional[Callable] = None,
+    cast_inputs: Optional[torch.dtype] = torch.float32,
+):
+    """Decorator for forward methods which, by default, *disables* autocast
+    and casts any floating-point tensor parameters into the specified dtype
+    (much like `torch.cuda.amp.custom_fwd`).
+
+    The *wrapped forward* will gain an additional `force_allow_autocast` keyword
+    parameter.
+    When set to `True`, the function will ignore `cast_inputs` and will not
+    disable autocast, as if this decorator was not specified.
+    (Thus, modules can specify a default recommended precision, and users can
+    override that behavior when desired.)
+
+    Note that as of PyTorch 2.1.1, this will **only** affect **CUDA** AMP.
+    Non-CUDA AMP will be unaffected and no input tensors will be cast!
+    This usecase may be supported by this function in the future.
+
+    When autocast is *not* active, this decorator does not change any behavior.
+
+    Arguments
+    ---------
+    fwd: Optional[Callable]
+        The function to wrap. If omitted, returns a partial application of the
+        decorator, e.g. allowing
+        `new_decorator = fwd_default_precision(cast_inputs=torch.float32)`.
+
+        Reminder: If you are decorating a function directly, this argument is
+        already specified implicitly.
+
+    cast_inputs: Optional[torch.dtype]
+        If specified, then any inputs to the wrapped functions will be cast to
+        the specified type, e.g. `torch.float32`.
+
+        Note: When autocasting is enabled, output tensors of autocast-compatible
+        operations may be of the autocast data type.
+        Disabling autocast *without* casting inputs will not change this fact,
+        so lower precision operations can happen even inside of an
+        autocast-disabled region, which this argument helps avoid if desired. 
+    """
+
+    if fwd is None:
+        return functools.partial(fwd_default_precision, cast_inputs=cast_inputs)
+
+    # NOTE: torch.cuda.amp.custom_fwd is written with the assumption of CUDA
+    # autocast. There does not seem to be a generic equivalent.
+    # Detecting CUDA AMP specifically also seems difficult or impossible, so we
+    # cannot even reliably warn about the issue. For now, we just document the
+    # problem.
+    wrapped_fwd = torch.cuda.amp.custom_fwd(fwd, cast_inputs=cast_inputs)
+
+    @functools.wraps(fwd)
+    def wrapper(*args, force_allow_autocast: bool = False, **kwargs):
+        if force_allow_autocast:
+            return fwd(*args, **kwargs)
+        else:
+            return wrapped_fwd(*args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
## What does this PR do?

Currently, when fp16 AMP is enabled, feature processing lobes may perform fp16 operations.  
In some recipes, this results in instability during training. Because this feature processing is usually rather trivial to process computationally, it seems reasonable to make them default to fp32 when AMP is active.

This is the result of 

This PR:
- adds a new `speechbrain.utils.autocast` file which would host general autocast related functionality in SpeechBrain,
- adds a `fwd_default_precision` decorator, very much like `torch.cuda.amp.custom_fwd`, but:
  - with more of a future-proofing ability (e.g. if someone wants to add non-CUDA AMP support, or to provide a list of acceptable precisions, etc.),
  - an attempt to heavily document consequences of its use and of autocasting in general,
  - the ability for the end user of the function/module to let autocast without the inputs casting if they really know what they're doing
- makes all processing lobes in `speechbrain.lobes.features` use this function to cast inputs to `torch.float32`

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
