### PR TITLE
Fix numba verbosity (code from Samsung AI Cambridge)

### DIFF
--- a/speechbrain/nnet/loss/transducer_loss.py
+++ b/speechbrain/nnet/loss/transducer_loss.py
@@ -9,9 +9,23 @@ Authors
 import torch
 from torch.autograd import Function
 from torch.nn import Module
+import logging
+import math
+import warnings
+
+NUMBA_VERBOSE = 0
 
 try:
     from numba import cuda
+
+    # Numba is extra verbose and this may lead to log.txt file of multiple gigabytes... we deactivate
+    if not NUMBA_VERBOSE:
+        nb_logger = logging.getLogger("numba")
+        nb_logger.setLevel(logging.ERROR)  # only show error
+
+        from numba.core.errors import NumbaPerformanceWarning
+
+        warnings.simplefilter("ignore", category=NumbaPerformanceWarning)
 except ImportError:
     err_msg = "The optional dependency Numba is needed to use this module\n"
     err_msg += "Cannot import numba. To use Transducer loss\n"
@@ -25,8 +39,6 @@ except ImportError:
     err_msg += "If you use conda:\n"
     err_msg += "conda install numba cudatoolkit=9.0"
     raise ImportError(err_msg)
-
-import math
 
 
 @cuda.jit()


### PR DESCRIPTION
## What does this PR do?

This PR is a simple fix to just remove all warnings and info from Numba drivers. Numba is extremely verbose, and this can lead to our log.txt file weighting many GB ... This remove all the warnings. This means that we may miss deprecation information or optimisation issue, but the flag can be switched off to investigate... 

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [x] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [x] Review the self-review checklist to ensure the code is ready for review

