### PR TITLE
Make a ddp broadcast clone that handles main-process-only

### DIFF
--- a/speechbrain/utils/checkpoints.py
+++ b/speechbrain/utils/checkpoints.py
@@ -64,6 +64,7 @@ from speechbrain.utils.distributed import (
     main_process_only,
     if_main_process,
     ddp_barrier,
+    ddp_broadcast,
 )
 
 logger = logging.getLogger(__name__)
@@ -603,10 +604,7 @@ class Checkpointer:
             )
 
         # Communicate ckpt_dir to all procs
-        communication_list = [ckpt_dir]
-        if torch.distributed.is_initialized():
-            torch.distributed.broadcast_object_list(communication_list, src=0)
-        ckpt_dir = communication_list[0]
+        ckpt_dir = ddp_broadcast(ckpt_dir, src=0)
 
         saved_paramfiles = {}
         for name, obj in self.recoverables.items():

--- a/speechbrain/utils/distributed.py
+++ b/speechbrain/utils/distributed.py
@@ -121,8 +121,20 @@ def ddp_barrier():
 
 
 def ddp_broadcast(communication_object, src=0):
-    """In DDP mode, this function will broadcast a tensor to all
+    """In DDP mode, this function will broadcast an object to all
     processes.
+
+    Arguments
+    ---------
+    communication_object: Any
+        The object to be communicated to all processes. Must be picklable.
+        See docs for ``torch.distributed.broadcast_object_list()``
+    src: int
+        The rank which holds the object to be communicated.
+
+    Returns
+    -------
+    The communication_object passed on rank src.
     """
     if MAIN_PROC_ONLY >= 1 or not torch.distributed.is_initialized():
         return communication_object

--- a/speechbrain/utils/distributed.py
+++ b/speechbrain/utils/distributed.py
@@ -120,6 +120,20 @@ def ddp_barrier():
         torch.distributed.barrier()
 
 
+def ddp_broadcast(communication_object, src=0):
+    """In DDP mode, this function will broadcast a tensor to all
+    processes.
+    """
+    if MAIN_PROC_ONLY >= 1 or not torch.distributed.is_initialized():
+        return communication_object
+
+    # Wrapping object in a list is required for preventing
+    # a copy of the object, maintaining a pointer instead
+    communication_list = [communication_object]
+    torch.distributed.broadcast_object_list(communication_list, src=src)
+    return communication_list[0]
+
+
 def ddp_init_group(run_opts):
     """This function will initialize the ddp group if
     distributed_launch bool is given in the python command line.

--- a/tests/unittests/test_checkpoints.py
+++ b/tests/unittests/test_checkpoints.py
@@ -455,11 +455,11 @@ def parallel_checkpoint(rank, world_size, tmpdir):
         assert torch.allclose(model(inp), prev_output)
 
 
-# def test_parallel_checkpoint(tmpdir):
-#    world_size = 2
-#    torch.multiprocessing.spawn(
-#        parallel_checkpoint,
-#        args=(world_size, tmpdir),
-#        nprocs=world_size,
-#        join=True,
-#    )
+def test_parallel_checkpoint(tmpdir):
+    world_size = 2
+    torch.multiprocessing.spawn(
+        parallel_checkpoint,
+        args=(world_size, tmpdir),
+        nprocs=world_size,
+        join=True,
+    )


### PR DESCRIPTION
Checkpointing with DDP uses a torch.distributed broadcast to communicate the folder for saving to all procs. However, this broadcast causes a freeze if checkpointing is called in a main-process-only section of the code. This PR addresses this by adding a `ddp_broadcast` function that should correctly handle the main-process-only limitation.