### PR TITLE
Fix zero_grad when opt_class is None

### DIFF
--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -1200,11 +1200,16 @@ class Brain:
         # 1. get the valid optimizers, i.e., the ones that are not frozen during this step
         if self.optimizers_dict is not None:
             valid_optimizers = self.freeze_optimizers(self.optimizers_dict)
-        else:
+        elif self.opt_class is not None:
             # if valid_optimizers is not defined which could happen if a user is using an old
             # init_optimizers() method, then we assume that the only valid optimizer is
             # self.optimizer (which is the default behavior).
             valid_optimizers = {"optimizer": self.optimizer}
+        else:
+            # Note: in some cases you might want to only compute gradients statistics and
+            # you do not need to call the optimizers.step() method. In this case, you can
+            # simply return from this method and skip the rest of the code.
+            return
 
         # 2. unscale the gradients of the valid optimizers
         for opt in valid_optimizers.values():

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -615,6 +615,7 @@ class Brain:
         checkpointer=None,
         profiler=None,
     ):
+        self.optimizers_dict = None
         self.opt_class = opt_class
         self.checkpointer = checkpointer
         self.profiler = profiler

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -1067,8 +1067,9 @@ class Brain:
         Setting gradients to None should save the memory, e.g.
         during ``evaluate()`` and thus larger batch might be used.
         """
-        for opt in self.freeze_optimizers(self.optimizers_dict).values():
-            opt.zero_grad(set_to_none=set_to_none)
+        if self.opt_class is not None:
+            for opt in self.freeze_optimizers(self.optimizers_dict).values():
+                opt.zero_grad(set_to_none=set_to_none)
 
     def on_evaluate_start(self, max_key=None, min_key=None):
         """Gets called at the beginning of ``evaluate()``

--- a/speechbrain/utils/__init__.py
+++ b/speechbrain/utils/__init__.py
@@ -5,7 +5,11 @@ import os
 __all__ = []
 for filename in os.listdir(os.path.dirname(__file__)):
     filename = os.path.basename(filename)
-    if filename.endswith(".py") and not filename.startswith("__"):
+    if (
+        filename.endswith(".py")
+        and not filename.startswith("__")
+        and not filename == "kmeans.py"
+    ):
         __all__.append(filename[:-3])
 
 from . import *  # noqa

--- a/speechbrain/utils/kmeans.py
+++ b/speechbrain/utils/kmeans.py
@@ -12,7 +12,12 @@ from tqdm.contrib import tqdm
 try:
     from sklearn.cluster import MiniBatchKMeans
 except ImportError:
-    print("Please install sklearn  in order to use the k-means model")
+    err_msg = "The optional dependency sklearn is needed to use this module\n"
+    err_msg += "Cannot import sklearn.cluster.MiniBatchKMeans to use KMeans/\n"
+    err_msg += "Please follow the instructions below\n"
+    err_msg += "=============================\n"
+    err_msg += "pip install -U scikit-learn\n"
+    raise ImportError(err_msg)
 import joblib
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
`zero_grad` breaks if `opt_class=None` because `self.optimizers_dict` is not defined. This PR fixes the issue.