### PR TITLE
Create legacy redirection from `speechbrain.pretrained` to `.inference`

### DIFF
--- a/speechbrain/__init__.py
+++ b/speechbrain/__init__.py
@@ -26,4 +26,8 @@ __all__ = [
 
 __version__ = version
 
-deprecated_redirect("speechbrain.pretrained", "speechbrain.inference")
+deprecated_redirect(
+    "speechbrain.pretrained",
+    "speechbrain.inference",
+    extra_reason="See: https://github.com/speechbrain/speechbrain/releases/tag/v1.0.0",
+)

--- a/speechbrain/__init__.py
+++ b/speechbrain/__init__.py
@@ -12,6 +12,7 @@ from . import nnet  # noqa
 from . import processing  # noqa
 from . import tokenizers  # noqa
 from . import utils  # noqa
+from .utils.importutils import deprecated_redirect
 
 with open(os.path.join(os.path.dirname(__file__), "version.txt")) as f:
     version = f.read().strip()

--- a/speechbrain/__init__.py
+++ b/speechbrain/__init__.py
@@ -26,13 +26,18 @@ __all__ = [
 
 __version__ = version
 
-_sb1_0_redirect_str = (
-    "This is a change from SpeechBrain 1.0. "
-    "See: https://github.com/speechbrain/speechbrain/releases/tag/v1.0.0"
-)
 
-deprecated_redirect(
-    "speechbrain.pretrained",
-    "speechbrain.inference",
-    extra_reason=_sb1_0_redirect_str,
-)
+def make_deprecated_redirections():
+    sb1_0_redirect_str = (
+        "This is a change from SpeechBrain 1.0. "
+        "See: https://github.com/speechbrain/speechbrain/releases/tag/v1.0.0"
+    )
+
+    deprecated_redirect(
+        "speechbrain.pretrained",
+        "speechbrain.inference",
+        extra_reason=sb1_0_redirect_str,
+    )
+
+
+make_deprecated_redirections()

--- a/speechbrain/__init__.py
+++ b/speechbrain/__init__.py
@@ -25,3 +25,5 @@ __all__ = [
 ]
 
 __version__ = version
+
+deprecated_redirect("speechbrain.pretrained", "speechbrain.inference")

--- a/speechbrain/__init__.py
+++ b/speechbrain/__init__.py
@@ -26,8 +26,13 @@ __all__ = [
 
 __version__ = version
 
+_sb1_0_redirect_str = (
+    "This is a change from SpeechBrain 1.0. "
+    "See: https://github.com/speechbrain/speechbrain/releases/tag/v1.0.0"
+)
+
 deprecated_redirect(
     "speechbrain.pretrained",
     "speechbrain.inference",
-    extra_reason="See: https://github.com/speechbrain/speechbrain/releases/tag/v1.0.0",
+    extra_reason=_sb1_0_redirect_str,
 )

--- a/speechbrain/utils/importutils.py
+++ b/speechbrain/utils/importutils.py
@@ -8,40 +8,67 @@ Author
 from types import ModuleType
 import importlib
 import sys
+from typing import Optional
 import warnings
 
 
 class LegacyModuleRedirect(ModuleType):
-    def __init__(self, old_import, new_import):
+    def __init__(
+        self, old_import, new_import, extra_reason: Optional[str] = None
+    ):
         super().__init__(old_import)
         self.old_import = old_import
         self.new_import = new_import
+        self.extra_reason = extra_reason
         self.lazy_module = None
 
-    def __getattr__(self, attr):
-        if self.lazy_module is None:
-            warnings.warn(
-                f"Module '{self.old_import}' was deprecated, redirecting to '{self.new_import}'",
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
-            self.lazy_module = importlib.import_module(self.new_import)
+    def _redirection_warn(self):
+        warning_text = (
+            f"Module '{self.old_import}' was deprecated, redirecting to "
+            f"'{self.new_import}'. Please update your script."
+        )
 
+        if self.extra_reason is not None:
+            warning_text += f" {self.extra_reason}"
+
+        # NOTE: we are not using DeprecationWarning because this gets ignored by
+        # default, even though we consider the warning to be rather important
+        # in the context of SB
+
+        warnings.warn(
+            warning_text,
+            # category=DeprecationWarning,
+            stacklevel=3,
+        )
+
+    def __getattr__(self, attr):
         # NOTE: exceptions here get eaten and not displayed
+
+        if self.lazy_module is None:
+            self._redirection_warn()
+            self.lazy_module = importlib.import_module(self.new_import)
 
         return getattr(self.lazy_module, attr)
 
 
-def deprecated_redirect(old_import: str, new_import: str) -> None:
+def deprecated_redirect(
+    old_import: str, new_import: str, extra_reason: Optional[str] = None
+) -> None:
     """Patches the module list to add a lazy redirection from `old_import` to
     `new_import`, emitting a `DeprecationWarning` when imported.
 
     Arguments
     ---------
-    old_import: str
+    old_import : str
         Old module import path e.g. `mypackage.myoldmodule`
-    new_import: str
+    new_import : str
         New module import path e.g. `mypackage.mynewcoolmodule.mycoolsubmodule`
+    extra_reason : str, optional
+        If specified, extra text to attach to the warning for clarification
+        (e.g. justifying why the move has occurred, or additional problems to
+        look out for).
     """
 
-    sys.modules[old_import] = LegacyModuleRedirect(old_import, new_import)
+    sys.modules[old_import] = LegacyModuleRedirect(
+        old_import, new_import, extra_reason=extra_reason
+    )

--- a/speechbrain/utils/importutils.py
+++ b/speechbrain/utils/importutils.py
@@ -1,0 +1,45 @@
+"""
+Module importing related utilities.
+
+Author
+ * Sylvain de Langen 2024
+"""
+
+from types import ModuleType
+import importlib
+import sys
+import warnings
+
+class LegacyModuleRedirect(ModuleType):
+    def __init__(self, old_import, new_import):
+        super().__init__(old_import)
+        self.old_import = old_import
+        self.new_import = new_import
+        self.lazy_module = None
+
+    def __getattr__(self, attr):
+        if self.lazy_module is None:
+            warnings.warn(
+                f"Module '{self.old_import}' was deprecated, redirecting to '{self.new_import}'",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+            self.lazy_module = importlib.import_module(self.new_import)
+
+        # NOTE: exceptions here get eaten and not displayed
+
+        return getattr(self.lazy_module, attr)
+
+def deprecated_redirect(old_import: str, new_import: str) -> None:
+    """Patches the module list to add a lazy redirection from `old_import` to
+    `new_import`, emitting a `DeprecationWarning` when imported.
+
+    Arguments
+    ---------
+    old_import: str
+        Old module import path e.g. `mypackage.myoldmodule`
+    new_import: str
+        New module import path e.g. `mypackage.mynewcoolmodule.mycoolsubmodule`
+    """
+
+    sys.modules[old_import] = LegacyModuleRedirect(old_import, new_import)

--- a/speechbrain/utils/importutils.py
+++ b/speechbrain/utils/importutils.py
@@ -13,8 +13,31 @@ import warnings
 
 
 class LegacyModuleRedirect(ModuleType):
+    """Defines a module type that lazily imports the target module (and warns
+    about the deprecation when this happens), thus allowing deprecated
+    redirections to be defined without immediately importing the target module
+    needlessly.
+
+    This is only the module type itself; if you want to define a redirection,
+    use :func:`~deprecated_redirect` instead.
+
+    Arguments
+    ---------
+    old_import : str
+        Old module import path e.g. `mypackage.myoldmodule`
+    new_import : str
+        New module import path e.g. `mypackage.mynewcoolmodule.mycoolsubmodule`
+    extra_reason : str, optional
+        If specified, extra text to attach to the warning for clarification
+        (e.g. justifying why the move has occurred, or additional problems to
+        look out for).
+    """
+
     def __init__(
-        self, old_import, new_import, extra_reason: Optional[str] = None
+        self,
+        old_import: str,
+        new_import: str,
+        extra_reason: Optional[str] = None,
     ):
         super().__init__(old_import)
         self.old_import = old_import
@@ -23,6 +46,9 @@ class LegacyModuleRedirect(ModuleType):
         self.lazy_module = None
 
     def _redirection_warn(self):
+        """Emits the warning for the redirection (with the extra reason if
+        provided)."""
+
         warning_text = (
             f"Module '{self.old_import}' was deprecated, redirecting to "
             f"'{self.new_import}'. Please update your script."

--- a/speechbrain/utils/importutils.py
+++ b/speechbrain/utils/importutils.py
@@ -10,6 +10,7 @@ import importlib
 import sys
 import warnings
 
+
 class LegacyModuleRedirect(ModuleType):
     def __init__(self, old_import, new_import):
         super().__init__(old_import)
@@ -29,6 +30,7 @@ class LegacyModuleRedirect(ModuleType):
         # NOTE: exceptions here get eaten and not displayed
 
         return getattr(self.lazy_module, attr)
+
 
 def deprecated_redirect(old_import: str, new_import: str) -> None:
     """Patches the module list to add a lazy redirection from `old_import` to


### PR DESCRIPTION
## What does this PR do?

When the user attempts to import using `speechbrain.pretrained`, emit a deprecation warning and automatically import `speechbrain.inference` instead. This should help consumers of the API migrate faster and reduce confusion.

~~Blocked by #2484 (technically can still be merged without, but this is an extra layer of confusion).~~

Related to #2480.

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>
