### PR TITLE
Fix weight_norm import in DAC

### DIFF
--- a/speechbrain/lobes/models/discrete/dac.py
+++ b/speechbrain/lobes/models/discrete/dac.py
@@ -19,8 +19,15 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+# Note: The path torch.nn.utils.parametrizations may not be available
+# in older PyTorch versions, such as 1.13.1. To ensure compatibility,
+# it is recommended to check and use the appropriate import statement.
+
+# Attempt to import the preferred module for parametrizations in newer PyTorch versions
 try:
     from torch.nn.utils.parametrizations import weight_norm
+
+# If the preferred import fails, fallback to the alternative import for compatibility
 except ImportError:
     from torch.nn.utils import weight_norm
 

--- a/speechbrain/lobes/models/discrete/dac.py
+++ b/speechbrain/lobes/models/discrete/dac.py
@@ -18,6 +18,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
 try:
     from torch.nn.utils.parametrizations import weight_norm
 except ImportError:

--- a/speechbrain/lobes/models/discrete/dac.py
+++ b/speechbrain/lobes/models/discrete/dac.py
@@ -18,7 +18,10 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.nn.utils.parametrizations import weight_norm
+try:
+    from torch.nn.utils.parametrizations import weight_norm
+except ImportError:
+    from torch.nn.utils import weight_norm
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
`from torch.nn.utils.parametrizations import weight_norm` does not work for older versions of PyTorch supported by SpeechBrain (e.g. `torch==1.13.1`). `from torch.nn.utils import weight_norm` should be used instead. However this throws a deprecation warning for newer versions. This PR fixes the issue.