### PR TITLE
Fix docs-related `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,11 +72,8 @@ instance/
 .scrapy
 
 # Sphinx documentation
-docs/_build/
-docs/source/*.rst
-!docs/source/index.rst
-!docs/source/_templates
-!docs/source/_static
+docs/build/
+docs/API/*.rst
 
 # PyBuilder
 target/


### PR DESCRIPTION
## What does this PR do?

The current `.gitignore` seems to reference obsolete paths that have been moved around since them. Notably, `docs/_build` no longer seems to be generated on my system (`docs/build` is), and `docs/source` no longer exists. The files in the repo that used to be there now live directly in `docs/`, and generated contents seem to exclusively go to `docs/API`.

Therefore, ignore `docs/build` and `docs/API`.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [x] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [x] Review the self-review checklist to ensure the code is ready for review

</details>