### PR TITLE
add opt recoverable

### DIFF
--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -762,12 +762,10 @@ class Brain:
         elif "cuda" in self.device and self.precision in ["fp16", "bf16"]:
             self.use_amp = True
 
-        if (
-            self.use_amp
-            and self.checkpointer is not None
-            and self.precision != "bf16"
-        ):
-            self.checkpointer.add_recoverable("scaler", self.scaler)
+        if self.use_amp and self.checkpointer is not None:
+            self.checkpointer.add_recoverable(
+                "scaler", self.scaler, is_optional=True
+            )
 
         # List parameter count for the user
         total_params = sum(

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -764,7 +764,7 @@ class Brain:
 
         if self.use_amp and self.checkpointer is not None:
             self.checkpointer.add_recoverable(
-                "scaler", self.scaler, is_optional=True
+                "scaler", self.scaler, optional_load=True
             )
 
         # List parameter count for the user

--- a/speechbrain/utils/checkpoints.py
+++ b/speechbrain/utils/checkpoints.py
@@ -491,7 +491,7 @@ class Checkpointer:
         obj,
         custom_load_hook=None,
         custom_save_hook=None,
-        is_optional=False,
+        optional_load=False,
     ):
         """Register a recoverable with possible custom hooks.
 
@@ -509,7 +509,7 @@ class Checkpointer:
             Called to save the object's parameters. The function/method must
             be callable with signature (instance, path) using positional
             arguments. This is satisfied by for example: def saver(self, path):
-        is_optional : bool, optional
+        optional_load : bool, optional
             If True, allows for the optional loading of an object from a checkpoint.
             If the checkpoint lacks the specified object, no error is raised.
             This is particularly useful during transitions between different training
@@ -522,7 +522,7 @@ class Checkpointer:
             in that checkpoint.
         """
         self.recoverables[name] = obj
-        self.optional_recoverables[name] = is_optional
+        self.optional_recoverables[name] = optional_load
         if custom_load_hook is not None:
             self.custom_load_hooks[name] = custom_load_hook
         if custom_save_hook is not None:


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

-->

This PR aims at fixing one issue with checkpointing. Indeed, when trying to reuse a checkpoint (e.g. from dropbox), one may want to perform inference/pre-training using a different type of precision. For instance, one may want to use fp16 while the model was trained in fp32. 

Unfortunately, doing so will add a recoverable around the `scaler` object. As the checkpoint was trained in fp32, we are missing this object in the checkpoint, and we are getting an error saying that there is a keyError. 

The following output log is when running the inference tests with the flag `--precision=fp16` (which can saves us a lot of vram/time):
```
Traceback (most recent call last):
  File "/users/amoumen/machine_learning/speechbrain/pr/beam_search_eos_blank/speechbrain/speechbrain/utils/checkpoints.py", line 1030, in _call_load_hooks
    loadpath = checkpoint.paramfiles[name]
KeyError: 'scaler'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/users/amoumen/machine_learning/speechbrain/pr/beam_search_eos_blank/speechbrain/recipes/LibriSpeech/ASR/transformer/train.py", line 476, in <module>
    asr_brain.evaluate(
  File "/users/amoumen/machine_learning/speechbrain/pr/beam_search_eos_blank/speechbrain/speechbrain/core.py", line 1668, in evaluate
    self.on_evaluate_start(max_key=max_key, min_key=min_key)
  File "/users/amoumen/machine_learning/speechbrain/pr/beam_search_eos_blank/speechbrain/recipes/LibriSpeech/ASR/transformer/train.py", line 161, in on_evaluate_start
    super().on_evaluate_start()
  File "/users/amoumen/machine_learning/speechbrain/pr/beam_search_eos_blank/speechbrain/speechbrain/core.py", line 1095, in on_evaluate_start
    self.checkpointer.recover_if_possible(
  File "/users/amoumen/machine_learning/speechbrain/pr/beam_search_eos_blank/speechbrain/speechbrain/utils/checkpoints.py", line 895, in recover_if_possible
    self.load_checkpoint(chosen_ckpt)
  File "/users/amoumen/machine_learning/speechbrain/pr/beam_search_eos_blank/speechbrain/speechbrain/utils/checkpoints.py", line 908, in load_checkpoint
    self._call_load_hooks(checkpoint)
  File "/users/amoumen/machine_learning/speechbrain/pr/beam_search_eos_blank/speechbrain/speechbrain/utils/checkpoints.py", line 1042, in _call_load_hooks
    raise RuntimeError(MSG)
RuntimeError: Loading checkpoint from tests/tmp/LibriSpeech_ASR_transformer/save/CKPT+2022-12-17+14-39-25+00,                             but missing a load path for scaler
```

So, this PR add a new optional parameter called `is_optional` when adding a recoverable around an object. This way, when we want to load an object, if this one is not found and that it is optional, we are adding a warning instead of an error. See:
```
/users/amoumen/machine_learning/speechbrain/pr/beam_search_eos_blank/speechbrain/speechbrain/utils/checkpoints.py:1062: UserWarning: Trying to load checkpoint from tests/tmp/LibriSpeech_ASR_transformer/save/CKPT+2022-12-17+14-39-25+00,                                 but missing a load path for scaler. Skipping as this                                 recoverable is marked as optional.
  warnings.warn(MSG, UserWarning)
``` 
And now, you can use fp16! 

CC: @pplantinga @mravanelli @TParcollet 
PS: I haven't been working a lot on the checkpointing so I don't really know if my solution is the best. I'm open to refactoring ofc :) 

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
