### PR TITLE
Minor fixes to UnitHIFIGAN

### DIFF
--- a/speechbrain/inference/vocoders.py
+++ b/speechbrain/inference/vocoders.py
@@ -311,16 +311,16 @@ class UnitHIFIGAN(Pretrained):
             self.hparams.generator.remove_weight_norm()
             self.first_call = False
 
-        # Ensure that the units sequence has a length of at least 3
-        if units.size(1) < 3:
-            logger.error(
-                "The 'units' argument should have a length of at least 3 because of padding size."
+        # Ensure that the units sequence has a length of at least 4
+        if units.size(1) < 4:
+            raise RuntimeError(
+                "The 'units' argument should have a length of at least 4 because of padding size."
             )
-            quit()
 
         # Increment units if tokenization is enabled
         if self.tokenize:
-            units += 1
+            # Avoid changing the input in-place
+            units = units + 1
         with torch.no_grad():
             waveform = self.infer(units.to(self.device))
         return waveform
@@ -341,16 +341,16 @@ class UnitHIFIGAN(Pretrained):
             self.hparams.generator.remove_weight_norm()
             self.first_call = False
 
-        # Ensure that the units sequence has a length of at least 3
-        if units.size(0) < 3:
-            logger.error(
-                "The 'units' argument should have a length of at least 3 because of padding size."
+        # Ensure that the units sequence has a length of at least 4
+        if units.size(0) < 4:
+            raise RuntimeError(
+                "The 'units' argument should have a length of at least 4 because of padding size."
             )
-            quit()
 
         # Increment units if tokenization is enabled
         if self.tokenize:
-            units += 1
+            # Avoid changing the input in-place
+            units = units + 1
         with torch.no_grad():
             waveform = self.infer(units.unsqueeze(0).to(self.device))
         return waveform.squeeze(0)


### PR DESCRIPTION
I found a few minor bugs in UnitHIFIGAN:
- The input tokens are modified in-place (+1 to each token)
- The minimum length of the sequence should be 4 instead of 3 (if you try with length 3 you get an error ` Padding size should be less than the corresponding input dimension ...`
- If length < 4, we should raise an exception rather than abruptly `quit()`

This PR fixes these issues.