### PR TITLE
Load audio with PyAV

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 -r lint-requirements.txt
+av
 huggingface_hub>=0.8.0
 hyperpyyaml>=0.0.1
 joblib>=0.14.1
@@ -6,7 +7,6 @@ numpy>=1.17.0
 packaging
 pandas>=1.0.1
 pre-commit>=2.3.0
-pyav
 pygtrie>=2.1,<3.0
 scipy>=1.4.1
 sentencepiece>=0.1.91

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,10 @@ numpy>=1.17.0
 packaging
 pandas>=1.0.1
 pre-commit>=2.3.0
+pyav
 pygtrie>=2.1,<3.0
 scipy>=1.4.1
 sentencepiece>=0.1.91
-SoundFile; sys_platform == 'win32'
 torch>=1.9.0
 torchaudio>=1.9.0
 tqdm>=4.42.0


### PR DESCRIPTION
Torchaudio depends on one of a few backends being installed, which has caused a number of problems. See #2225 

This PR solves it by using PyAV to load the audio, because it bundles ffmpeg and makes for easy install.

https://pyav.org/docs/stable/

This is the approach taken by faster whisper (see https://github.com/SYSTRAN/faster-whisper/blob/master/faster_whisper/audio.py#L1)