### PR TITLE
Optimize masked Dynamic Chunk Convolution

### DIFF
--- a/speechbrain/lobes/models/transformer/Conformer.py
+++ b/speechbrain/lobes/models/transformer/Conformer.py
@@ -197,9 +197,6 @@ class ConvolutionModule(nn.Module):
 
             chunk_size = dynchunktrain_config.chunk_size
             batch_size = x.shape[0]
-            chunk_left_context = self.padding
-
-            chunk_count = int(math.ceil(x.shape[1] / chunk_size))
 
             # determine the amount of padding we need to insert at the right of
             # the last chunk so that all chunks end up with the same size.

--- a/speechbrain/lobes/models/transformer/Conformer.py
+++ b/speechbrain/lobes/models/transformer/Conformer.py
@@ -13,7 +13,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from typing import Optional, List
 import speechbrain as sb
-import math
 import warnings
 
 

--- a/speechbrain/lobes/models/transformer/Conformer.py
+++ b/speechbrain/lobes/models/transformer/Conformer.py
@@ -208,13 +208,6 @@ class ConvolutionModule(nn.Module):
             else:
                 final_right_padding = 0
 
-            # compute the left context that can and should be added, for each
-            # chunk. for the first few chunks, we will need to add extra padding
-            applied_left_context = [
-                min(chunk_left_context, i * chunk_size)
-                for i in range(chunk_count)
-            ]
-
             # -> [batch_size, t, in_channels]
             out = self.layer_norm(x)
 

--- a/speechbrain/lobes/models/transformer/Conformer.py
+++ b/speechbrain/lobes/models/transformer/Conformer.py
@@ -244,11 +244,7 @@ class ConvolutionModule(nn.Module):
             #   could not be evenly split in `chunk_size` chunks
 
             # -> [batch_size, in_channels, num_chunks, lc+chunk_size]
-            out = out.unfold(
-                2,
-                size=chunk_size + self.padding,
-                step=chunk_size
-            )
+            out = out.unfold(2, size=chunk_size + self.padding, step=chunk_size)
 
             # as we manually disable padding in the convolution below, we insert
             # right 0-padding to the chunks, e.g. reusing the above example:

--- a/tests/unittests/test_conformer.py
+++ b/tests/unittests/test_conformer.py
@@ -1,0 +1,82 @@
+import torch
+
+
+@torch.no_grad
+def test_streaming_conformer_layer(device):
+    """Test whether the Conformer encoder layer masking code path (used at train
+    time) is equivalent to a real streaming scenario."""
+
+    from speechbrain.lobes.models.transformer.Conformer import (
+        ConformerEncoderLayer
+    )
+    from speechbrain.nnet.attention import RelPosEncXL
+    from speechbrain.utils.dynamic_chunk_training import DynChunkTrainConfig
+    from speechbrain.lobes.models.transformer.TransformerASR import (
+        make_transformer_src_mask
+    )
+
+    TOLERATED_MEAN_ERROR = 1.0e-6
+
+    bs, seq_len, num_feats = input_shape = 1, 24, 16
+    config = DynChunkTrainConfig(chunk_size=8, left_context_size=1)
+
+    assert (
+        seq_len % config.chunk_size == 0
+    ), "For this test, we assume the sequence length can evenly be divided"
+    num_chunks = seq_len // config.chunk_size
+
+    torch.manual_seed(1337)
+
+    module = ConformerEncoderLayer(
+        d_model=num_feats,
+        d_ffn=num_feats*2,
+        nhead=1,
+        kernel_size=5
+    ).to(device=device)
+    module.eval()
+
+    pos_encoder = RelPosEncXL(num_feats).to(device=device)
+
+    # build inputs
+    test_input = torch.randn(input_shape, device=device)
+
+    test_input_chunked = test_input.unfold(1, size=config.chunk_size, step=config.chunk_size)
+    test_input_chunked = test_input_chunked.transpose(1, 3)
+    assert (
+        test_input_chunked.shape
+        == (bs, config.chunk_size, num_feats, num_chunks)
+    ), "Test bug: incorrect shape for the chunked input?"
+
+    # build the transformer mask for masked inference (dynchunktrain_config does
+    # not suffice)
+    src_mask = make_transformer_src_mask(test_input, dynchunktrain_config=config)
+
+    # masked inference
+    pos_embs_full = pos_encoder(test_input)
+    out_mask_path, _out_attn = module(test_input, src_mask=src_mask, pos_embs=pos_embs_full, dynchunktrain_config=config)
+
+    # streaming inference
+    mutable_ctx = module.make_streaming_context(config.left_context_size * config.chunk_size)
+    output_chunks = []
+
+    for i in range(num_chunks):
+        chunk_in = test_input_chunked[..., i]
+
+        # HACK due to pos embeddings
+        pos_embs_dummy_input = chunk_in
+        if mutable_ctx.mha_left_context is not None:
+            pos_embs_dummy_input = torch.empty(
+                (bs, config.chunk_size + mutable_ctx.mha_left_context.size(1), num_feats),
+                device=device
+            )
+
+        pos_embs_chunk = pos_encoder(pos_embs_dummy_input)
+        chunk_out, _chunk_attn = module.forward_streaming(chunk_in, mutable_ctx, pos_embs=pos_embs_chunk)
+        output_chunks.append(chunk_out)
+
+    out_stream_path = torch.cat(output_chunks, dim=1)
+
+    # check output embedding differences
+    abs_diff = (out_mask_path - out_stream_path).abs()
+
+    assert torch.mean(abs_diff).item() < TOLERATED_MEAN_ERROR


### PR DESCRIPTION
## What does this PR do?

#2140 introduced a streaming Conformer-Transducer recipe. @TParcollet noted a slowdown when training with `streaming: True`. This PR reworks the convolution module code to not use lists of slices and expresses the entire chunking logic as tensor operations.

- The layernorm and bottleneck are unaffected by the time axis, and are thus applied over the input tensor directly.
- The "list of slice + stack" logic was fully replaced in favor of more clever use of padding and `Tensor.unfold`.

When testing, I found the output of the function to be virtually identical without and with this PR, and the WER% remains unchanged. Training doesn't crash. No breaking changes should occur due to the PR.

I tested performance on my 7900 XT (HIP vs CUDA might have some performance characteristics differences) in a more extreme case (chunk size of `8`, longest batch in `test-clean`, no GS, forward-only):

| Scenario | Performance |
|-|-|
| No masking | `124 ms ± 212 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)` |
| Chunk size = 8, **before** | `236 ms ± 1.55 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)` |
| Chunk size = 8, **after** | `186 ms ± 645 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)` |

The difference is fairly large here as the chunk size is rather small. I don't exactly know how this would translate in training performance and whether that fully solves the performance difference observed by @TParcollet.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [x] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [x] Review the self-review checklist to ensure the code is ready for review

</details>