### PR TITLE
Fix EncoderASR interface that was very restrictive 

### DIFF
--- a/speechbrain/decoders/ctc.py
+++ b/speechbrain/decoders/ctc.py
@@ -4,7 +4,7 @@ Authors
  * Mirco Ravanelli 2020
  * Aku Rouhe 2020
  * Sung-Lin Yeh 2020
- * Adel Moumen 2023
+ * Adel Moumen 2023, 2024
 """
 from itertools import groupby
 from speechbrain.dataio.dataio import length_to_mask
@@ -966,7 +966,9 @@ class CTCBaseSearcher(torch.nn.Module):
             )
 
         # check if we have log_probs
-        if not torch.allclose(torch.exp(log_probs).sum(dim=-1), torch.ones(log_probs.shape[0])):
+        if not torch.allclose(
+            torch.exp(log_probs).sum(dim=-1), torch.ones(log_probs.shape[0])
+        ):
             warnings.warn(
                 "The input `log_probs` are not log probabilities. "
                 "Going to convert them to log probabilities."

--- a/speechbrain/decoders/ctc.py
+++ b/speechbrain/decoders/ctc.py
@@ -965,6 +965,14 @@ class CTCBaseSearcher(torch.nn.Module):
                 "During decoding, going to truncate the log_probs vocab dim to match vocab_list."
             )
 
+        # check if we have log_probs
+        if not torch.allclose(torch.exp(log_probs).sum(dim=-1), torch.ones(log_probs.shape[0])):
+            warnings.warn(
+                "The input `log_probs` are not log probabilities. "
+                "Going to convert them to log probabilities."
+            )
+            log_probs = torch.log_softmax(log_probs, dim=-1)
+
         # compute wav_lens and cast to numpy as it is faster
         if wav_lens is not None:
             wav_lens = log_probs.size(1) * wav_lens

--- a/speechbrain/inference/ASR.py
+++ b/speechbrain/inference/ASR.py
@@ -10,16 +10,15 @@ Authors:
  * Andreas Nautsch 2022, 2023
  * Pooneh Mousavi 2023
  * Sylvain de Langen 2023
- * Adel Moumen 2023
+ * Adel Moumen 2023, 2024
  * Pradnya Kandarkar 2023
 """
 import torch
 import sentencepiece
 import speechbrain
 from speechbrain.inference.interfaces import Pretrained
-from speechbrain.utils.fetching import fetch
-from speechbrain.utils.data_utils import split_path
 import functools
+
 
 class EncoderDecoderASR(Pretrained):
     """A ready-to-use Encoder-Decoder ASR model
@@ -184,7 +183,7 @@ class EncoderASR(Pretrained):
         """Set the decoding function based on the parameters defined in the hyperparameter file.
 
         The decoding function is determined by the `decoding_function` specified in the hyperparameter file.
-        It can be either a functools.partial object representing a decoding function or an instance of 
+        It can be either a functools.partial object representing a decoding function or an instance of
         `speechbrain.decoders.ctc.CTCBaseSearcher` for beam search decoding.
 
         Raises:
@@ -198,17 +197,24 @@ class EncoderASR(Pretrained):
         """
         # Greedy Decoding case
         if isinstance(self.hparams.decoding_function, functools.partial):
-            self.decoding_function  = self.hparams.decoding_function
+            self.decoding_function = self.hparams.decoding_function
         # CTCBeamSearcher case
         else:
             # 1. check if the decoding function is an instance of speechbrain.decoders.CTCBaseSearcher
-            if issubclass(self.hparams.decoding_function, speechbrain.decoders.ctc.CTCBaseSearcher):
-                # If so, we need to retrieve the vocab list from the tokenizer. 
+            if issubclass(
+                self.hparams.decoding_function,
+                speechbrain.decoders.ctc.CTCBaseSearcher,
+            ):
+                # If so, we need to retrieve the vocab list from the tokenizer.
                 # We also need to check if the tokenizer is a sentencepiece or a CTCTextEncoder.
-                if isinstance(self.tokenizer, speechbrain.dataio.encoder.CTCTextEncoder):
+                if isinstance(
+                    self.tokenizer, speechbrain.dataio.encoder.CTCTextEncoder
+                ):
                     ind2lab = self.tokenizer.ind2lab
                     vocab_list = [ind2lab[x] for x in range(len(ind2lab))]
-                elif isinstance(self.tokenizer, sentencepiece.SentencePieceProcessor):
+                elif isinstance(
+                    self.tokenizer, sentencepiece.SentencePieceProcessor
+                ):
                     vocab_list = [
                         self.tokenizer.id_to_piece(i)
                         for i in range(self.tokenizer.vocab_size())
@@ -217,7 +223,7 @@ class EncoderASR(Pretrained):
                     raise ValueError(
                         "The tokenizer must be sentencepiece or CTCTextEncoder"
                     )
-                
+
                 # We can now instantiate the decoding class and add all the parameters
                 if hasattr(self.hparams, "test_beam_search"):
                     opt_beam_search_params = self.hparams.test_beam_search


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

-->

This PR fix the `EncoderASR` class which was forcing the users to add a new parameter in our HF inference YAMLs `decoding_type`. Furthermore, this parameter was not letting the possibility to the end user to customise easily the type of beam search used, the hyperparams etc. 

Now, we do not need this parameter. We can automatically retrieve if it's greedy search or beam search. You can either use greedy search like that:
```yaml
decoding_function: !name:speechbrain.decoders.ctc_greedy_decode
    blank_id: !ref <blank_index>
```
Or beam search:
```yaml
decoding_function: !name:speechbrain.decoders.CTCBeamSearcher
# Decoding parameters
test_beam_search:
   beam_size: 143
   topk: 1
   blank_index: !ref <blank_index>
   space_token: ' ' # make sure this is the same as the one used in the tokenizer
   beam_prune_logp: -12.0
   token_prune_min_logp: -1.2
   prune_history: True
   alpha: 0.8
   beta: 1.2
   # can be downloaded from here https://www.openslr.org/11/ or trained with kenLM
   # It can either be a .bin or .arpa ; note: .arpa is much slower at loading
   # If you don't want to use an LM, comment it out or set it to null
   kenlm_model_path: null
```

Furthermore, for a mysterious reason, the class was expecting Sentencepiece tokenizer while most of our models expect CTCTextEncoder... So this PR is also solving this issue by checking the tokenizer before retrieving the vocab_list. 

Finally, this PR adds a small check that the input log_probs are effectively log_probs. I found that in wav2vec2 HF models, we were not passing the log softmax in the encoder which means that the logits (and not log probs) were given to the beam search decoder and ultimately led to wrong results!

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
