### PR TITLE
Fix import statement ordering using isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
       - id: black
         types: [python]
         additional_dependencies: ['click==8.1.7']
+
   - repo: https://github.com/PyCQA/flake8
     rev: 7.0.0
     hooks:
@@ -37,3 +38,8 @@ repos:
         args: [--ignore-words=.dict-speechbrain.txt]
         additional_dependencies:
           - tomli
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+
 import hyperpyyaml
 
 sys.path.insert(-1, os.path.abspath("../"))

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,6 +1,7 @@
 black==24.3.0
 click==8.1.7
 flake8==7.0.0
+isort==5.13.2
 pycodestyle==2.11.0
 pydoclint==0.4.1
 pytest==7.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,8 @@ exclude = '''
 
 [tool.codespell]
 skip = "./tests/tmp,./**/result,*.csv,*train.txt,*test.txt"
+
+[tool.isort]
+profile = "black"
+line_length = 80
+filter_files = true

--- a/recipes/AISHELL-1/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/AISHELL-1/ASR/CTC/train_with_wav2vec.py
@@ -14,12 +14,14 @@ Authors
  * Yingzhi WANG 2022
 """
 
-import sys
-import torch
 import logging
+import sys
+
+import torch
+from hyperpyyaml import load_hyperpyyaml
+
 import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
-from hyperpyyaml import load_hyperpyyaml
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/AISHELL-1/ASR/seq2seq/train.py
+++ b/recipes/AISHELL-1/ASR/seq2seq/train.py
@@ -3,12 +3,14 @@
 AISHELL-1 seq2seq model recipe. (Adapted from the LibriSpeech recipe.)
 """
 
-import sys
-import torch
 import logging
+import sys
+
+import torch
+from hyperpyyaml import load_hyperpyyaml
+
 import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
-from hyperpyyaml import load_hyperpyyaml
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/AISHELL-1/ASR/transformer/train.py
+++ b/recipes/AISHELL-1/ASR/transformer/train.py
@@ -8,12 +8,14 @@ Authors
     * Titouan Parcollet 2021
 """
 
-import sys
-import torch
 import logging
+import sys
+
+import torch
+from hyperpyyaml import load_hyperpyyaml
+
 import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
-from hyperpyyaml import load_hyperpyyaml
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/AISHELL-1/ASR/transformer/train_with_wav2vect.py
+++ b/recipes/AISHELL-1/ASR/transformer/train_with_wav2vect.py
@@ -6,12 +6,14 @@ It is designed to work with wav2vec2 pre-training.
 
 """
 
-import sys
-import torch
 import logging
+import sys
+
+import torch
+from hyperpyyaml import load_hyperpyyaml
+
 import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
-from hyperpyyaml import load_hyperpyyaml
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/AISHELL-1/Tokenizer/pretrained.py
+++ b/recipes/AISHELL-1/Tokenizer/pretrained.py
@@ -7,8 +7,10 @@ Authors
 """
 
 import os
-from speechbrain.utils.data_utils import download_file
+
 import sentencepiece as spm
+
+from speechbrain.utils.data_utils import download_file
 
 
 class tokenizer:

--- a/recipes/AISHELL-1/Tokenizer/train.py
+++ b/recipes/AISHELL-1/Tokenizer/train.py
@@ -14,8 +14,10 @@ Authors
 """
 
 import sys
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
 
 if __name__ == "__main__":

--- a/recipes/AISHELL-1/aishell_prepare.py
+++ b/recipes/AISHELL-1/aishell_prepare.py
@@ -8,14 +8,15 @@ Authors
  * Adel Moumen 2023
 """
 
+import csv
+import functools
+import glob
+import logging
 import os
 import shutil
-import logging
-import glob
-import csv
+
 from speechbrain.dataio.dataio import read_audio_info
 from speechbrain.utils.parallel import parallel_map
-import functools
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/AMI/Diarization/experiment.py
+++ b/recipes/AMI/Diarization/experiment.py
@@ -18,24 +18,25 @@ Authors
  * Nauman Dawalatabad 2020
 """
 
-import os
-import sys
-import torch
-import logging
-import pickle
-import json
 import glob
+import json
+import logging
+import os
+import pickle
 import shutil
+import sys
+
 import numpy as np
-import speechbrain as sb
-from tqdm.contrib import tqdm
+import torch
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main
-from speechbrain.processing.PLDA_LDA import StatObject_SB
+from tqdm.contrib import tqdm
+
+import speechbrain as sb
+from speechbrain.dataio.dataio import read_audio, read_audio_multichannel
 from speechbrain.processing import diarization as diar
+from speechbrain.processing.PLDA_LDA import StatObject_SB
 from speechbrain.utils.DER import DER
-from speechbrain.dataio.dataio import read_audio
-from speechbrain.dataio.dataio import read_audio_multichannel
+from speechbrain.utils.distributed import run_on_main
 
 np.random.seed(1234)
 

--- a/recipes/AMI/ami_prepare.py
+++ b/recipes/AMI/ami_prepare.py
@@ -6,17 +6,15 @@ Download: http://groups.inf.ed.ac.uk/ami/download/
 Prepares metadata files (JSON) from manual annotations "segments/" using RTTM format (Oracle VAD).
 """
 
-import os
-import logging
-import xml.etree.ElementTree as et
 import glob
 import json
+import logging
+import os
+import xml.etree.ElementTree as et
+
 from ami_splits import get_AMI_split
 
-from speechbrain.dataio.dataio import (
-    load_pkl,
-    save_pkl,
-)
+from speechbrain.dataio.dataio import load_pkl, save_pkl
 
 logger = logging.getLogger(__name__)
 SAMPLERATE = 16000

--- a/recipes/Aishell1Mix/meta/preprocess_dynamic_mixing.py
+++ b/recipes/Aishell1Mix/meta/preprocess_dynamic_mixing.py
@@ -8,18 +8,18 @@ Author
 Samuele Cornell, 2020
 """
 
-import os
 import argparse
-from pathlib import Path
-import tqdm
-import torchaudio
 import glob
+import os
+from pathlib import Path
+
+import numpy as np
+import torch
+import torchaudio
+import tqdm
 
 # from oct2py import octave
 from scipy import signal
-import numpy as np
-import torch
-
 
 parser = argparse.ArgumentParser(
     "utility for resampling all audio files in a folder recursively"

--- a/recipes/Aishell1Mix/prepare_data.py
+++ b/recipes/Aishell1Mix/prepare_data.py
@@ -5,16 +5,17 @@ Author
  * Cem Subakan 2020
 """
 
-import os
 import csv
+import functools
+import glob
+import os
 import tarfile
 import zipfile
-import glob
-import tqdm.contrib.concurrent
-import soundfile as sf
-import functools
-from pysndfx import AudioEffectsChain
 from urllib.request import urlretrieve
+
+import soundfile as sf
+import tqdm.contrib.concurrent
+from pysndfx import AudioEffectsChain
 
 
 def prepare_aishell1mix(

--- a/recipes/Aishell1Mix/separation/dynamic_mixing.py
+++ b/recipes/Aishell1Mix/separation/dynamic_mixing.py
@@ -6,17 +6,19 @@ Authors
     * Cem Subakan 2021
 """
 
-import speechbrain as sb
-import numpy as np
-import torch
-import torchaudio
 import glob
 import os
-from speechbrain.dataio.batch import PaddedBatch
-from tqdm import tqdm
-import warnings
-import pyloudnorm
 import random
+import warnings
+
+import numpy as np
+import pyloudnorm
+import torch
+import torchaudio
+from tqdm import tqdm
+
+import speechbrain as sb
+from speechbrain.dataio.batch import PaddedBatch
 
 
 def build_spk_hashtable_aishell1mix(hparams):

--- a/recipes/Aishell1Mix/separation/scripts/create_aishell1_metadata.py
+++ b/recipes/Aishell1Mix/separation/scripts/create_aishell1_metadata.py
@@ -1,8 +1,9 @@
-import os
 import argparse
-import soundfile as sf
-import pandas as pd
 import glob
+import os
+
+import pandas as pd
+import soundfile as sf
 from tqdm import tqdm
 
 # Global parameter

--- a/recipes/Aishell1Mix/separation/scripts/create_aishell1mix_from_metadata.py
+++ b/recipes/Aishell1Mix/separation/scripts/create_aishell1mix_from_metadata.py
@@ -1,13 +1,14 @@
-import os
 import argparse
-import soundfile as sf
-import pandas as pd
-import numpy as np
 import functools
-from scipy.signal import resample_poly
-import tqdm.contrib.concurrent
 import glob
+import os
 import shutil
+
+import numpy as np
+import pandas as pd
+import soundfile as sf
+import tqdm.contrib.concurrent
+from scipy.signal import resample_poly
 
 # eps secures log and division
 EPS = 1e-10

--- a/recipes/Aishell1Mix/separation/scripts/create_wham_metadata.py
+++ b/recipes/Aishell1Mix/separation/scripts/create_wham_metadata.py
@@ -1,8 +1,9 @@
-import os
 import argparse
-import soundfile as sf
-import pandas as pd
 import glob
+import os
+
+import pandas as pd
+import soundfile as sf
 from tqdm import tqdm
 
 # Global parameter

--- a/recipes/Aishell1Mix/separation/train.py
+++ b/recipes/Aishell1Mix/separation/train.py
@@ -21,20 +21,22 @@ Authors
  * Jianyuan Zhong 2020
 """
 
-import os
 import csv
-import sys
-import torch
-import torchaudio
-import numpy as np
-from tqdm import tqdm
-import speechbrain as sb
-import torch.nn.functional as F
-import speechbrain.nnet.schedulers as schedulers
-from speechbrain.utils.distributed import run_on_main
-from hyperpyyaml import load_hyperpyyaml
 import logging
+import os
+import sys
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+import torchaudio
+from hyperpyyaml import load_hyperpyyaml
+from tqdm import tqdm
+
+import speechbrain as sb
+import speechbrain.nnet.schedulers as schedulers
 from speechbrain.core import AMPConfig
+from speechbrain.utils.distributed import run_on_main
 
 
 # from: recipes/LibriMix/separation/train.py

--- a/recipes/AudioMNIST/audiomnist_prepare.py
+++ b/recipes/AudioMNIST/audiomnist_prepare.py
@@ -12,25 +12,23 @@ Artem Ploujnikov 2023
 Mirco Ravanelli 2023
 """
 
-import logging
 import csv
-import math
 import json
+import logging
+import math
 import os
-import torchaudio
-import speechbrain as sb
-
-from glob import glob
 from functools import partial
-from tqdm.auto import tqdm
-from torchaudio import functional as F
+from glob import glob
 from subprocess import list2cmdline
-from speechbrain.utils.superpowers import run_shell
+
+import torchaudio
+from torchaudio import functional as F
+from tqdm.auto import tqdm
+
+import speechbrain as sb
+from speechbrain.dataio.dataio import load_pkl, save_pkl
 from speechbrain.utils.data_utils import download_file
-from speechbrain.dataio.dataio import (
-    load_pkl,
-    save_pkl,
-)
+from speechbrain.utils.superpowers import run_shell
 
 DEFAULT_SPLITS = ["train", "valid", "test"]
 DEFAULT_AUDIOMNIST_REPO = "https://github.com/soerenab/AudioMNIST.git"

--- a/recipes/AudioMNIST/diffusion/train.py
+++ b/recipes/AudioMNIST/diffusion/train.py
@@ -13,29 +13,31 @@ Authors
  * Artem Ploujnikov 2022
 """
 import logging
-import sys
-import torch
-import speechbrain as sb
 import os
+import sys
 from collections import namedtuple
+from enum import Enum
+
+import torch
 from audiomnist_prepare import prepare_audiomnist
 from hyperpyyaml import load_hyperpyyaml
 from torchaudio import functional as AF
+
+import speechbrain as sb
 from speechbrain.dataio.dataio import length_to_mask, write_audio
 from speechbrain.dataio.dataset import apply_overfit_test
 from speechbrain.utils import data_utils
-from speechbrain.utils.train_logger import plot_spectrogram
-from enum import Enum
-from speechbrain.utils.distributed import run_on_main
 from speechbrain.utils.data_utils import (
     dict_value_combinations,
     dist_stats,
+    masked_max,
     masked_mean,
     masked_min,
-    masked_max,
     masked_std,
     match_shape,
 )
+from speechbrain.utils.distributed import run_on_main
+from speechbrain.utils.train_logger import plot_spectrogram
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/BinauralWSJ0Mix/prepare_data.py
+++ b/recipes/BinauralWSJ0Mix/prepare_data.py
@@ -7,8 +7,8 @@ Author
 
  """
 
-import os
 import csv
+import os
 
 
 def prepare_binaural_wsj0mix(

--- a/recipes/BinauralWSJ0Mix/separation/dynamic_mixing.py
+++ b/recipes/BinauralWSJ0Mix/separation/dynamic_mixing.py
@@ -1,13 +1,15 @@
-import speechbrain as sb
-import numpy as np
-import torch
-import torchaudio
 import glob
 import os
 import random
-from speechbrain.processing.signal_processing import rescale
-from speechbrain.dataio.batch import PaddedBatch
+
+import numpy as np
+import torch
+import torchaudio
 from scipy.signal import fftconvolve
+
+import speechbrain as sb
+from speechbrain.dataio.batch import PaddedBatch
+from speechbrain.processing.signal_processing import rescale
 
 """
 The functions to implement Dynamic Mixing For SpeechSeparation

--- a/recipes/BinauralWSJ0Mix/separation/train.py
+++ b/recipes/BinauralWSJ0Mix/separation/train.py
@@ -21,23 +21,25 @@ Authors
  * Zijian Huang 2022
 """
 
+import csv
+import logging
 import os
 import sys
+
+import numpy as np
 import torch
 import torch.nn.functional as F
 import torchaudio
+from hyperpyyaml import load_hyperpyyaml
+from pyroomacoustics.experimental.localization import tdoa
+from torch.nn import Conv1d
+from tqdm import tqdm
+
 import speechbrain as sb
 import speechbrain.nnet.schedulers as schedulers
-from speechbrain.utils.distributed import run_on_main
-from hyperpyyaml import load_hyperpyyaml
-import numpy as np
-from tqdm import tqdm
-import csv
-import logging
-from pyroomacoustics.experimental.localization import tdoa
-from speechbrain.processing.features import STFT, spectral_magnitude
-from torch.nn import Conv1d
 from speechbrain.core import AMPConfig
+from speechbrain.processing.features import STFT, spectral_magnitude
+from speechbrain.utils.distributed import run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/CVSS/S2ST/extract_code.py
+++ b/recipes/CVSS/S2ST/extract_code.py
@@ -5,22 +5,20 @@ Authors
  * Jarod Duret 2023
 """
 
-import logging
 import json
+import logging
 import pathlib as pl
 
 import joblib
+import numpy as np
 import torch
 import torchaudio
-import numpy as np
-from tqdm import tqdm
-import speechbrain as sb
-from speechbrain.dataio.dataio import (
-    load_pkl,
-    save_pkl,
-)
-from speechbrain.lobes.models.huggingface_transformers.wav2vec2 import Wav2Vec2
 from huggingface_hub import hf_hub_download
+from tqdm import tqdm
+
+import speechbrain as sb
+from speechbrain.dataio.dataio import load_pkl, save_pkl
+from speechbrain.lobes.models.huggingface_transformers.wav2vec2 import Wav2Vec2
 
 OPT_FILE = "opt_cvss_extract.pkl"
 TRAIN_JSON = "train.json"

--- a/recipes/CVSS/S2ST/train.py
+++ b/recipes/CVSS/S2ST/train.py
@@ -9,18 +9,20 @@
  * Jarod Duret 2023
 """
 
-import sys
-import torch
 import logging
 import pathlib as pl
-from hyperpyyaml import load_hyperpyyaml
-import speechbrain as sb
-from speechbrain.inference.vocoders import UnitHIFIGAN
-from speechbrain.inference.ASR import EncoderDecoderASR
-import tqdm
-import torchaudio
+import sys
+
 import numpy as np
+import torch
+import torchaudio
+import tqdm
+from hyperpyyaml import load_hyperpyyaml
 from torch.nn.parallel import DistributedDataParallel
+
+import speechbrain as sb
+from speechbrain.inference.ASR import EncoderDecoderASR
+from speechbrain.inference.vocoders import UnitHIFIGAN
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/CVSS/cvss_prepare.py
+++ b/recipes/CVSS/cvss_prepare.py
@@ -6,19 +6,17 @@ Authors
  * Jarod DURET 2023
 """
 
-import os
 import csv
 import json
 import logging
-import random
-import tqdm
+import os
 import pathlib as pl
+import random
 
 import torchaudio
-from speechbrain.dataio.dataio import (
-    load_pkl,
-    save_pkl,
-)
+import tqdm
+
+from speechbrain.dataio.dataio import load_pkl, save_pkl
 
 OPT_FILE = "opt_cvss_prepare.pkl"
 

--- a/recipes/CommonLanguage/common_language_prepare.py
+++ b/recipes/CommonLanguage/common_language_prepare.py
@@ -8,11 +8,13 @@ Author
 Pavlo Ruban 2021
 """
 
-import os
 import csv
 import logging
+import os
+
 import torchaudio
 from tqdm.contrib import tzip
+
 from speechbrain.utils.data_utils import get_all_files
 
 logger = logging.getLogger(__name__)

--- a/recipes/CommonLanguage/lang_id/train.py
+++ b/recipes/CommonLanguage/lang_id/train.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
+import logging
 import os
 import sys
-import logging
+
 import torchaudio
-import speechbrain as sb
-from hyperpyyaml import load_hyperpyyaml
 from common_language_prepare import prepare_common_language
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 
 """Recipe for training a LID system with CommonLanguage.
 

--- a/recipes/CommonVoice/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/CommonVoice/ASR/CTC/train_with_wav2vec.py
@@ -23,15 +23,17 @@ Authors
  * Titouan Parcollet 2021
 """
 
-import sys
-import torch
 import logging
-import speechbrain as sb
+import sys
+
+import torch
 import torchaudio
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.tokenizers.SentencePiece import SentencePiece
 from speechbrain.utils.data_utils import undo_padding
-from speechbrain.utils.distributed import run_on_main, if_main_process
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/CommonVoice/ASR/seq2seq/train.py
+++ b/recipes/CommonVoice/ASR/seq2seq/train.py
@@ -17,15 +17,17 @@ Authors
  * Titouan Parcollet 2020
 """
 
-import sys
-import torch
 import logging
-import speechbrain as sb
+import sys
+
+import torch
 import torchaudio
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.tokenizers.SentencePiece import SentencePiece
 from speechbrain.utils.data_utils import undo_padding
-from speechbrain.utils.distributed import run_on_main, if_main_process
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/CommonVoice/ASR/seq2seq/train_with_wav2vec.py
+++ b/recipes/CommonVoice/ASR/seq2seq/train_with_wav2vec.py
@@ -25,15 +25,17 @@ Authors
  * Titouan Parcollet 2020
 """
 
-import sys
-import torch
 import logging
-import speechbrain as sb
+import sys
+
+import torch
 import torchaudio
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.tokenizers.SentencePiece import SentencePiece
 from speechbrain.utils.data_utils import undo_padding
-from speechbrain.utils.distributed import run_on_main, if_main_process
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/CommonVoice/ASR/transducer/train.py
+++ b/recipes/CommonVoice/ASR/transducer/train.py
@@ -25,15 +25,17 @@ Authors
  * Peter Plantinga 2020
 """
 
-import sys
-import torch
 import logging
-import speechbrain as sb
+import sys
+
+import torch
 import torchaudio
-from speechbrain.utils.distributed import run_on_main, if_main_process
-from speechbrain.utils.data_utils import undo_padding
-from speechbrain.tokenizers.SentencePiece import SentencePiece
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
+from speechbrain.tokenizers.SentencePiece import SentencePiece
+from speechbrain.utils.data_utils import undo_padding
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/CommonVoice/ASR/transformer/train.py
+++ b/recipes/CommonVoice/ASR/transformer/train.py
@@ -25,16 +25,17 @@ Authors
  * Jianyuan Zhong 2020
  * Pooneh Mousavi 2023
 """
+import logging
 import sys
+
 import torch
 import torchaudio
-import logging
-import speechbrain as sb
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.tokenizers.SentencePiece import SentencePiece
-from speechbrain.utils.distributed import run_on_main, if_main_process
-from speechbrain.utils.data_utils import undo_padding
 
+import speechbrain as sb
+from speechbrain.tokenizers.SentencePiece import SentencePiece
+from speechbrain.utils.data_utils import undo_padding
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/CommonVoice/ASR/transformer/train_with_whisper.py
+++ b/recipes/CommonVoice/ASR/transformer/train_with_whisper.py
@@ -9,15 +9,17 @@ To run this recipe, do the following:
  * Pooneh Mousavi 2022
 """
 
-import sys
-import torch
 import logging
+import sys
+
+import torch
 import torchaudio
-import speechbrain as sb
-from speechbrain.utils.distributed import run_on_main, if_main_process
-from speechbrain.utils.data_utils import undo_padding
 from hyperpyyaml import load_hyperpyyaml
 from transformers.models.whisper.tokenization_whisper import LANGUAGES
+
+import speechbrain as sb
+from speechbrain.utils.data_utils import undo_padding
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/CommonVoice/LM/train.py
+++ b/recipes/CommonVoice/LM/train.py
@@ -8,14 +8,15 @@ Author
  * Pooneh Mousavi 2023
 """
 
-import os
 import csv
-import sys
 import logging
-import speechbrain as sb
-from speechbrain.utils.distributed import run_on_main
+import os
+import sys
+
 from hyperpyyaml import load_hyperpyyaml
 
+import speechbrain as sb
+from speechbrain.utils.distributed import run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/CommonVoice/common_voice_prepare.py
+++ b/recipes/CommonVoice/common_voice_prepare.py
@@ -9,16 +9,16 @@ Pooneh Mousavi 2022
 Salima Mdhaffar 2023
 """
 
-from dataclasses import dataclass
-import os
 import csv
-import re
-import logging
-import unicodedata
 import functools
+import logging
+import os
+import re
+import unicodedata
+from dataclasses import dataclass
 
-from speechbrain.utils.parallel import parallel_map
 from speechbrain.dataio.dataio import read_audio_info
+from speechbrain.utils.parallel import parallel_map
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/CommonVoice/quantization/train.py
+++ b/recipes/CommonVoice/quantization/train.py
@@ -7,17 +7,18 @@ Author
  * Pooneh Mousavi 2023
 """
 
+import logging
 import os
 import sys
-import logging
-import speechbrain as sb
+
 import torchaudio
-from speechbrain.utils.distributed import run_on_main
 from hyperpyyaml import load_hyperpyyaml
 from torch.utils.data import DataLoader
-from speechbrain.dataio.dataloader import LoopedLoader
-from speechbrain.utils.kmeans import fetch_kmeans_model, train, save_model
 
+import speechbrain as sb
+from speechbrain.dataio.dataloader import LoopedLoader
+from speechbrain.utils.distributed import run_on_main
+from speechbrain.utils.kmeans import fetch_kmeans_model, save_model, train
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/CommonVoice/self-supervised-learning/wav2vec2/train_hf_wav2vec2.py
+++ b/recipes/CommonVoice/self-supervised-learning/wav2vec2/train_hf_wav2vec2.py
@@ -26,12 +26,14 @@ Authors
  * Titouan Parcollet 2021
  * Yan Gao 2021
 """
-import sys
-import torch
 import logging
-import speechbrain as sb
+import sys
+
+import torch
 import torchaudio
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
 
 logger = logging.getLogger(__name__)

--- a/recipes/DNS/create_wds_shards.py
+++ b/recipes/DNS/create_wds_shards.py
@@ -7,11 +7,10 @@
 # Author(s): Tanel Alumäe, Nik Vaessen, Sangeet Sagar (2023)
 ################################################################################
 
-import os
-import json
-from tqdm import tqdm
-import pathlib
 import argparse
+import json
+import os
+import pathlib
 import random
 from collections import defaultdict
 
@@ -19,6 +18,7 @@ import librosa
 import torch
 import torchaudio
 import webdataset as wds
+from tqdm import tqdm
 
 ################################################################################
 # methods for writing the shards

--- a/recipes/DNS/dns_download.py
+++ b/recipes/DNS/dns_download.py
@@ -21,18 +21,19 @@ Authors
     * Sangeet Sagar 2022
 """
 
-import os
-import ssl
-import shutil
-import zipfile
-import tarfile
-import certifi
 import argparse
 import fileinput
-import requests
+import os
+import shutil
+import ssl
+import tarfile
 import urllib.request
-from tqdm.auto import tqdm
+import zipfile
 from concurrent.futures import ThreadPoolExecutor
+
+import certifi
+import requests
+from tqdm.auto import tqdm
 
 BLOB_NAMES = [
     "clean_fullband/datasets_fullband.clean_fullband.VocalSet_48kHz_mono_000_NA_NA.tar.bz2",

--- a/recipes/DNS/enhancement/composite_eval.py
+++ b/recipes/DNS/enhancement/composite_eval.py
@@ -6,13 +6,14 @@ Authors
  * adiyoss (https://github.com/adiyoss)
 """
 
-from scipy.linalg import toeplitz
-from tqdm import tqdm
-from pesq import pesq
-import librosa
-import numpy as np
 import os
 import sys
+
+import librosa
+import numpy as np
+from pesq import pesq
+from scipy.linalg import toeplitz
+from tqdm import tqdm
 
 
 def eval_composite(ref_wav, deg_wav, sample_rate):

--- a/recipes/DNS/enhancement/train.py
+++ b/recipes/DNS/enhancement/train.py
@@ -19,35 +19,34 @@ Authors
  * Jianyuan Zhong 2020
 """
 
-import os
-import glob
-import sys
 import csv
+import glob
 import json
 import logging
-import numpy as np
-from tqdm import tqdm
-from typing import Dict
+import os
+import sys
 from functools import partial
+from typing import Dict
 
-import torch
-import torchaudio
 import braceexpand
-import webdataset as wds
+import numpy as np
+import torch
 import torch.nn.functional as F
-
-import speechbrain as sb
-from hyperpyyaml import load_hyperpyyaml
+import torchaudio
+import webdataset as wds
 from composite_eval import eval_composite
-import speechbrain.nnet.schedulers as schedulers
-from speechbrain.utils.distributed import run_on_main
-from speechbrain.utils.metric_stats import MetricStats
-from speechbrain.processing.features import spectral_magnitude
-from speechbrain.dataio.batch import PaddedBatch
-from speechbrain.core import AMPConfig
-
+from hyperpyyaml import load_hyperpyyaml
 from pesq import pesq
 from pystoi import stoi
+from tqdm import tqdm
+
+import speechbrain as sb
+import speechbrain.nnet.schedulers as schedulers
+from speechbrain.core import AMPConfig
+from speechbrain.dataio.batch import PaddedBatch
+from speechbrain.processing.features import spectral_magnitude
+from speechbrain.utils.distributed import run_on_main
+from speechbrain.utils.metric_stats import MetricStats
 
 
 # Define training procedure

--- a/recipes/DNS/noisyspeech_synthesizer/audiolib.py
+++ b/recipes/DNS/noisyspeech_synthesizer/audiolib.py
@@ -6,12 +6,13 @@ Ownership: Microsoft
     chkarada
 """
 
+import glob
 import os
+import subprocess
+
+import librosa
 import numpy as np
 import soundfile as sf
-import subprocess
-import glob
-import librosa
 
 EPS = np.finfo(float).eps
 np.random.seed(0)

--- a/recipes/DNS/noisyspeech_synthesizer/noisyspeech_synthesizer_singleprocess.py
+++ b/recipes/DNS/noisyspeech_synthesizer/noisyspeech_synthesizer_singleprocess.py
@@ -17,36 +17,28 @@ audio. The output is again stored in webdataset shards.
 # speech sourcefile once (from the webdataset shards), as it does not
 # randomly sample from these files
 
-import sys
+import json
 import os
-from pathlib import Path
 import random
+import sys
 import time
+from collections import defaultdict
+from functools import partial
+from pathlib import Path
+from typing import Dict
 
+import librosa
 import numpy as np
+import pandas as pd
+import torch
+import utils
+import webdataset as wds
+from audiolib import activitydetector, is_clipped, segmental_snr_mixer
+from hyperpyyaml import load_hyperpyyaml
 from scipy import signal
 from scipy.io import wavfile
 
-import librosa
-
-import utils
-from audiolib import (
-    segmental_snr_mixer,
-    activitydetector,
-    is_clipped,
-)
-
-import pandas as pd
-import json
-from functools import partial
-from typing import Dict
-from collections import defaultdict
-
-
 import speechbrain as sb
-import webdataset as wds
-from hyperpyyaml import load_hyperpyyaml
-import torch
 
 np.random.seed(5)
 random.seed(5)

--- a/recipes/DNS/noisyspeech_synthesizer/utils.py
+++ b/recipes/DNS/noisyspeech_synthesizer/utils.py
@@ -6,10 +6,10 @@ Ownership: Microsoft
     rocheng
 """
 
-import os
 import csv
-from shutil import copyfile
 import glob
+import os
+from shutil import copyfile
 
 
 def get_dir(cfg, param_name, new_dir_name):

--- a/recipes/DVoice/ASR/CTC/train_with_wav2vec2.py
+++ b/recipes/DVoice/ASR/CTC/train_with_wav2vec2.py
@@ -23,15 +23,17 @@ Authors
  * Naira Abdou Mohamed 2022
 """
 
-import sys
-import torch
 import logging
-import speechbrain as sb
+import sys
+
+import torch
 import torchaudio
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.tokenizers.SentencePiece import SentencePiece
 from speechbrain.utils.data_utils import undo_padding
-from speechbrain.utils.distributed import run_on_main, if_main_process
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/DVoice/dvoice_prepare.py
+++ b/recipes/DVoice/dvoice_prepare.py
@@ -7,17 +7,19 @@ Author
 Abdou Mohamed Naira 2022
 """
 
-import os
 import csv
-import re
+import glob
 import logging
-import unicodedata
-from tqdm.contrib import tzip
+import os
 import random
+import re
+import unicodedata
+
+import numpy as np
 import pandas as pd
 from tqdm import tqdm
-import numpy as np
-import glob
+from tqdm.contrib import tzip
+
 from speechbrain.dataio.dataio import read_audio_info
 
 logger = logging.getLogger(__name__)

--- a/recipes/ESC50/classification/confusion_matrix_fig.py
+++ b/recipes/ESC50/classification/confusion_matrix_fig.py
@@ -6,9 +6,10 @@ Authors
  * Ala Eddine Limame 2021
 """
 
-import numpy as np
-import matplotlib.pyplot as plt
 import itertools
+
+import matplotlib.pyplot as plt
+import numpy as np
 
 
 def create_cm_fig(cm, display_labels):

--- a/recipes/ESC50/classification/train_classifier.py
+++ b/recipes/ESC50/classification/train_classifier.py
@@ -15,15 +15,17 @@ Based on the Urban8k recipe by
 """
 import os
 import sys
+
+import numpy as np
 import torch
 import torchaudio
-import speechbrain as sb
-from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main
-from esc50_prepare import prepare_esc50
-from sklearn.metrics import confusion_matrix
-import numpy as np
 from confusion_matrix_fig import create_cm_fig
+from esc50_prepare import prepare_esc50
+from hyperpyyaml import load_hyperpyyaml
+from sklearn.metrics import confusion_matrix
+
+import speechbrain as sb
+from speechbrain.utils.distributed import run_on_main
 
 
 class ESC50Brain(sb.core.Brain):

--- a/recipes/ESC50/esc50_prepare.py
+++ b/recipes/ESC50/esc50_prepare.py
@@ -11,13 +11,14 @@ Authors:
  Adapted from the Urbansound8k recipe.
 """
 
-import os
-import shutil
 import json
 import logging
+import os
+import shutil
+
 import torchaudio
-from speechbrain.dataio.dataio import read_audio
-from speechbrain.dataio.dataio import load_data_csv
+
+from speechbrain.dataio.dataio import load_data_csv, read_audio
 from speechbrain.utils.fetching import fetch
 
 logger = logging.getLogger(__name__)

--- a/recipes/ESC50/interpret/train_l2i.py
+++ b/recipes/ESC50/interpret/train_l2i.py
@@ -7,16 +7,18 @@ Authors
 """
 import os
 import sys
-import torch
-import torchaudio
-import speechbrain as sb
-from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main
-from esc50_prepare import prepare_esc50
-from speechbrain.utils.metric_stats import MetricStats
 from os import makedirs
+
+import torch
 import torch.nn.functional as F
+import torchaudio
+from esc50_prepare import prepare_esc50
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.processing.NMF import spectral_phase
+from speechbrain.utils.distributed import run_on_main
+from speechbrain.utils.metric_stats import MetricStats
 
 eps = 1e-10
 

--- a/recipes/ESC50/interpret/train_nmf.py
+++ b/recipes/ESC50/interpret/train_nmf.py
@@ -11,12 +11,14 @@ Authors
 
 
 import sys
+
 import torch
-import speechbrain as sb
-from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main
 from esc50_prepare import prepare_esc50
+from hyperpyyaml import load_hyperpyyaml
 from train_l2i import dataio_prep
+
+import speechbrain as sb
+from speechbrain.utils.distributed import run_on_main
 
 
 class NMFBrain(sb.core.Brain):

--- a/recipes/ESC50/interpret/train_piq.py
+++ b/recipes/ESC50/interpret/train_piq.py
@@ -7,17 +7,19 @@ Authors
 """
 import os
 import sys
-import torch
-import torchaudio
-import speechbrain as sb
-from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main
-from esc50_prepare import prepare_esc50
-from speechbrain.utils.metric_stats import MetricStats
 from os import makedirs
-import torch.nn.functional as F
-from speechbrain.processing.NMF import spectral_phase
+
 import matplotlib.pyplot as plt
+import torch
+import torch.nn.functional as F
+import torchaudio
+from esc50_prepare import prepare_esc50
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
+from speechbrain.processing.NMF import spectral_phase
+from speechbrain.utils.distributed import run_on_main
+from speechbrain.utils.metric_stats import MetricStats
 
 eps = 1e-10
 

--- a/recipes/Fisher-Callhome-Spanish/ST/transformer/train.py
+++ b/recipes/Fisher-Callhome-Spanish/ST/transformer/train.py
@@ -11,14 +11,14 @@ Authors
  * YAO-FEI, CHENG 2021
 """
 
-import sys
-import torch
 import logging
+import sys
+
+import torch
+from hyperpyyaml import load_hyperpyyaml
+from sacremoses import MosesDetokenizer
 
 import speechbrain as sb
-
-from sacremoses import MosesDetokenizer
-from hyperpyyaml import load_hyperpyyaml
 from speechbrain.utils.distributed import run_on_main
 
 logger = logging.getLogger(__name__)

--- a/recipes/Fisher-Callhome-Spanish/Tokenizer/train.py
+++ b/recipes/Fisher-Callhome-Spanish/Tokenizer/train.py
@@ -15,9 +15,10 @@ Authors
 
 import sys
 
-import speechbrain as sb
-from hyperpyyaml import load_hyperpyyaml
 from fisher_callhome_prepare import prepare_fisher_callhome_spanish
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides

--- a/recipes/Fisher-Callhome-Spanish/fisher_callhome_prepare.py
+++ b/recipes/Fisher-Callhome-Spanish/fisher_callhome_prepare.py
@@ -6,23 +6,22 @@ Author
 YAO-FEI, CHENG 2021
 """
 
+import json
+import logging
 import os
 import re
-import json
 import string
-import logging
 import subprocess
-
-from typing import List
 from dataclasses import dataclass, field
+from typing import List
 
 import torch
 import torchaudio
-
 from tqdm import tqdm
+
+from speechbrain.augment.time_domain import Resample
 from speechbrain.utils.data_utils import get_all_files
 from speechbrain.utils.torch_audio_backend import check_torchaudio_backend
-from speechbrain.augment.time_domain import Resample
 
 try:
     from sacremoses import MosesPunctNormalizer, MosesTokenizer

--- a/recipes/Google-speech-commands/prepare_GSC.py
+++ b/recipes/Google-speech-commands/prepare_GSC.py
@@ -9,18 +9,20 @@ David Raby-Pepin 2021
 
 """
 
-import os
-from os import walk
-import glob
-import shutil
-import logging
-import torch
-import re
-import hashlib
 import copy
+import glob
+import hashlib
+import logging
+import os
+import re
+import shutil
+from os import walk
+
 import numpy as np
-from speechbrain.utils.data_utils import download_file
+import torch
+
 from speechbrain.dataio.dataio import read_audio
+from speechbrain.utils.data_utils import download_file
 
 try:
     import pandas as pd

--- a/recipes/Google-speech-commands/train.py
+++ b/recipes/Google-speech-commands/train.py
@@ -17,11 +17,12 @@ Author
 """
 import os
 import sys
+
 import torch
 import torchaudio
-import speechbrain as sb
 from hyperpyyaml import load_hyperpyyaml
 
+import speechbrain as sb
 import speechbrain.nnet.CNN
 from speechbrain.utils.distributed import run_on_main
 

--- a/recipes/IEMOCAP/emotion_recognition/iemocap_prepare.py
+++ b/recipes/IEMOCAP/emotion_recognition/iemocap_prepare.py
@@ -9,11 +9,12 @@ Authors:
  * Yingzhi Wang, 2022
 """
 
-import os
-import re
 import json
-import random
 import logging
+import os
+import random
+import re
+
 from speechbrain.dataio.dataio import read_audio
 
 logger = logging.getLogger(__name__)

--- a/recipes/IEMOCAP/emotion_recognition/train.py
+++ b/recipes/IEMOCAP/emotion_recognition/train.py
@@ -11,15 +11,17 @@ Authors
  * Pierre-Yves Yanni 2021
 """
 
+import csv
 import os
 import sys
-import csv
-import speechbrain as sb
-import torch
-from torch.utils.data import DataLoader
 from enum import Enum, auto
-from tqdm.contrib import tqdm
+
+import torch
 from hyperpyyaml import load_hyperpyyaml
+from torch.utils.data import DataLoader
+from tqdm.contrib import tqdm
+
+import speechbrain as sb
 
 
 class EmoIdBrain(sb.Brain):

--- a/recipes/IEMOCAP/emotion_recognition/train_with_wav2vec2.py
+++ b/recipes/IEMOCAP/emotion_recognition/train_with_wav2vec2.py
@@ -13,8 +13,10 @@ Authors
 
 import os
 import sys
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 
 
 class EmoIdBrain(sb.Brain):

--- a/recipes/IEMOCAP/iemocap_prepare.py
+++ b/recipes/IEMOCAP/iemocap_prepare.py
@@ -9,11 +9,12 @@ Authors:
  * Yingzhi Wang, 2022
 """
 
-import os
-import re
 import json
-import random
 import logging
+import os
+import random
+import re
+
 from speechbrain.dataio.dataio import read_audio
 
 logger = logging.getLogger(__name__)

--- a/recipes/IEMOCAP/quantization/train.py
+++ b/recipes/IEMOCAP/quantization/train.py
@@ -7,16 +7,18 @@ Author
  * Pooneh Mousavi 2023
 """
 
+import logging
 import os
 import sys
-import logging
-import speechbrain as sb
-from speechbrain.utils.distributed import run_on_main
+
+import torchaudio
 from hyperpyyaml import load_hyperpyyaml
 from torch.utils.data import DataLoader
+
+import speechbrain as sb
 from speechbrain.dataio.dataloader import LoopedLoader
-from speechbrain.utils.kmeans import fetch_kmeans_model, train, save_model
-import torchaudio
+from speechbrain.utils.distributed import run_on_main
+from speechbrain.utils.kmeans import fetch_kmeans_model, save_model, train
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/IWSLT22_lowresource/AST/transformer/train.py
+++ b/recipes/IWSLT22_lowresource/AST/transformer/train.py
@@ -5,14 +5,16 @@ Author
  * Marcely Zanon Boito, 2022
 """
 
-import sys
-import torch
 import logging
+import sys
+
+import torch
+from hyperpyyaml import load_hyperpyyaml
+from sacremoses import MosesDetokenizer
+
 import speechbrain as sb
 from speechbrain.tokenizers.SentencePiece import SentencePiece
 from speechbrain.utils.distributed import run_on_main
-from hyperpyyaml import load_hyperpyyaml
-from sacremoses import MosesDetokenizer
 
 
 # Define training procedure

--- a/recipes/IWSLT22_lowresource/AST/transformer/train_samu.py
+++ b/recipes/IWSLT22_lowresource/AST/transformer/train_samu.py
@@ -5,12 +5,14 @@ Author
  * Ha Nguyen, 2023
 """
 
-import sys
-import torch
 import logging
-from hyperpyyaml import load_hyperpyyaml
-import speechbrain as sb
+import sys
+
+import torch
 import torch.nn.functional as F
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
 
 logger = logging.getLogger(__name__)

--- a/recipes/IWSLT22_lowresource/AST/transformer/train_with_samu_mbart.py
+++ b/recipes/IWSLT22_lowresource/AST/transformer/train_with_samu_mbart.py
@@ -5,15 +5,16 @@ Author
  * Ha Nguyen, 2023
 """
 
-import sys
-import torch
 import logging
+import sys
 
-import speechbrain as sb
-from speechbrain.utils.distributed import run_on_main
+import torch
 from hyperpyyaml import load_hyperpyyaml
 from sacremoses import MosesDetokenizer
 from torch.nn.parallel import DistributedDataParallel
+
+import speechbrain as sb
+from speechbrain.utils.distributed import run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/IWSLT22_lowresource/AST/transformer/train_with_w2v_mbart.py
+++ b/recipes/IWSLT22_lowresource/AST/transformer/train_with_w2v_mbart.py
@@ -5,15 +5,16 @@ Author
  * Ha Nguyen, 2023
 """
 
-import sys
-import torch
 import logging
+import sys
 
-import speechbrain as sb
-from speechbrain.utils.distributed import run_on_main
+import torch
 from hyperpyyaml import load_hyperpyyaml
 from sacremoses import MosesDetokenizer
 from torch.nn.parallel import DistributedDataParallel
+
+import speechbrain as sb
+from speechbrain.utils.distributed import run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/KsponSpeech/ASR/transformer/train.py
+++ b/recipes/KsponSpeech/ASR/transformer/train.py
@@ -34,13 +34,15 @@ Authors
  * Titouan Parcollet 2021, 2022
  * Dongwon Kim, Dongwoo Kim 2023
 """
-import sys
-import torch
 import logging
+import sys
 from pathlib import Path
-import speechbrain as sb
+
+import torch
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main, if_main_process
+
+import speechbrain as sb
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/KsponSpeech/LM/train.py
+++ b/recipes/KsponSpeech/LM/train.py
@@ -12,14 +12,15 @@ Authors
  * Ju-Chieh Chou 2020
  * Dongwon Kim, Dongwoo Kim 2023
 """
-import sys
 import logging
+import sys
 from pathlib import Path
+
 import torch
 from hyperpyyaml import load_hyperpyyaml
+
 import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
-
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/KsponSpeech/Tokenizer/train.py
+++ b/recipes/KsponSpeech/Tokenizer/train.py
@@ -17,8 +17,10 @@ Authors
 """
 
 import sys
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
 
 if __name__ == "__main__":

--- a/recipes/LJSpeech/TTS/fastspeech2/train.py
+++ b/recipes/LJSpeech/TTS/fastspeech2/train.py
@@ -11,18 +11,20 @@ synthesis' paper
  * Pradnya Kandarkar 2023
 """
 
+import logging
 import os
 import sys
-import torch
-import logging
-import torchaudio
-import numpy as np
-import speechbrain as sb
-from speechbrain.inference.vocoders import HIFIGAN
 from pathlib import Path
+
+import numpy as np
+import torch
+import torchaudio
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.data_utils import scalarize
+
+import speechbrain as sb
 from speechbrain.inference.text import GraphemeToPhoneme
+from speechbrain.inference.vocoders import HIFIGAN
+from speechbrain.utils.data_utils import scalarize
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 logger = logging.getLogger(__name__)

--- a/recipes/LJSpeech/TTS/fastspeech2/train_internal_alignment.py
+++ b/recipes/LJSpeech/TTS/fastspeech2/train_internal_alignment.py
@@ -10,16 +10,18 @@ Authors
 * Yingzhi Wang 2023
 """
 
+import logging
 import os
 import sys
-import torch
-import logging
-import torchaudio
+from pathlib import Path
+
 import numpy as np
+import torch
+import torchaudio
+from hyperpyyaml import load_hyperpyyaml
+
 import speechbrain as sb
 from speechbrain.inference.vocoders import HIFIGAN
-from pathlib import Path
-from hyperpyyaml import load_hyperpyyaml
 from speechbrain.utils.data_utils import scalarize
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"

--- a/recipes/LJSpeech/TTS/quantization/train.py
+++ b/recipes/LJSpeech/TTS/quantization/train.py
@@ -8,22 +8,23 @@ Authors
  * Jarod Duret 2023
 """
 
-import sys
-import logging
-import time
-import random
 import itertools
+import logging
 import pathlib as pl
+import random
+import sys
+import time
 
 import joblib
+import numpy as np
 import torch
 import torchaudio
 import tqdm
-import numpy as np
-from sklearn.cluster import MiniBatchKMeans
 from hyperpyyaml import load_hyperpyyaml
-import speechbrain as sb
 from ljspeech_prepare import prepare_ljspeech
+from sklearn.cluster import MiniBatchKMeans
+
+import speechbrain as sb
 from speechbrain.lobes.models.huggingface_wav2vec import HuggingFaceWav2Vec2
 
 

--- a/recipes/LJSpeech/TTS/tacotron2/train.py
+++ b/recipes/LJSpeech/TTS/tacotron2/train.py
@@ -17,13 +17,15 @@
  * Artem Ploujnikov 2021
  * Yingzhi Wang 2022
 """
-import torch
-import speechbrain as sb
-import sys
 import logging
+import sys
+
+import torch
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.text_to_sequence import text_to_sequence
+
+import speechbrain as sb
 from speechbrain.utils.data_utils import scalarize
+from speechbrain.utils.text_to_sequence import text_to_sequence
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/LJSpeech/TTS/vocoder/diffwave/train.py
+++ b/recipes/LJSpeech/TTS/vocoder/diffwave/train.py
@@ -6,13 +6,15 @@ Authors
  * Yingzhi Wang 2022
 """
 
-import torchaudio
 import logging
-import sys
-import torch
-import speechbrain as sb
 import os
+import sys
+
+import torch
+import torchaudio
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/LJSpeech/TTS/vocoder/hifi_gan/train.py
+++ b/recipes/LJSpeech/TTS/vocoder/hifi_gan/train.py
@@ -10,14 +10,16 @@ Authors
  * Yingzhi WANG 2022
 """
 
-import sys
-import torch
 import copy
+import os
+import sys
+
+import torch
+import torchaudio
 from hyperpyyaml import load_hyperpyyaml
+
 import speechbrain as sb
 from speechbrain.utils.data_utils import scalarize
-import torchaudio
-import os
 
 
 class HifiGanBrain(sb.Brain):

--- a/recipes/LJSpeech/TTS/vocoder/hifi_gan_unit/extract_code.py
+++ b/recipes/LJSpeech/TTS/vocoder/hifi_gan_unit/extract_code.py
@@ -5,20 +5,18 @@ Authors
  * Jarod Duret 2023
 """
 
-import logging
 import json
+import logging
 import pathlib as pl
 
 import joblib
+import numpy as np
 import torch
 import torchaudio
-import numpy as np
 from tqdm import tqdm
+
 import speechbrain as sb
-from speechbrain.dataio.dataio import (
-    load_pkl,
-    save_pkl,
-)
+from speechbrain.dataio.dataio import load_pkl, save_pkl
 from speechbrain.lobes.models.huggingface_transformers.wav2vec2 import Wav2Vec2
 
 OPT_FILE = "opt_ljspeech_extract.pkl"

--- a/recipes/LJSpeech/TTS/vocoder/hifi_gan_unit/train.py
+++ b/recipes/LJSpeech/TTS/vocoder/hifi_gan_unit/train.py
@@ -11,17 +11,18 @@ Authors
  * Yingzhi WANG 2022
 """
 
-import sys
 import copy
-import random
 import pathlib as pl
+import random
+import sys
 
-from hyperpyyaml import load_hyperpyyaml
-import speechbrain as sb
-from speechbrain.utils.data_utils import scalarize
+import numpy as np
 import torch
 import torchaudio
-import numpy as np
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
+from speechbrain.utils.data_utils import scalarize
 
 
 class HifiGanBrain(sb.Brain):

--- a/recipes/LJSpeech/ljspeech_prepare.py
+++ b/recipes/LJSpeech/ljspeech_prepare.py
@@ -8,23 +8,24 @@ Authors
  * Pradnya Kandarkar 2023
 """
 
-import os
 import csv
 import json
-import random
 import logging
+import os
+import random
+import re
+
+import numpy as np
+import tgt
 import torch
 import torchaudio
-import numpy as np
 from tqdm import tqdm
-from speechbrain.utils.data_utils import download_file
-from speechbrain.dataio.dataio import load_pkl, save_pkl
-import tgt
-from speechbrain.inference.text import GraphemeToPhoneme
-import re
 from unidecode import unidecode
-from speechbrain.utils.text_to_sequence import _g2p_keep_punctuations
 
+from speechbrain.dataio.dataio import load_pkl, save_pkl
+from speechbrain.inference.text import GraphemeToPhoneme
+from speechbrain.utils.data_utils import download_file
+from speechbrain.utils.text_to_sequence import _g2p_keep_punctuations
 
 logger = logging.getLogger(__name__)
 OPT_FILE = "opt_ljspeech_prepare.pkl"

--- a/recipes/LJSpeech/quantization/train.py
+++ b/recipes/LJSpeech/quantization/train.py
@@ -7,17 +7,18 @@ Author
  * Pooneh Mousavi 2023
 """
 
+import logging
 import os
 import sys
-import logging
-import speechbrain as sb
-from speechbrain.utils.distributed import run_on_main
+
+import torchaudio
 from hyperpyyaml import load_hyperpyyaml
 from torch.utils.data import DataLoader
-from speechbrain.dataio.dataloader import LoopedLoader
-from speechbrain.utils.kmeans import fetch_kmeans_model, train, save_model
-import torchaudio
 
+import speechbrain as sb
+from speechbrain.dataio.dataloader import LoopedLoader
+from speechbrain.utils.distributed import run_on_main
+from speechbrain.utils.kmeans import fetch_kmeans_model, save_model, train
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/LibriMix/meta/preprocess_dynamic_mixing.py
+++ b/recipes/LibriMix/meta/preprocess_dynamic_mixing.py
@@ -8,18 +8,18 @@ Author
 Samuele Cornell, 2020
 """
 
-import os
 import argparse
-from pathlib import Path
-import tqdm
-import torchaudio
 import glob
+import os
+from pathlib import Path
+
+import numpy as np
+import torch
+import torchaudio
+import tqdm
 
 # from oct2py import octave
 from scipy import signal
-import numpy as np
-import torch
-
 
 parser = argparse.ArgumentParser(
     "utility for resampling all audio files in a folder recursively"

--- a/recipes/LibriMix/prepare_data.py
+++ b/recipes/LibriMix/prepare_data.py
@@ -5,8 +5,8 @@ Author
  * Cem Subakan 2020
 """
 
-import os
 import csv
+import os
 
 
 def prepare_librimix(

--- a/recipes/LibriMix/separation/dynamic_mixing.py
+++ b/recipes/LibriMix/separation/dynamic_mixing.py
@@ -1,14 +1,16 @@
-import speechbrain as sb
-import numpy as np
-import torch
-import torchaudio
 import glob
 import os
-from speechbrain.dataio.batch import PaddedBatch
-from tqdm import tqdm
-import warnings
-import pyloudnorm
 import random
+import warnings
+
+import numpy as np
+import pyloudnorm
+import torch
+import torchaudio
+from tqdm import tqdm
+
+import speechbrain as sb
+from speechbrain.dataio.batch import PaddedBatch
 
 """
 The functions to implement Dynamic Mixing For SpeechSeparation

--- a/recipes/LibriMix/separation/train.py
+++ b/recipes/LibriMix/separation/train.py
@@ -21,20 +21,22 @@ Authors
  * Jianyuan Zhong 2020
 """
 
+import csv
+import logging
 import os
 import sys
+
+import numpy as np
 import torch
 import torch.nn.functional as F
 import torchaudio
+from hyperpyyaml import load_hyperpyyaml
+from tqdm import tqdm
+
 import speechbrain as sb
 import speechbrain.nnet.schedulers as schedulers
-from speechbrain.utils.distributed import run_on_main
-from hyperpyyaml import load_hyperpyyaml
-import numpy as np
-from tqdm import tqdm
-import csv
-import logging
 from speechbrain.core import AMPConfig
+from speechbrain.utils.distributed import run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/LibriParty/VAD/commonlanguage_prepare.py
+++ b/recipes/LibriParty/VAD/commonlanguage_prepare.py
@@ -1,6 +1,8 @@
-import os
 import logging
+import os
+
 import torchaudio
+
 import speechbrain as sb
 from speechbrain.utils.data_utils import get_all_files
 

--- a/recipes/LibriParty/VAD/data_augment.py
+++ b/recipes/LibriParty/VAD/data_augment.py
@@ -4,9 +4,10 @@ Authors
  * Mirco Ravanelli 2020
 """
 
+import random
+
 import torch
 import torchaudio
-import random
 
 # fade-in/fade-out definition
 fade_in = torchaudio.transforms.Fade(fade_in_len=1000, fade_out_len=0)

--- a/recipes/LibriParty/VAD/libriparty_prepare.py
+++ b/recipes/LibriParty/VAD/libriparty_prepare.py
@@ -13,12 +13,12 @@ Authors
   * Arjun V 2021
 """
 
-import numpy as np
-import pandas as pd
 import json
 import logging
 from collections import OrderedDict
 
+import numpy as np
+import pandas as pd
 
 """ Global variables"""
 logger = logging.getLogger(__name__)

--- a/recipes/LibriParty/VAD/musan_prepare.py
+++ b/recipes/LibriParty/VAD/musan_prepare.py
@@ -1,6 +1,8 @@
-import os
 import logging
+import os
+
 import torchaudio
+
 import speechbrain as sb
 from speechbrain.utils.data_utils import get_all_files
 

--- a/recipes/LibriParty/VAD/train.py
+++ b/recipes/LibriParty/VAD/train.py
@@ -22,14 +22,16 @@ Authors
  * Mirco Ravanelli 2021
 """
 
-import sys
-import torch
 import logging
+import sys
+
 import numpy as np
-import speechbrain as sb
-from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main
+import torch
 from data_augment import augment_data
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
+from speechbrain.utils.distributed import run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/LibriParty/generate_dataset/create_custom_dataset.py
+++ b/recipes/LibriParty/generate_dataset/create_custom_dataset.py
@@ -6,18 +6,20 @@ Author
 Samuele Cornell, 2020
 """
 
-import os
-import sys
 import json
+import os
 import random
-import numpy as np
-import speechbrain as sb
-from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.data_utils import get_all_files
-from local.create_mixtures_metadata import create_metadata
-from local.create_mixtures_from_metadata import create_mixture
+import sys
 from pathlib import Path
+
+import numpy as np
+from hyperpyyaml import load_hyperpyyaml
+from local.create_mixtures_from_metadata import create_mixture
+from local.create_mixtures_metadata import create_metadata
 from tqdm import tqdm
+
+import speechbrain as sb
+from speechbrain.utils.data_utils import get_all_files
 
 # Load hyperparameters file with command-line overrides
 params_file, run_opts, overrides = sb.core.parse_arguments(sys.argv[1:])

--- a/recipes/LibriParty/generate_dataset/download_required_data.py
+++ b/recipes/LibriParty/generate_dataset/download_required_data.py
@@ -8,8 +8,10 @@ Samuele Cornell, 2020
 
 import argparse
 import os
-from speechbrain.utils.data_utils import download_file
+
 from local.resample_folder import resample_folder
+
+from speechbrain.utils.data_utils import download_file
 
 LIBRISPEECH_URLS = [
     "http://www.openslr.org/resources/12/test-clean.tar.gz",

--- a/recipes/LibriParty/generate_dataset/get_dataset_from_metadata.py
+++ b/recipes/LibriParty/generate_dataset/get_dataset_from_metadata.py
@@ -6,14 +6,16 @@ Samuele Cornell, 2020
 Mirco Ravanelli, 2020
 """
 
+import json
 import os
 import sys
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.data_utils import download_file
 from local.create_mixtures_from_metadata import create_mixture
-import json
 from tqdm import tqdm
+
+import speechbrain as sb
+from speechbrain.utils.data_utils import download_file
 
 URL_METADATA = (
     "https://www.dropbox.com/s/0u6x6ndyedb4rl7/LibriParty_metadata.zip?dl=1"

--- a/recipes/LibriParty/generate_dataset/local/create_mixtures_from_metadata.py
+++ b/recipes/LibriParty/generate_dataset/local/create_mixtures_from_metadata.py
@@ -7,11 +7,13 @@ Author
 Samuele Cornell, 2020
 """
 
-import os
-import torch
 import json
+import os
+
 import numpy as np
+import torch
 import torchaudio
+
 from speechbrain.processing.signal_processing import rescale, reverberate
 
 

--- a/recipes/LibriParty/generate_dataset/local/create_mixtures_metadata.py
+++ b/recipes/LibriParty/generate_dataset/local/create_mixtures_metadata.py
@@ -7,11 +7,12 @@ Author
 Samuele Cornell, 2020
 """
 
-import numpy as np
-from pathlib import Path
 import json
-from tqdm import tqdm
+from pathlib import Path
+
+import numpy as np
 import torchaudio
+from tqdm import tqdm
 
 
 def _read_metadata(file_path, configs):

--- a/recipes/LibriParty/generate_dataset/local/resample_folder.py
+++ b/recipes/LibriParty/generate_dataset/local/resample_folder.py
@@ -9,12 +9,14 @@ Author
 Samuele Cornell, 2020
 """
 
-import os
 import argparse
+import os
 from pathlib import Path
-import tqdm
-import torchaudio
+
 import torch
+import torchaudio
+import tqdm
+
 from speechbrain.utils.data_utils import get_all_files
 
 parser = argparse.ArgumentParser(

--- a/recipes/LibriSpeech/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/LibriSpeech/ASR/CTC/train_with_wav2vec.py
@@ -21,14 +21,16 @@ Authors
  * Samuele Cornell 2020
  * Adel Moumen 2023
 """
+import logging
 import os
 import sys
-import torch
-import logging
-import speechbrain as sb
-from speechbrain.utils.distributed import run_on_main, if_main_process
-from hyperpyyaml import load_hyperpyyaml
 from pathlib import Path
+
+import torch
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/LibriSpeech/ASR/CTC/train_with_wav2vec_k2.py
+++ b/recipes/LibriSpeech/ASR/CTC/train_with_wav2vec_k2.py
@@ -21,17 +21,18 @@ Authors
  * Samuele Cornell 2020
 """
 
+import logging
 import os
 import sys
-import torch
-import logging
-import speechbrain as sb
-from speechbrain.utils.distributed import run_on_main, if_main_process
-from hyperpyyaml import load_hyperpyyaml
 from collections import defaultdict
 from pathlib import Path
 
+import torch
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 import speechbrain.k2_integration as sbk2
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/LibriSpeech/ASR/CTC/train_with_whisper.py
+++ b/recipes/LibriSpeech/ASR/CTC/train_with_whisper.py
@@ -20,15 +20,17 @@ Authors
  * Samuele Cornell 2020
 """
 
-import sys
-import torch
 import logging
+import sys
+from pathlib import Path
+
+import torch
+from hyperpyyaml import load_hyperpyyaml
+
 import speechbrain as sb
-from speechbrain.utils.distributed import run_on_main, if_main_process
 from speechbrain.tokenizers.SentencePiece import SentencePiece
 from speechbrain.utils.data_utils import undo_padding
-from hyperpyyaml import load_hyperpyyaml
-from pathlib import Path
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/LibriSpeech/ASR/seq2seq/train.py
+++ b/recipes/LibriSpeech/ASR/seq2seq/train.py
@@ -34,13 +34,15 @@ Authors
  * Andreas Nautsch 2021
 """
 
-import sys
-import torch
 import logging
-import speechbrain as sb
-from speechbrain.utils.distributed import run_on_main, if_main_process
-from hyperpyyaml import load_hyperpyyaml
+import sys
 from pathlib import Path
+
+import torch
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 
@@ -267,9 +269,9 @@ def dataio_prepare(hparams):
     train_batch_sampler = None
     valid_batch_sampler = None
     if hparams["dynamic_batching"]:
-        from speechbrain.dataio.sampler import DynamicBatchSampler  # noqa
-        from speechbrain.dataio.dataloader import SaveableDataLoader  # noqa
         from speechbrain.dataio.batch import PaddedBatch  # noqa
+        from speechbrain.dataio.dataloader import SaveableDataLoader  # noqa
+        from speechbrain.dataio.sampler import DynamicBatchSampler  # noqa
 
         dynamic_hparams = hparams["dynamic_batch_sampler"]
         hop_size = hparams["feats_hop_size"]

--- a/recipes/LibriSpeech/ASR/transducer/train.py
+++ b/recipes/LibriSpeech/ASR/transducer/train.py
@@ -32,14 +32,16 @@ Authors
  * Peter Plantinga 2020
 """
 
-import sys
-import torch
 import logging
-import speechbrain as sb
-from speechbrain.utils.distributed import run_on_main, if_main_process
-from hyperpyyaml import load_hyperpyyaml
-from pathlib import Path
 import os
+import sys
+from pathlib import Path
+
+import torch
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/LibriSpeech/ASR/transformer/train.py
+++ b/recipes/LibriSpeech/ASR/transformer/train.py
@@ -34,14 +34,16 @@ Authors
  * Titouan Parcollet 2021, 2022
 """
 
+import logging
 import os
 import sys
-import torch
-import logging
 from pathlib import Path
-import speechbrain as sb
+
+import torch
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main, if_main_process
+
+import speechbrain as sb
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/LibriSpeech/ASR/transformer/train_bayesspeech.py
+++ b/recipes/LibriSpeech/ASR/transformer/train_bayesspeech.py
@@ -38,14 +38,16 @@ Authors
  * Luca Della Libera 2023
 """
 
+import logging
 import os
 import sys
-import torch
-import logging
 from pathlib import Path
-import speechbrain as sb
+
+import torch
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main, if_main_process
+
+import speechbrain as sb
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/LibriSpeech/ASR/transformer/train_with_whisper.py
+++ b/recipes/LibriSpeech/ASR/transformer/train_with_whisper.py
@@ -14,15 +14,17 @@ Authors
  * Titouan Parcollet 2022
 """
 
+import logging
 import os
 import sys
-import torch
-import logging
-import speechbrain as sb
-from speechbrain.utils.distributed import run_on_main, if_main_process
-from speechbrain.utils.data_utils import undo_padding
-from hyperpyyaml import load_hyperpyyaml
 from pathlib import Path
+
+import torch
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
+from speechbrain.utils.data_utils import undo_padding
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/LibriSpeech/G2P/evaluate.py
+++ b/recipes/LibriSpeech/G2P/evaluate.py
@@ -8,20 +8,22 @@ Authors
  * Artem Ploujnikov 2022
 """
 
+import itertools
+import logging
+import math
+import sys
+from types import SimpleNamespace
+
+import torch
 from hyperpyyaml import load_hyperpyyaml
+from tqdm.auto import tqdm
+from train import dataio_prep, load_dependencies
+
+import speechbrain as sb
 from speechbrain.dataio.batch import PaddedBatch
 from speechbrain.lobes.models.g2p.dataio import get_sequence_key
 from speechbrain.utils import hpopt as hp
 from speechbrain.wordemb.util import expand_to_chars
-from train import dataio_prep, load_dependencies
-from types import SimpleNamespace
-from tqdm.auto import tqdm
-import math
-import itertools
-import speechbrain as sb
-import torch
-import sys
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/LibriSpeech/G2P/tokenizer_prepare.py
+++ b/recipes/LibriSpeech/G2P/tokenizer_prepare.py
@@ -5,6 +5,7 @@
 import json
 import os
 import re
+
 import datasets
 
 from speechbrain.lobes.models.g2p.dataio import build_token_char_map

--- a/recipes/LibriSpeech/G2P/train.py
+++ b/recipes/LibriSpeech/G2P/train.py
@@ -8,38 +8,40 @@ Authors
  * Mirco Ravanelli 2020
  * Artem Ploujnikov 2021
 """
-from speechbrain.dataio.dataset import (
-    FilteredSortedDynamicItemDataset,
-    DynamicItemDataset,
-)
-from speechbrain.dataio.sampler import BalancingDataSampler
-from speechbrain.utils.data_utils import undo_padding
-import datasets
 import logging
 import os
 import random
-import speechbrain as sb
 import sys
-from enum import Enum
 from collections import namedtuple
-from hyperpyyaml import load_hyperpyyaml
+from enum import Enum
 from functools import partial
-from speechbrain.utils.distributed import run_on_main
-from speechbrain.utils.pretrained import save_for_pretrained
+from io import StringIO
+
+import datasets
+import numpy as np
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
+from speechbrain.dataio.dataset import (
+    DynamicItemDataset,
+    FilteredSortedDynamicItemDataset,
+)
+from speechbrain.dataio.sampler import BalancingDataSampler
+from speechbrain.dataio.wer import print_alignments
 from speechbrain.lobes.models.g2p.dataio import (
+    add_bos_eos,
     enable_eos_bos,
+    get_sequence_key,
     grapheme_pipeline,
     phoneme_pipeline,
-    tokenizer_encode_pipeline,
-    add_bos_eos,
-    get_sequence_key,
     phonemes_to_label,
+    tokenizer_encode_pipeline,
 )
-from speechbrain.dataio.wer import print_alignments
-from speechbrain.wordemb.util import expand_to_chars
-from io import StringIO
 from speechbrain.utils import hpopt as hp
-import numpy as np
+from speechbrain.utils.data_utils import undo_padding
+from speechbrain.utils.distributed import run_on_main
+from speechbrain.utils.pretrained import save_for_pretrained
+from speechbrain.wordemb.util import expand_to_chars
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/LibriSpeech/G2P/train_lm.py
+++ b/recipes/LibriSpeech/G2P/train_lm.py
@@ -13,13 +13,15 @@ Authors
  * Mirco Ravanelli 2021
  * Artem Ploujnikov 2021
 """
-import sys
 import logging
 import os
-import speechbrain as sb
+import sys
+
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main
 from train import dataio_prep
+
+import speechbrain as sb
+from speechbrain.utils.distributed import run_on_main
 
 # The following hyperparameters are used in dataio_prep, shared with the
 # main G2P training script:

--- a/recipes/LibriSpeech/LM/dataset.py
+++ b/recipes/LibriSpeech/LM/dataset.py
@@ -23,9 +23,9 @@ Authors
 
 from __future__ import absolute_import, division, print_function
 
-import datasets
 import re
 
+import datasets
 
 _CITATION = """\
 @inproceedings{panayotov2015librispeech,

--- a/recipes/LibriSpeech/LM/train.py
+++ b/recipes/LibriSpeech/LM/train.py
@@ -9,16 +9,17 @@ Authors
  * Jianyuan Zhong 2021
  * Ju-Chieh Chou 2020
 """
+import glob
+import logging
 import os
 import sys
-import logging
-import glob
+
 import torch
 from datasets import load_dataset
 from hyperpyyaml import load_hyperpyyaml
+
 import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
-
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/LibriSpeech/LM/train_ngram.py
+++ b/recipes/LibriSpeech/LM/train_ngram.py
@@ -9,17 +9,16 @@ Authors
  * Pierre Champion 2023
 """
 
+import logging
 import os
 import sys
-import logging
-import speechbrain as sb
-from speechbrain.utils.distributed import run_on_main
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 import speechbrain.k2_integration as sbk2
-from speechbrain.utils.data_utils import (
-    download_file,
-    get_list_from_csv,
-)
+from speechbrain.utils.data_utils import download_file, get_list_from_csv
+from speechbrain.utils.distributed import run_on_main
 
 logger = logging.getLogger(__name__)
 OPEN_SLR_11_LINK = "http://www.openslr.org/resources/11/"

--- a/recipes/LibriSpeech/Tokenizer/train.py
+++ b/recipes/LibriSpeech/Tokenizer/train.py
@@ -16,8 +16,10 @@ Authors
 """
 
 import sys
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
 
 if __name__ == "__main__":

--- a/recipes/LibriSpeech/librispeech_prepare.py
+++ b/recipes/LibriSpeech/librispeech_prepare.py
@@ -12,23 +12,21 @@ Author
  * Adel Moumen, 2024
 """
 
-import os
 import csv
+import functools
+import logging
+import os
 import random
 from collections import Counter
 from dataclasses import dataclass
-import functools
-import logging
-from speechbrain.utils.data_utils import (
-    download_file,
-    get_all_files,
-)
+
 from speechbrain.dataio.dataio import (
     load_pkl,
-    save_pkl,
     merge_csvs,
     read_audio_info,
+    save_pkl,
 )
+from speechbrain.utils.data_utils import download_file, get_all_files
 from speechbrain.utils.parallel import parallel_map
 
 logger = logging.getLogger(__name__)

--- a/recipes/LibriSpeech/quantization/train.py
+++ b/recipes/LibriSpeech/quantization/train.py
@@ -7,16 +7,18 @@ Author
  * Pooneh Mousavi 2023
 """
 
+import logging
 import os
 import sys
-import logging
-import speechbrain as sb
-from speechbrain.utils.distributed import run_on_main
+
+import torchaudio
 from hyperpyyaml import load_hyperpyyaml
 from torch.utils.data import DataLoader
+
+import speechbrain as sb
 from speechbrain.dataio.dataloader import LoopedLoader
-from speechbrain.utils.kmeans import fetch_kmeans_model, train, save_model
-import torchaudio
+from speechbrain.utils.distributed import run_on_main
+from speechbrain.utils.kmeans import fetch_kmeans_model, save_model, train
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/LibriSpeech/self-supervised-learning/wav2vec2/train_sb_wav2vec2.py
+++ b/recipes/LibriSpeech/self-supervised-learning/wav2vec2/train_sb_wav2vec2.py
@@ -17,19 +17,21 @@ import sys
 import time
 from functools import partial
 
-import speechbrain as sb
 import torch
 import torch.nn.functional as F
-from torch.nn.parallel import DistributedDataParallel
 from hyperpyyaml import load_hyperpyyaml
+from torch.nn.parallel import DistributedDataParallel
 
+import speechbrain as sb
 from speechbrain import Stage
-from speechbrain.utils.distributed import run_on_main
+from speechbrain.core import AMPConfig
 from speechbrain.dataio.dataloader import SaveableDataLoader
 from speechbrain.dataio.sampler import DynamicBatchSampler
-from speechbrain.lobes.models.wav2vec import w2v_mask_collate_fn
-from speechbrain.lobes.models.wav2vec import sample_negatives
-from speechbrain.core import AMPConfig
+from speechbrain.lobes.models.wav2vec import (
+    sample_negatives,
+    w2v_mask_collate_fn,
+)
+from speechbrain.utils.distributed import run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/LibriTTS/TTS/mstacotron2/compute_speaker_embeddings.py
+++ b/recipes/LibriTTS/TTS/mstacotron2/compute_speaker_embeddings.py
@@ -1,11 +1,13 @@
 import json
-from speechbrain.inference.encoders import MelSpectrogramEncoder
-from speechbrain.inference.classifiers import EncoderClassifier
-import torchaudio
-import pickle
 import logging
 import os
+import pickle
+
+import torchaudio
 from tqdm import tqdm
+
+from speechbrain.inference.classifiers import EncoderClassifier
+from speechbrain.inference.encoders import MelSpectrogramEncoder
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/LibriTTS/TTS/mstacotron2/train.py
+++ b/recipes/LibriTTS/TTS/mstacotron2/train.py
@@ -12,16 +12,18 @@
  * Yingzhi Wang 2022
  * Pradnya Kandarkar 2023
 """
-import torch
-import speechbrain as sb
-import sys
 import logging
-from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.text_to_sequence import text_to_sequence
-from speechbrain.utils.data_utils import scalarize
 import os
-from speechbrain.inference.vocoders import HIFIGAN
+import sys
+
+import torch
 import torchaudio
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
+from speechbrain.inference.vocoders import HIFIGAN
+from speechbrain.utils.data_utils import scalarize
+from speechbrain.utils.text_to_sequence import text_to_sequence
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 logger = logging.getLogger(__name__)

--- a/recipes/LibriTTS/libritts_prepare.py
+++ b/recipes/LibriTTS/libritts_prepare.py
@@ -5,16 +5,18 @@ Authors
  * Pradnya Kandarkar 2022
 """
 
-from speechbrain.utils.data_utils import get_all_files, download_file
 import json
-import os
-import shutil
-import random
 import logging
-import torchaudio
+import os
+import random
+import shutil
+
 import torch
+import torchaudio
 from tqdm import tqdm
+
 from speechbrain.inference.txt import GraphemeToPhoneme
+from speechbrain.utils.data_utils import download_file, get_all_files
 from speechbrain.utils.text_to_sequence import _g2p_keep_punctuations
 
 logger = logging.getLogger(__name__)

--- a/recipes/LibriTTS/vocoder/hifigan/train.py
+++ b/recipes/LibriTTS/vocoder/hifigan/train.py
@@ -11,13 +11,15 @@ Authors
  * Pradnya Kandarkar 2022
 """
 
+import os
 import sys
+
 import torch
+import torchaudio
 from hyperpyyaml import load_hyperpyyaml
+
 import speechbrain as sb
 from speechbrain.utils.data_utils import scalarize
-import torchaudio
-import os
 
 
 class HifiGanBrain(sb.Brain):

--- a/recipes/MEDIA/ASR/CTC/train_hf_wav2vec.py
+++ b/recipes/MEDIA/ASR/CTC/train_hf_wav2vec.py
@@ -20,14 +20,16 @@ Authors
  * Gaëlle Laperrière 2023
 """
 
-import sys
-import torch
 import logging
-import speechbrain as sb
+import sys
+
+import torch
 from hyperpyyaml import load_hyperpyyaml
+from media_prepare import prepare_media
+
+import speechbrain as sb
 from speechbrain.dataio.batch import PaddedBatch
 from speechbrain.utils.distributed import run_on_main
-from media_prepare import prepare_media
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/MEDIA/SLU/CTC/train_hf_wav2vec.py
+++ b/recipes/MEDIA/SLU/CTC/train_hf_wav2vec.py
@@ -20,14 +20,16 @@ Authors
  * Gaëlle Laperrière 2023
 """
 
-import sys
-import torch
 import logging
-import speechbrain as sb
+import sys
+
+import torch
 from hyperpyyaml import load_hyperpyyaml
+from media_prepare import prepare_media
+
+import speechbrain as sb
 from speechbrain.dataio.batch import PaddedBatch
 from speechbrain.utils.distributed import run_on_main
-from media_prepare import prepare_media
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/MEDIA/media_prepare.py
+++ b/recipes/MEDIA/media_prepare.py
@@ -11,14 +11,15 @@ Author
 Gaëlle Laperrière 2023
 """
 
-import xml.dom.minidom as DOM
-from tqdm import tqdm
-import logging
-import subprocess
 import csv
-import os
 import glob
+import logging
+import os
 import re
+import subprocess
+import xml.dom.minidom as DOM
+
+from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/MultiWOZ/response_generation/gpt/train_with_gpt.py
+++ b/recipes/MultiWOZ/response_generation/gpt/train_with_gpt.py
@@ -13,14 +13,16 @@ Authors
 """
 
 
-import sys
-import speechbrain as sb
-import torch
-from itertools import chain
-from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main
 import math
+import sys
+from itertools import chain
+
+import torch
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.dataio.batch import PaddedBatch
+from speechbrain.utils.distributed import run_on_main
 
 
 class ResGenBrain(sb.Brain):

--- a/recipes/MultiWOZ/response_generation/llama2/train_with_llama2.py
+++ b/recipes/MultiWOZ/response_generation/llama2/train_with_llama2.py
@@ -12,14 +12,16 @@ Authors
 """
 
 
-import sys
-import speechbrain as sb
-import torch
-from itertools import chain
-from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main
 import math
+import sys
+from itertools import chain
+
+import torch
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.dataio.batch import PaddedBatch
+from speechbrain.utils.distributed import run_on_main
 
 
 class ResGenBrain(sb.Brain):

--- a/recipes/MultiWOZ/response_generation/multiwoz_prepare.py
+++ b/recipes/MultiWOZ/response_generation/multiwoz_prepare.py
@@ -1,12 +1,14 @@
-from itertools import product
-from statistics import mean
-from typing import Any, Dict, List, Optional, Set, Tuple
 import json
 import logging
 import os
 import re
 import shutil
+from itertools import product
+from statistics import mean
+from typing import Any, Dict, List, Optional, Set, Tuple
+
 from tqdm import tqdm
+
 from speechbrain.utils.data_utils import download_file
 
 """

--- a/recipes/REAL-M/sisnr-estimation/train.py
+++ b/recipes/REAL-M/sisnr-estimation/train.py
@@ -8,19 +8,21 @@ Authors:
  * Samuele Cornell 2021
 """
 
+import csv
+import itertools as it
+import logging
 import os
 import sys
+
+import numpy as np
 import torch
+from hyperpyyaml import load_hyperpyyaml
+from tqdm import tqdm
+
 import speechbrain as sb
 import speechbrain.nnet.schedulers as schedulers
-from speechbrain.utils.distributed import run_on_main
-from hyperpyyaml import load_hyperpyyaml
-import itertools as it
-from tqdm import tqdm
-import numpy as np
-import logging
-import csv
 from speechbrain.core import AMPConfig
+from speechbrain.utils.distributed import run_on_main
 
 
 # Define training procedure
@@ -630,8 +632,8 @@ if __name__ == "__main__":
 
     # if whamr, and we do speedaugment we need to prepare the csv file
     if hparams["use_reverb_augment"]:
-        from prepare_data_wham import create_whamr_rir_csv
         from create_whamr_rirs import create_rirs
+        from prepare_data_wham import create_whamr_rir_csv
 
         # If the Room Impulse Responses do not exist, we create them
         if not os.path.exists(hparams["rir_path"]):

--- a/recipes/RescueSpeech/ASR/noise-robust/train.py
+++ b/recipes/RescueSpeech/ASR/noise-robust/train.py
@@ -19,23 +19,24 @@ Authors
  * Titouan Parcollet 2022
 """
 
-import os
-import sys
 import csv
 import logging
+import os
+import sys
+
 import numpy as np
-from tqdm import tqdm
+import torch
+import torch.nn.functional as F
+import torchaudio
+from hyperpyyaml import load_hyperpyyaml
 from pesq import pesq
 from pystoi import stoi
+from tqdm import tqdm
 
-import torch
-import torchaudio
-import torch.nn.functional as F
 import speechbrain as sb
-from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.metric_stats import MetricStats
-from speechbrain.utils.distributed import run_on_main
 from speechbrain.utils.data_utils import undo_padding
+from speechbrain.utils.distributed import run_on_main
+from speechbrain.utils.metric_stats import MetricStats
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/RescueSpeech/rescuespeech_prepare.py
+++ b/recipes/RescueSpeech/rescuespeech_prepare.py
@@ -17,15 +17,17 @@ Sangeet Sagar 2023
 adapted from the CommonVoice recipe)
 """
 
-import os
-import re
 import csv
 import glob
 import logging
-import torchaudio
+import os
+import re
 import unicodedata
+
+import torchaudio
 from tqdm import tqdm
 from tqdm.contrib import tzip
+
 from speechbrain.dataio.dataio import read_audio
 
 logger = logging.getLogger(__name__)

--- a/recipes/SLURP/NLU/train.py
+++ b/recipes/SLURP/NLU/train.py
@@ -9,14 +9,16 @@ Authors
 
 """
 
-import sys
-import torch
-import speechbrain as sb
-from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main, if_main_process
-import jsonlines
 import ast
+import sys
+
+import jsonlines
 import pandas as pd
+import torch
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 
 # Define training procedure

--- a/recipes/SLURP/Tokenizer/train.py
+++ b/recipes/SLURP/Tokenizer/train.py
@@ -14,8 +14,10 @@ Authors
 """
 
 import sys
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
 
 if __name__ == "__main__":

--- a/recipes/SLURP/direct/train.py
+++ b/recipes/SLURP/direct/train.py
@@ -15,14 +15,16 @@ Authors
  * Mirco Ravanelli 2020
 """
 
-import sys
-import torch
-import speechbrain as sb
-from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main, if_main_process
-import jsonlines
 import ast
+import sys
+
+import jsonlines
 import pandas as pd
+import torch
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 
 # Define training procedure

--- a/recipes/SLURP/direct/train_with_wav2vec2.py
+++ b/recipes/SLURP/direct/train_with_wav2vec2.py
@@ -15,14 +15,16 @@ Authors
 For more wav2vec2/HuBERT results, please see https://arxiv.org/pdf/2111.02735.pdf
 """
 
-import sys
-import torch
-import speechbrain as sb
-from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main, if_main_process
-import jsonlines
 import ast
+import sys
+
+import jsonlines
 import pandas as pd
+import torch
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 
 class SLU(sb.Brain):

--- a/recipes/SLURP/prepare.py
+++ b/recipes/SLURP/prepare.py
@@ -1,8 +1,10 @@
 import os
-import jsonlines
-from speechbrain.dataio.dataio import read_audio, merge_csvs
-from speechbrain.utils.data_utils import download_file
 import shutil
+
+import jsonlines
+
+from speechbrain.dataio.dataio import merge_csvs, read_audio
+from speechbrain.utils.data_utils import download_file
 
 try:
     import pandas as pd

--- a/recipes/Switchboard/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/Switchboard/ASR/CTC/train_with_wav2vec.py
@@ -23,19 +23,19 @@ Authors
 """
 
 import functools
+import logging
 import os
 import sys
 from pathlib import Path
 
 import torch
-import logging
-import speechbrain as sb
 import torchaudio
 from hyperpyyaml import load_hyperpyyaml
 
+import speechbrain as sb
 from speechbrain.tokenizers.SentencePiece import SentencePiece
 from speechbrain.utils.data_utils import undo_padding
-from speechbrain.utils.distributed import run_on_main, if_main_process
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 
@@ -347,8 +347,8 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Dataset preparation (parsing Switchboard)
-    from switchboard_prepare import prepare_switchboard  # noqa
     from normalize_util import normalize_words, read_glm_csv  # noqa
+    from switchboard_prepare import prepare_switchboard  # noqa
 
     # Create experiment directory
     sb.create_experiment_directory(

--- a/recipes/Switchboard/ASR/normalize_util.py
+++ b/recipes/Switchboard/ASR/normalize_util.py
@@ -10,9 +10,9 @@ Author
 Dominik Wagner 2022
 """
 
-import re
-import os
 import csv
+import os
+import re
 import string
 from collections import defaultdict
 

--- a/recipes/Switchboard/ASR/seq2seq/train.py
+++ b/recipes/Switchboard/ASR/seq2seq/train.py
@@ -30,18 +30,17 @@ Authors
  * Dominik Wagner 2022
 """
 import functools
+import logging
 import os
 import sys
+from pathlib import Path
 
 import torch
-import logging
-
 import torchaudio
+from hyperpyyaml import load_hyperpyyaml
 
 import speechbrain as sb
-from speechbrain.utils.distributed import run_on_main, if_main_process
-from hyperpyyaml import load_hyperpyyaml
-from pathlib import Path
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 
@@ -326,9 +325,9 @@ def dataio_prepare(hparams):
     train_batch_sampler = None
     valid_batch_sampler = None
     if hparams["dynamic_batching"]:
-        from speechbrain.dataio.sampler import DynamicBatchSampler  # noqa
-        from speechbrain.dataio.dataloader import SaveableDataLoader  # noqa
         from speechbrain.dataio.batch import PaddedBatch  # noqa
+        from speechbrain.dataio.dataloader import SaveableDataLoader  # noqa
+        from speechbrain.dataio.sampler import DynamicBatchSampler  # noqa
 
         dynamic_hparams = hparams["dynamic_batch_sampler"]
         hop_size = hparams["feats_hop_size"]
@@ -372,8 +371,8 @@ if __name__ == "__main__":
     )
 
     # Dataset prep (parsing Switchboard)
-    from switchboard_prepare import prepare_switchboard  # noqa
     from normalize_util import normalize_words, read_glm_csv  # noqa
+    from switchboard_prepare import prepare_switchboard  # noqa
 
     # multi-gpu (ddp) save data preparation
     run_on_main(

--- a/recipes/Switchboard/ASR/transformer/train.py
+++ b/recipes/Switchboard/ASR/transformer/train.py
@@ -33,18 +33,17 @@ Authors
  * Dominik Wagner 2022
 """
 import functools
+import logging
 import os
 import sys
-
-import torch
-import logging
 from pathlib import Path
 
+import torch
 import torchaudio
+from hyperpyyaml import load_hyperpyyaml
 
 import speechbrain as sb
-from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main, if_main_process
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 
@@ -446,8 +445,8 @@ if __name__ == "__main__":
     # create ddp_group with the right communication protocol
     sb.utils.distributed.ddp_init_group(run_opts)
 
-    from switchboard_prepare import prepare_switchboard  # noqa
     from normalize_util import normalize_words, read_glm_csv  # noqa
+    from switchboard_prepare import prepare_switchboard  # noqa
 
     # Create experiment directory
     sb.create_experiment_directory(

--- a/recipes/Switchboard/LM/train.py
+++ b/recipes/Switchboard/LM/train.py
@@ -10,10 +10,12 @@ Authors
  * Ju-Chieh Chou 2020
  * Dominik Wagner 2022
 """
-import sys
 import logging
+import sys
+
 import torch
 from hyperpyyaml import load_hyperpyyaml
+
 import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
 

--- a/recipes/Switchboard/Tokenizer/train.py
+++ b/recipes/Switchboard/Tokenizer/train.py
@@ -16,8 +16,10 @@ Authors
 """
 
 import sys
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
 
 if __name__ == "__main__":

--- a/recipes/Switchboard/switchboard_prepare.py
+++ b/recipes/Switchboard/switchboard_prepare.py
@@ -18,10 +18,10 @@ Author
 Dominik Wagner 2022
 """
 
-import re
 import csv
 import logging
 import os
+import re
 from collections import defaultdict
 
 from speechbrain.dataio.dataio import merge_csvs

--- a/recipes/TIMIT/ASR/CTC/train.py
+++ b/recipes/TIMIT/ASR/CTC/train.py
@@ -16,12 +16,14 @@ Authors
  * Peter Plantinga 2020
 """
 
+import logging
 import os
 import sys
-import logging
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main, if_main_process
+
+import speechbrain as sb
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/TIMIT/ASR/seq2seq/train.py
+++ b/recipes/TIMIT/ASR/seq2seq/train.py
@@ -19,16 +19,18 @@ Authors
  * Andreas Nautsch 2021
 """
 
+import logging
 import os
 import sys
+
 import torch
-import logging
-import speechbrain as sb
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main, if_main_process
+
+import speechbrain as sb
+from speechbrain.dataio.batch import PaddedBatch
 from speechbrain.dataio.dataloader import SaveableDataLoader
 from speechbrain.dataio.sampler import DynamicBatchSampler
-from speechbrain.dataio.batch import PaddedBatch
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/TIMIT/ASR/seq2seq/train_with_wav2vec2.py
+++ b/recipes/TIMIT/ASR/seq2seq/train_with_wav2vec2.py
@@ -14,13 +14,15 @@ Authors
  * Abdel Heba 2020
 """
 
+import logging
 import os
 import sys
+
 import torch
-import logging
-import speechbrain as sb
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main, if_main_process
+
+import speechbrain as sb
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/TIMIT/ASR/transducer/train.py
+++ b/recipes/TIMIT/ASR/transducer/train.py
@@ -15,11 +15,13 @@ Authors
  * Mirco Ravanelli 2020
  * Ju-Chieh Chou 2020
 """
+import logging
 import os
 import sys
-import logging
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
 
 logger = logging.getLogger(__name__)

--- a/recipes/TIMIT/ASR/transducer/train_wav2vec.py
+++ b/recipes/TIMIT/ASR/transducer/train_wav2vec.py
@@ -11,12 +11,14 @@ Authors
  * Mirco Ravanelli 2020
  * Ju-Chieh Chou 2020
 """
+import logging
 import os
 import sys
-import logging
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main, if_main_process
+
+import speechbrain as sb
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/TIMIT/Alignment/train.py
+++ b/recipes/TIMIT/Alignment/train.py
@@ -12,9 +12,11 @@ Authors
 """
 import os
 import sys
+
 import torch
-import speechbrain as sb
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
 
 # Define training procedure

--- a/recipes/TIMIT/timit_prepare.py
+++ b/recipes/TIMIT/timit_prepare.py
@@ -8,11 +8,12 @@ Authors
 * Elena Rastorgueva 2020
 """
 
-import os
 import json
 import logging
-from speechbrain.utils.data_utils import get_all_files
+import os
+
 from speechbrain.dataio.dataio import read_audio
+from speechbrain.utils.data_utils import get_all_files
 
 logger = logging.getLogger(__name__)
 SAMPLERATE = 16000

--- a/recipes/Tedlium2/ASR/transformer/tedlium2_prepare.py
+++ b/recipes/Tedlium2/ASR/transformer/tedlium2_prepare.py
@@ -6,11 +6,13 @@ Authors
  * Adel Moumen 2023
 """
 
-import os
 import csv
-import logging
-import torchaudio
 import functools
+import logging
+import os
+
+import torchaudio
+
 from speechbrain.utils.parallel import parallel_map
 
 logger = logging.getLogger(__name__)

--- a/recipes/Tedlium2/ASR/transformer/train.py
+++ b/recipes/Tedlium2/ASR/transformer/train.py
@@ -31,14 +31,16 @@ Authors
  * Shucong Zhang 2023
 """
 
+import logging
 import os
 import sys
-import torch
-import logging
 from pathlib import Path
-import speechbrain as sb
+
+import torch
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main, if_main_process
+
+import speechbrain as sb
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/Tedlium2/Tokenizer/train.py
+++ b/recipes/Tedlium2/Tokenizer/train.py
@@ -14,11 +14,13 @@ Authors
  * Shucong Zhang 2023
 """
 
-import sys
-import speechbrain as sb
-from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main
 import shutil
+import sys
+
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
+from speechbrain.utils.distributed import run_on_main
 
 if __name__ == "__main__":
     # CLI:

--- a/recipes/Tedlium2/tedlium2_prepare.py
+++ b/recipes/Tedlium2/tedlium2_prepare.py
@@ -6,11 +6,13 @@ Authors
  * Adel Moumen 2023
 """
 
-import os
 import csv
-import logging
-import torchaudio
 import functools
+import logging
+import os
+
+import torchaudio
+
 from speechbrain.utils.parallel import parallel_map
 
 logger = logging.getLogger(__name__)

--- a/recipes/UrbanSound8k/SoundClassification/confusion_matrix_fig.py
+++ b/recipes/UrbanSound8k/SoundClassification/confusion_matrix_fig.py
@@ -6,9 +6,10 @@ Authors
  * Ala Eddine Limame 2021
 """
 
-import numpy as np
-import matplotlib.pyplot as plt
 import itertools
+
+import matplotlib.pyplot as plt
+import numpy as np
 
 
 def create_cm_fig(cm, display_labels):

--- a/recipes/UrbanSound8k/SoundClassification/custom_model.py
+++ b/recipes/UrbanSound8k/SoundClassification/custom_model.py
@@ -17,11 +17,12 @@ Adapted From:
 
 import torch  # noqa: F401
 import torch.nn as nn
+
 import speechbrain as sb
-from speechbrain.nnet.pooling import StatisticsPooling
 from speechbrain.nnet.CNN import Conv1d
 from speechbrain.nnet.linear import Linear
 from speechbrain.nnet.normalization import BatchNorm1d
+from speechbrain.nnet.pooling import StatisticsPooling
 
 
 class Xvector(torch.nn.Module):

--- a/recipes/UrbanSound8k/SoundClassification/train.py
+++ b/recipes/UrbanSound8k/SoundClassification/train.py
@@ -20,15 +20,17 @@ Based on VoxCeleb By:
 """
 import os
 import sys
+
+import numpy as np
 import torch
 import torchaudio
-import speechbrain as sb
-from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main
-from urbansound8k_prepare import prepare_urban_sound_8k
-from sklearn.metrics import confusion_matrix
-import numpy as np
 from confusion_matrix_fig import create_cm_fig
+from hyperpyyaml import load_hyperpyyaml
+from sklearn.metrics import confusion_matrix
+from urbansound8k_prepare import prepare_urban_sound_8k
+
+import speechbrain as sb
+from speechbrain.utils.distributed import run_on_main
 
 
 class UrbanSound8kBrain(sb.core.Brain):

--- a/recipes/UrbanSound8k/urbansound8k_prepare.py
+++ b/recipes/UrbanSound8k/urbansound8k_prepare.py
@@ -38,13 +38,14 @@ Authors:
  * David Whipps, 2021
 """
 
-import os
 import json
 import logging
 import ntpath
+import os
+
 import torchaudio
-from speechbrain.dataio.dataio import read_audio
-from speechbrain.dataio.dataio import load_data_csv
+
+from speechbrain.dataio.dataio import load_data_csv, read_audio
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/Voicebank/ASR/CTC/train.py
+++ b/recipes/Voicebank/ASR/CTC/train.py
@@ -14,10 +14,12 @@ Authors
 """
 import os
 import sys
+
 import torch
+from hyperpyyaml import load_hyperpyyaml
+
 import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
-from hyperpyyaml import load_hyperpyyaml
 
 
 # Define training procedure

--- a/recipes/Voicebank/MTL/ASR_enhance/composite_eval.py
+++ b/recipes/Voicebank/MTL/ASR_enhance/composite_eval.py
@@ -6,13 +6,14 @@ Authors
  * adiyoss (https://github.com/adiyoss)
 """
 
-from scipy.linalg import toeplitz
-from tqdm import tqdm
-from pesq import pesq
-import librosa
-import numpy as np
 import os
 import sys
+
+import librosa
+import numpy as np
+from pesq import pesq
+from scipy.linalg import toeplitz
+from tqdm import tqdm
 
 
 def eval_composite(ref_wav, deg_wav):

--- a/recipes/Voicebank/MTL/ASR_enhance/train.py
+++ b/recipes/Voicebank/MTL/ASR_enhance/train.py
@@ -16,18 +16,20 @@ can be used for enhancement or ASR models.
 Authors
  * Peter Plantinga 2020, 2021
 """
+import logging
 import os
 import sys
+
 import torch
 import torchaudio
-import logging
-import speechbrain as sb
-from pesq import pesq
-from pystoi import stoi
 from composite_eval import eval_composite
 from hyperpyyaml import load_hyperpyyaml
+from pesq import pesq
+from pystoi import stoi
+
+import speechbrain as sb
 from speechbrain.utils.data_utils import undo_padding
-from speechbrain.utils.distributed import run_on_main, if_main_process
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/Voicebank/dereverb/MetricGAN-U/train.py
+++ b/recipes/Voicebank/dereverb/MetricGAN-U/train.py
@@ -9,28 +9,29 @@ Authors
  * Szu-Wei Fu 2021/09
 """
 
+import json
 import os
-import sys
+import pickle
 import shutil
+import sys
+import time
+from enum import Enum, auto
+from urllib.parse import urljoin, urlparse
+
+import numpy as np
+import requests
 import torch
 import torchaudio
-import speechbrain as sb
-import numpy as np
-import json
-import pickle
-import requests
-import time
-
-from urllib.parse import urlparse, urljoin
-from srmrpy import srmr
-from pesq import pesq
-from enum import Enum, auto
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.metric_stats import MetricStats
-from speechbrain.processing.features import spectral_magnitude
-from speechbrain.nnet.loss.stoi_loss import stoi_loss
-from speechbrain.utils.distributed import run_on_main
+from pesq import pesq
+from srmrpy import srmr
+
+import speechbrain as sb
 from speechbrain.dataio.sampler import ReproducibleWeightedRandomSampler
+from speechbrain.nnet.loss.stoi_loss import stoi_loss
+from speechbrain.processing.features import spectral_magnitude
+from speechbrain.utils.distributed import run_on_main
+from speechbrain.utils.metric_stats import MetricStats
 
 ### For DNSMSOS
 # URL for the web service

--- a/recipes/Voicebank/dereverb/MetricGAN-U/voicebank_revb_prepare.py
+++ b/recipes/Voicebank/dereverb/MetricGAN-U/voicebank_revb_prepare.py
@@ -12,12 +12,13 @@ Authors:
  * Peter Plantinga, 2020
 """
 
-import os
 import json
-import string
 import logging
-from speechbrain.utils.data_utils import get_all_files
+import os
+import string
+
 from speechbrain.dataio.dataio import read_audio
+from speechbrain.utils.data_utils import get_all_files
 
 logger = logging.getLogger(__name__)
 LEXICON_URL = "http://www.openslr.org/resources/11/librispeech-lexicon.txt"

--- a/recipes/Voicebank/dereverb/spectral_mask/train.py
+++ b/recipes/Voicebank/dereverb/spectral_mask/train.py
@@ -9,15 +9,17 @@ Authors
 """
 import os
 import sys
+
 import torch
 import torchaudio
-import speechbrain as sb
-from pesq import pesq
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.metric_stats import MetricStats
-from speechbrain.processing.features import spectral_magnitude
+from pesq import pesq
+
+import speechbrain as sb
 from speechbrain.nnet.loss.stoi_loss import stoi_loss
+from speechbrain.processing.features import spectral_magnitude
 from speechbrain.utils.distributed import run_on_main
+from speechbrain.utils.metric_stats import MetricStats
 
 
 # Brain class for speech enhancement training

--- a/recipes/Voicebank/dereverb/spectral_mask/voicebank_revb_prepare.py
+++ b/recipes/Voicebank/dereverb/spectral_mask/voicebank_revb_prepare.py
@@ -12,12 +12,13 @@ Authors:
  * Peter Plantinga, 2020
 """
 
-import os
 import json
-import string
 import logging
-from speechbrain.utils.data_utils import get_all_files
+import os
+import string
+
 from speechbrain.dataio.dataio import read_audio
+from speechbrain.utils.data_utils import get_all_files
 
 logger = logging.getLogger(__name__)
 LEXICON_URL = "http://www.openslr.org/resources/11/librispeech-lexicon.txt"

--- a/recipes/Voicebank/enhance/MetricGAN-U/train.py
+++ b/recipes/Voicebank/enhance/MetricGAN-U/train.py
@@ -9,28 +9,29 @@ Authors
  * Szu-Wei Fu 2021/09
 """
 
+import json
 import os
-import sys
+import pickle
 import shutil
+import sys
+import time
+from enum import Enum, auto
+from urllib.parse import urljoin, urlparse
+
+import numpy as np
+import requests
 import torch
 import torchaudio
-import speechbrain as sb
-import numpy as np
-import json
-import pickle
-import requests
-import time
-
-from urllib.parse import urlparse, urljoin
-from srmrpy import srmr
-from pesq import pesq
-from enum import Enum, auto
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.metric_stats import MetricStats
-from speechbrain.processing.features import spectral_magnitude
-from speechbrain.nnet.loss.stoi_loss import stoi_loss
-from speechbrain.utils.distributed import run_on_main
+from pesq import pesq
+from srmrpy import srmr
+
+import speechbrain as sb
 from speechbrain.dataio.sampler import ReproducibleWeightedRandomSampler
+from speechbrain.nnet.loss.stoi_loss import stoi_loss
+from speechbrain.processing.features import spectral_magnitude
+from speechbrain.utils.distributed import run_on_main
+from speechbrain.utils.metric_stats import MetricStats
 
 ### For DNSMSOS
 # URL for the web service

--- a/recipes/Voicebank/enhance/MetricGAN-U/voicebank_prepare.py
+++ b/recipes/Voicebank/enhance/MetricGAN-U/voicebank_prepare.py
@@ -10,17 +10,19 @@ Authors:
  * Peter Plantinga, 2020
 """
 
-import os
 import json
-import string
-import urllib
-import shutil
 import logging
+import os
+import shutil
+import string
 import tempfile
+import urllib
+
 import torchaudio
 from torchaudio.transforms import Resample
-from speechbrain.utils.data_utils import get_all_files, download_file
+
 from speechbrain.dataio.dataio import read_audio
+from speechbrain.utils.data_utils import download_file, get_all_files
 
 logger = logging.getLogger(__name__)
 LEXICON_URL = "http://www.openslr.org/resources/11/librispeech-lexicon.txt"

--- a/recipes/Voicebank/enhance/MetricGAN/train.py
+++ b/recipes/Voicebank/enhance/MetricGAN/train.py
@@ -11,20 +11,22 @@ Authors
 """
 
 import os
-import sys
-import shutil
 import pickle
+import shutil
+import sys
+from enum import Enum, auto
+
 import torch
 import torchaudio
-import speechbrain as sb
-from pesq import pesq
-from enum import Enum, auto
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.metric_stats import MetricStats
-from speechbrain.processing.features import spectral_magnitude
-from speechbrain.nnet.loss.stoi_loss import stoi_loss
-from speechbrain.utils.distributed import run_on_main
+from pesq import pesq
+
+import speechbrain as sb
 from speechbrain.dataio.sampler import ReproducibleWeightedRandomSampler
+from speechbrain.nnet.loss.stoi_loss import stoi_loss
+from speechbrain.processing.features import spectral_magnitude
+from speechbrain.utils.distributed import run_on_main
+from speechbrain.utils.metric_stats import MetricStats
 
 
 def pesq_eval(pred_wav, target_wav):

--- a/recipes/Voicebank/enhance/SEGAN/train.py
+++ b/recipes/Voicebank/enhance/SEGAN/train.py
@@ -12,14 +12,16 @@ Authors
 
 import os
 import sys
+
 import torch
 import torchaudio
-import speechbrain as sb
-from pesq import pesq
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.metric_stats import MetricStats
+from pesq import pesq
+
+import speechbrain as sb
 from speechbrain.nnet.loss.stoi_loss import stoi_loss
 from speechbrain.utils.distributed import run_on_main
+from speechbrain.utils.metric_stats import MetricStats
 
 
 # Brain class for speech enhancement training

--- a/recipes/Voicebank/enhance/spectral_mask/train.py
+++ b/recipes/Voicebank/enhance/spectral_mask/train.py
@@ -9,15 +9,17 @@ Authors
 """
 import os
 import sys
+
 import torch
 import torchaudio
-import speechbrain as sb
-from pesq import pesq
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.metric_stats import MetricStats
-from speechbrain.processing.features import spectral_magnitude
+from pesq import pesq
+
+import speechbrain as sb
 from speechbrain.nnet.loss.stoi_loss import stoi_loss
+from speechbrain.processing.features import spectral_magnitude
 from speechbrain.utils.distributed import run_on_main
+from speechbrain.utils.metric_stats import MetricStats
 
 
 # Brain class for speech enhancement training

--- a/recipes/Voicebank/enhance/waveform_map/train.py
+++ b/recipes/Voicebank/enhance/waveform_map/train.py
@@ -10,14 +10,16 @@ Authors
 """
 import os
 import sys
+
 import torch
 import torchaudio
-import speechbrain as sb
-from pesq import pesq
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.metric_stats import MetricStats
+from pesq import pesq
+
+import speechbrain as sb
 from speechbrain.nnet.loss.stoi_loss import stoi_loss
 from speechbrain.utils.distributed import run_on_main
+from speechbrain.utils.metric_stats import MetricStats
 
 
 # Brain class for speech enhancement training

--- a/recipes/Voicebank/voicebank_prepare.py
+++ b/recipes/Voicebank/voicebank_prepare.py
@@ -10,17 +10,19 @@ Authors:
  * Peter Plantinga, 2020
 """
 
-import os
 import json
-import string
-import urllib
-import shutil
 import logging
+import os
+import shutil
+import string
 import tempfile
+import urllib
+
 import torchaudio
 from torchaudio.transforms import Resample
-from speechbrain.utils.data_utils import get_all_files, download_file
+
 from speechbrain.dataio.dataio import read_audio
+from speechbrain.utils.data_utils import download_file, get_all_files
 
 logger = logging.getLogger(__name__)
 LEXICON_URL = "http://www.openslr.org/resources/11/librispeech-lexicon.txt"

--- a/recipes/VoxCeleb/SpeakerRec/extract_speaker_embeddings.py
+++ b/recipes/VoxCeleb/SpeakerRec/extract_speaker_embeddings.py
@@ -28,18 +28,18 @@ Author
     * Nauman Dawalatabad 2020
     * Xuechen Liu 2023
 """
+import logging
 import os
 import sys
 
 import numpy as np
 import torch
-import logging
 import torchaudio
-import speechbrain as sb
 from hyperpyyaml import load_hyperpyyaml
 
-from speechbrain.utils.distributed import run_on_main
+import speechbrain as sb
 from speechbrain.utils.data_utils import download_file
+from speechbrain.utils.distributed import run_on_main
 
 
 def compute_embeddings_single(wavs, wav_lens, params):

--- a/recipes/VoxCeleb/SpeakerRec/speaker_verification_cosine.py
+++ b/recipes/VoxCeleb/SpeakerRec/speaker_verification_cosine.py
@@ -12,17 +12,19 @@ Authors
     * Mirco Ravanelli 2020
     * Xuechen Liu 2023
 """
+import logging
 import os
 import sys
+
 import torch
-import logging
 import torchaudio
-import speechbrain as sb
-from tqdm.contrib import tqdm
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.metric_stats import EER, minDCF
+from tqdm.contrib import tqdm
+
+import speechbrain as sb
 from speechbrain.utils.data_utils import download_file
 from speechbrain.utils.distributed import run_on_main
+from speechbrain.utils.metric_stats import EER, minDCF
 
 
 # Compute embeddings from the waveforms

--- a/recipes/VoxCeleb/SpeakerRec/speaker_verification_plda.py
+++ b/recipes/VoxCeleb/SpeakerRec/speaker_verification_plda.py
@@ -11,22 +11,26 @@ Authors
     * Mirco Ravanelli 2020
 """
 
+import logging
 import os
+import pickle
 import sys
+
+import numpy
 import torch
 import torchaudio
-import logging
-import speechbrain as sb
-import numpy
-import pickle
-from tqdm.contrib import tqdm
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.metric_stats import EER, minDCF
-from speechbrain.processing.PLDA_LDA import StatObject_SB
-from speechbrain.processing.PLDA_LDA import Ndx
-from speechbrain.processing.PLDA_LDA import fast_PLDA_scoring
+from tqdm.contrib import tqdm
+
+import speechbrain as sb
+from speechbrain.processing.PLDA_LDA import (
+    Ndx,
+    StatObject_SB,
+    fast_PLDA_scoring,
+)
 from speechbrain.utils.data_utils import download_file
 from speechbrain.utils.distributed import run_on_main
+from speechbrain.utils.metric_stats import EER, minDCF
 
 
 # Compute embeddings from the waveforms

--- a/recipes/VoxCeleb/SpeakerRec/train_speaker_embeddings.py
+++ b/recipes/VoxCeleb/SpeakerRec/train_speaker_embeddings.py
@@ -15,13 +15,15 @@ Author
     * Nauman Dawalatabad 2020
 """
 import os
-import sys
 import random
+import sys
+
 import torch
 import torchaudio
+from hyperpyyaml import load_hyperpyyaml
+
 import speechbrain as sb
 from speechbrain.utils.data_utils import download_file
-from hyperpyyaml import load_hyperpyyaml
 from speechbrain.utils.distributed import run_on_main
 
 

--- a/recipes/VoxCeleb/voxceleb_prepare.py
+++ b/recipes/VoxCeleb/voxceleb_prepare.py
@@ -4,21 +4,20 @@ Data preparation.
 Download: http://www.robots.ox.ac.uk/~vgg/data/voxceleb/
 """
 
-import os
 import csv
-import logging
 import glob
+import logging
+import os
 import random
 import shutil
 import sys  # noqa F401
+
 import numpy as np
 import torch
 import torchaudio
 from tqdm.contrib import tqdm
-from speechbrain.dataio.dataio import (
-    load_pkl,
-    save_pkl,
-)
+
+from speechbrain.dataio.dataio import load_pkl, save_pkl
 
 logger = logging.getLogger(__name__)
 OPT_FILE = "opt_voxceleb_prepare.pkl"

--- a/recipes/VoxLingua107/lang_id/create_wds_shards.py
+++ b/recipes/VoxLingua107/lang_id/create_wds_shards.py
@@ -6,9 +6,9 @@
 # Author(s): Tanel Alumäe, Nik Vaessen
 ################################################################################
 
+import argparse
 import json
 import pathlib
-import argparse
 import random
 import re
 from collections import defaultdict

--- a/recipes/VoxLingua107/lang_id/train.py
+++ b/recipes/VoxLingua107/lang_id/train.py
@@ -17,18 +17,19 @@ Author
     * Tanel Alumäe 2021
     * @nikvaessen
 """
-import os
-import sys
-import random
-from typing import Dict
 import json
-from functools import partial
-import webdataset as wds
 import logging
+import os
+import random
+import sys
+from functools import partial
+from typing import Dict
 
 import torch
-import speechbrain as sb
+import webdataset as wds
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.dataio.batch import PaddedBatch
 
 logger = logging.getLogger(__name__)

--- a/recipes/VoxPopuli/ASR/transducer/train.py
+++ b/recipes/VoxPopuli/ASR/transducer/train.py
@@ -17,13 +17,15 @@ Authors
  * Titouan Parcollet 2024
 """
 
-import sys
-import torch
 import logging
-import speechbrain as sb
-from speechbrain.utils.distributed import run_on_main, if_main_process
-from hyperpyyaml import load_hyperpyyaml
+import sys
 from pathlib import Path
+
+import torch
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/VoxPopuli/Tokenizer/train.py
+++ b/recipes/VoxPopuli/Tokenizer/train.py
@@ -12,8 +12,10 @@ Authors
 """
 
 import sys
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
 
 if __name__ == "__main__":

--- a/recipes/VoxPopuli/voxpopuli_prepare.py
+++ b/recipes/VoxPopuli/voxpopuli_prepare.py
@@ -6,15 +6,15 @@ Author
 Titouan Parcollet 2024
 """
 
-from dataclasses import dataclass
-import os
 import csv
-import re
-import logging
 import functools
+import logging
+import os
+import re
+from dataclasses import dataclass
 
-from speechbrain.utils.parallel import parallel_map
 from speechbrain.dataio.dataio import read_audio_info
+from speechbrain.utils.parallel import parallel_map
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/WHAMandWHAMR/enhancement/dynamic_mixing.py
+++ b/recipes/WHAMandWHAMR/enhancement/dynamic_mixing.py
@@ -1,13 +1,15 @@
-import speechbrain as sb
+import glob
+import os
+import random
+from pathlib import Path
+
 import numpy as np
 import torch
 import torchaudio
-import glob
-import os
-from pathlib import Path
-import random
-from speechbrain.processing.signal_processing import rescale
+
+import speechbrain as sb
 from speechbrain.dataio.batch import PaddedBatch
+from speechbrain.processing.signal_processing import rescale
 
 """
 The functions to implement Dynamic Mixing For SpeechSeparation

--- a/recipes/WHAMandWHAMR/enhancement/train.py
+++ b/recipes/WHAMandWHAMR/enhancement/train.py
@@ -18,23 +18,25 @@ Authors
  * Jianyuan Zhong 2020
 """
 
+import csv
+import logging
 import os
 import sys
+
+import numpy as np
 import torch
 import torch.nn.functional as F
 import torchaudio
+from hyperpyyaml import load_hyperpyyaml
+from pesq import pesq
+from tqdm import tqdm
+
 import speechbrain as sb
 import speechbrain.nnet.schedulers as schedulers
-from speechbrain.utils.distributed import run_on_main
-from hyperpyyaml import load_hyperpyyaml
-import numpy as np
-from tqdm import tqdm
-import csv
-import logging
-from speechbrain.processing.features import spectral_magnitude
-from speechbrain.utils.metric_stats import MetricStats
-from pesq import pesq
 from speechbrain.core import AMPConfig
+from speechbrain.processing.features import spectral_magnitude
+from speechbrain.utils.distributed import run_on_main
+from speechbrain.utils.metric_stats import MetricStats
 
 
 # Define training procedure
@@ -656,8 +658,8 @@ if __name__ == "__main__":
 
     # if whamr, and we do speedaugment we need to prepare the csv file
     if "whamr" in hparams["data_folder"] and hparams["use_speedperturb"]:
-        from prepare_data import create_whamr_rir_csv
         from create_whamr_rirs import create_rirs
+        from prepare_data import create_whamr_rir_csv
 
         # If the Room Impulse Responses do not exist, we create them
         if not os.path.exists(hparams["rir_path"]):

--- a/recipes/WHAMandWHAMR/meta/create_whamr_rirs.py
+++ b/recipes/WHAMandWHAMR/meta/create_whamr_rirs.py
@@ -5,16 +5,17 @@ Authors
     * Cem Subakan 2021
 """
 
-import os
-import pandas as pd
 import argparse
-import torchaudio
+import os
 
-from wham_room import WhamRoom
-from scipy.signal import resample_poly
+import pandas as pd
 import torch
-from speechbrain.utils.fetching import fetch
+import torchaudio
+from scipy.signal import resample_poly
 from tqdm import tqdm
+from wham_room import WhamRoom
+
+from speechbrain.utils.fetching import fetch
 
 
 def create_rirs(output_dir, sr=8000):

--- a/recipes/WHAMandWHAMR/meta/preprocess_dynamic_mixing.py
+++ b/recipes/WHAMandWHAMR/meta/preprocess_dynamic_mixing.py
@@ -8,18 +8,18 @@ Author
 Samuele Cornell, 2020
 """
 
-import os
 import argparse
-from pathlib import Path
-import tqdm
-import torchaudio
 import glob
+import os
+from pathlib import Path
+
+import numpy as np
+import torch
+import torchaudio
+import tqdm
 
 # from oct2py import octave
 from scipy import signal
-import numpy as np
-import torch
-
 
 parser = argparse.ArgumentParser(
     "utility for resampling all audio files in a folder recursively"

--- a/recipes/WHAMandWHAMR/prepare_data.py
+++ b/recipes/WHAMandWHAMR/prepare_data.py
@@ -5,8 +5,8 @@ Author
 The .csv preparation functions for WSJ0-Mix.
 """
 
-import os
 import csv
+import os
 
 
 def prepare_wham_whamr_csv(

--- a/recipes/WHAMandWHAMR/separation/dynamic_mixing.py
+++ b/recipes/WHAMandWHAMR/separation/dynamic_mixing.py
@@ -1,13 +1,15 @@
-import speechbrain as sb
+import glob
+import os
+import random
+from pathlib import Path
+
 import numpy as np
 import torch
 import torchaudio
-import glob
-import os
-from pathlib import Path
-import random
-from speechbrain.processing.signal_processing import rescale
+
+import speechbrain as sb
 from speechbrain.dataio.batch import PaddedBatch
+from speechbrain.processing.signal_processing import rescale
 
 """
 The functions to implement Dynamic Mixing For SpeechSeparation

--- a/recipes/WHAMandWHAMR/separation/train.py
+++ b/recipes/WHAMandWHAMR/separation/train.py
@@ -18,20 +18,22 @@ Authors
  * Jianyuan Zhong 2020
 """
 
+import csv
+import logging
 import os
 import sys
+
+import numpy as np
 import torch
 import torch.nn.functional as F
 import torchaudio
+from hyperpyyaml import load_hyperpyyaml
+from tqdm import tqdm
+
 import speechbrain as sb
 import speechbrain.nnet.schedulers as schedulers
-from speechbrain.utils.distributed import run_on_main
-from hyperpyyaml import load_hyperpyyaml
-import numpy as np
-from tqdm import tqdm
-import csv
-import logging
 from speechbrain.core import AMPConfig
+from speechbrain.utils.distributed import run_on_main
 
 
 # Define training procedure
@@ -575,8 +577,8 @@ if __name__ == "__main__":
 
     # if whamr, and we do speedaugment we need to prepare the csv file
     if "whamr" in hparams["data_folder"] and hparams["use_speedperturb"]:
-        from prepare_data import create_whamr_rir_csv
         from create_whamr_rirs import create_rirs
+        from prepare_data import create_whamr_rir_csv
 
         # If the Room Impulse Responses do not exist, we create them
         if not os.path.exists(hparams["rir_path"]):

--- a/recipes/WSJ0Mix/meta/preprocess_dynamic_mixing.py
+++ b/recipes/WSJ0Mix/meta/preprocess_dynamic_mixing.py
@@ -8,18 +8,18 @@ Author
 Samuele Cornell, 2020
 """
 
-import os
 import argparse
-from pathlib import Path
-import tqdm
-import torchaudio
 import glob
+import os
+from pathlib import Path
+
+import numpy as np
+import torch
+import torchaudio
+import tqdm
 
 # from oct2py import octave
 from scipy import signal
-import numpy as np
-import torch
-
 
 parser = argparse.ArgumentParser(
     "utility for resampling all audio files in a folder recursively"

--- a/recipes/WSJ0Mix/prepare_data.py
+++ b/recipes/WSJ0Mix/prepare_data.py
@@ -6,8 +6,8 @@ Author
 
  """
 
-import os
 import csv
+import os
 
 
 def prepare_wsjmix(

--- a/recipes/WSJ0Mix/separation/dynamic_mixing.py
+++ b/recipes/WSJ0Mix/separation/dynamic_mixing.py
@@ -1,13 +1,15 @@
-import speechbrain as sb
+import glob
+import os
+import random
+from pathlib import Path
+
 import numpy as np
 import torch
 import torchaudio
-import glob
-import os
-from pathlib import Path
-import random
-from speechbrain.processing.signal_processing import rescale
+
+import speechbrain as sb
 from speechbrain.dataio.batch import PaddedBatch
+from speechbrain.processing.signal_processing import rescale
 
 """
 The functions to implement Dynamic Mixing For SpeechSeparation

--- a/recipes/WSJ0Mix/separation/train.py
+++ b/recipes/WSJ0Mix/separation/train.py
@@ -21,20 +21,22 @@ Authors
  * Jianyuan Zhong 2020
 """
 
+import csv
+import logging
 import os
 import sys
+
+import numpy as np
 import torch
 import torch.nn.functional as F
 import torchaudio
+from hyperpyyaml import load_hyperpyyaml
+from tqdm import tqdm
+
 import speechbrain as sb
 import speechbrain.nnet.schedulers as schedulers
-from speechbrain.utils.distributed import run_on_main
-from hyperpyyaml import load_hyperpyyaml
-import numpy as np
-from tqdm import tqdm
-import csv
-import logging
 from speechbrain.core import AMPConfig
+from speechbrain.utils.distributed import run_on_main
 
 
 # Define training procedure

--- a/recipes/ZaionEmotionDataset/emotion_diarization/datasets/prepare_EMOVDB.py
+++ b/recipes/ZaionEmotionDataset/emotion_diarization/datasets/prepare_EMOVDB.py
@@ -10,14 +10,15 @@ Author
 Yingzhi Wang 2023
 """
 
-import numpy as np
+import json
+import logging
 import os
 import random
-from pydub import AudioSegment
-import json
-from datasets.vad import vad_for_folder
 from pathlib import Path
-import logging
+
+import numpy as np
+from datasets.vad import vad_for_folder
+from pydub import AudioSegment
 
 logger = logging.getLogger(__name__)
 repos = [

--- a/recipes/ZaionEmotionDataset/emotion_diarization/datasets/prepare_ESD.py
+++ b/recipes/ZaionEmotionDataset/emotion_diarization/datasets/prepare_ESD.py
@@ -10,13 +10,14 @@ Author
 Yingzhi Wang 2023
 """
 
-import numpy as np
+import json
+import logging
 import os
 import random
-from pydub import AudioSegment
-import json
+
+import numpy as np
 from datasets.vad import vad_for_folder
-import logging
+from pydub import AudioSegment
 
 logger = logging.getLogger(__name__)
 # we choose here only english utterances

--- a/recipes/ZaionEmotionDataset/emotion_diarization/datasets/prepare_IEMOCAP.py
+++ b/recipes/ZaionEmotionDataset/emotion_diarization/datasets/prepare_IEMOCAP.py
@@ -10,15 +10,16 @@ Author
 Yingzhi Wang 2023
 """
 
-import numpy as np
-import re
+import json
+import logging
 import os
 import random
-from pydub import AudioSegment
-import json
-from datasets.vad import write_audio
+import re
 from pathlib import Path
-import logging
+
+import numpy as np
+from datasets.vad import write_audio
+from pydub import AudioSegment
 
 logger = logging.getLogger(__name__)
 combinations = ["neu_emo", "emo_neu", "neu_emo_neu", "emo_emo"]

--- a/recipes/ZaionEmotionDataset/emotion_diarization/datasets/prepare_JLCORPUS.py
+++ b/recipes/ZaionEmotionDataset/emotion_diarization/datasets/prepare_JLCORPUS.py
@@ -10,15 +10,16 @@ Author
 Yingzhi Wang 2023
 """
 
-import numpy as np
+import json
+import logging
 import os
 import random
-from pydub import AudioSegment
-import json
-from datasets.vad import vad_for_folder
-from pathlib import Path
 import shutil
-import logging
+from pathlib import Path
+
+import numpy as np
+from datasets.vad import vad_for_folder
+from pydub import AudioSegment
 
 logger = logging.getLogger(__name__)
 repos = [

--- a/recipes/ZaionEmotionDataset/emotion_diarization/datasets/prepare_RAVDESS.py
+++ b/recipes/ZaionEmotionDataset/emotion_diarization/datasets/prepare_RAVDESS.py
@@ -10,14 +10,15 @@ Author
 Yingzhi Wang 2023
 """
 
-import numpy as np
+import json
+import logging
 import os
 import random
-from pydub import AudioSegment
-import json
-from datasets.vad import vad_for_folder
 from pathlib import Path
-import logging
+
+import numpy as np
+from datasets.vad import vad_for_folder
+from pydub import AudioSegment
 
 logger = logging.getLogger(__name__)
 repos = [

--- a/recipes/ZaionEmotionDataset/emotion_diarization/datasets/vad.py
+++ b/recipes/ZaionEmotionDataset/emotion_diarization/datasets/vad.py
@@ -9,10 +9,11 @@ Yingzhi Wang 2023
 """
 
 import collections
-import webrtcvad
 import contextlib
-import wave
 import os
+import wave
+
+import webrtcvad
 
 
 def read_wave(path):

--- a/recipes/ZaionEmotionDataset/emotion_diarization/train.py
+++ b/recipes/ZaionEmotionDataset/emotion_diarization/train.py
@@ -4,13 +4,15 @@ Authors
  * Yingzhi WANG 2023
 """
 
+import itertools
+import json
 import os
 import sys
-import speechbrain as sb
-from hyperpyyaml import load_hyperpyyaml
+
 import torch
-import json
-import itertools
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.utils.EDER import EDER
 
 
@@ -284,7 +286,7 @@ if __name__ == "__main__":
 
     # Data preparation, to be run on only one process.
     if not hparams["skip_prep"]:
-        from zed_prepare import prepare_train, prepare_test
+        from zed_prepare import prepare_test, prepare_train
 
         sb.utils.distributed.run_on_main(
             prepare_train,

--- a/recipes/ZaionEmotionDataset/emotion_diarization/zed_prepare.py
+++ b/recipes/ZaionEmotionDataset/emotion_diarization/zed_prepare.py
@@ -9,10 +9,11 @@ Author
 Yingzhi Wang 2023
 """
 
-import os
-import random
 import json
 import logging
+import os
+import random
+
 from datasets.prepare_EMOVDB import prepare_emovdb
 from datasets.prepare_ESD import prepare_esd
 from datasets.prepare_IEMOCAP import prepare_iemocap

--- a/recipes/fluent-speech-commands/Tokenizer/train.py
+++ b/recipes/fluent-speech-commands/Tokenizer/train.py
@@ -14,8 +14,10 @@ Authors
 """
 
 import sys
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
 
 if __name__ == "__main__":

--- a/recipes/fluent-speech-commands/direct/train.py
+++ b/recipes/fluent-speech-commands/direct/train.py
@@ -15,12 +15,14 @@ Authors
  * Mirco Ravanelli 2020
 """
 
-import sys
-import torch
-import speechbrain as sb
 import logging
+import sys
+
+import torch
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main, if_main_process
+
+import speechbrain as sb
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/fluent-speech-commands/prepare.py
+++ b/recipes/fluent-speech-commands/prepare.py
@@ -1,5 +1,6 @@
-import os
 import logging
+import os
+
 from speechbrain.dataio.dataio import read_audio
 
 try:

--- a/recipes/timers-and-such/LM/train.py
+++ b/recipes/timers-and-such/LM/train.py
@@ -10,9 +10,11 @@ Authors
 """
 
 import sys
+
 import torch
-import speechbrain as sb
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
 
 

--- a/recipes/timers-and-such/Tokenizer/train.py
+++ b/recipes/timers-and-such/Tokenizer/train.py
@@ -14,8 +14,10 @@ Authors
 """
 
 import sys
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
 
 if __name__ == "__main__":

--- a/recipes/timers-and-such/decoupled/train.py
+++ b/recipes/timers-and-such/decoupled/train.py
@@ -13,10 +13,12 @@ Authors
 """
 
 import sys
+
 import torch
-import speechbrain as sb
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main, if_main_process
+
+import speechbrain as sb
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 
 # Define training procedure

--- a/recipes/timers-and-such/direct/train.py
+++ b/recipes/timers-and-such/direct/train.py
@@ -15,12 +15,14 @@ Authors
  * Mirco Ravanelli 2020
 """
 
-import sys
-import torch
-import speechbrain as sb
 import logging
+import sys
+
+import torch
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main, if_main_process
+
+import speechbrain as sb
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/timers-and-such/direct/train_with_wav2vec2.py
+++ b/recipes/timers-and-such/direct/train_with_wav2vec2.py
@@ -16,13 +16,14 @@ Authors
  * Lugosch Loren 2020
 """
 
-import sys
-import torch
-import speechbrain as sb
 import logging
-from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main, if_main_process
+import sys
 
+import torch
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/recipes/timers-and-such/multistage/train.py
+++ b/recipes/timers-and-such/multistage/train.py
@@ -19,10 +19,12 @@ Authors
 """
 
 import sys
+
 import torch
-import speechbrain as sb
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.distributed import run_on_main, if_main_process
+
+import speechbrain as sb
+from speechbrain.utils.distributed import if_main_process, run_on_main
 
 
 # Define training procedure

--- a/recipes/timers-and-such/prepare.py
+++ b/recipes/timers-and-such/prepare.py
@@ -1,7 +1,8 @@
+import logging
 import os
 import shutil
-import logging
-from speechbrain.dataio.dataio import read_audio, merge_csvs
+
+from speechbrain.dataio.dataio import merge_csvs, read_audio
 from speechbrain.utils.data_utils import download_file
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 import os
-import sys
 import site
-import setuptools
+import sys
 from distutils.core import setup
 
+import setuptools
 
 # Editable install in user site directory can be allowed with this hack:
 # https://github.com/pypa/pip/issues/7953.

--- a/speechbrain/__init__.py
+++ b/speechbrain/__init__.py
@@ -12,6 +12,7 @@ from . import nnet  # noqa
 from . import processing  # noqa
 from . import tokenizers  # noqa
 from . import utils  # noqa
+from .core import Brain, Stage, create_experiment_directory, parse_arguments
 from .utils.importutils import deprecated_redirect
 
 with open(os.path.join(os.path.dirname(__file__), "version.txt")) as f:

--- a/speechbrain/__init__.py
+++ b/speechbrain/__init__.py
@@ -2,16 +2,17 @@
 """
 
 import os
-from .core import Stage, Brain, create_experiment_directory, parse_arguments
+
 from . import alignment  # noqa
 from . import dataio  # noqa
 from . import decoders  # noqa
-from . import lobes  # noqa
 from . import lm  # noqa
+from . import lobes  # noqa
 from . import nnet  # noqa
 from . import processing  # noqa
 from . import tokenizers  # noqa
 from . import utils  # noqa
+from .core import Brain, Stage, create_experiment_directory, parse_arguments
 
 with open(os.path.join(os.path.dirname(__file__), "version.txt")) as f:
     version = f.read().strip()

--- a/speechbrain/alignment/aligner.py
+++ b/speechbrain/alignment/aligner.py
@@ -6,11 +6,15 @@ Authors
  * Loren Lugosch 2020
 """
 
-import torch
 import random
-from speechbrain.utils.checkpoints import register_checkpoint_hooks
-from speechbrain.utils.checkpoints import mark_as_saver
-from speechbrain.utils.checkpoints import mark_as_loader
+
+import torch
+
+from speechbrain.utils.checkpoints import (
+    mark_as_loader,
+    mark_as_saver,
+    register_checkpoint_hooks,
+)
 from speechbrain.utils.data_utils import undo_padding
 
 

--- a/speechbrain/alignment/ctc_segmentation.py
+++ b/speechbrain/alignment/ctc_segmentation.py
@@ -12,23 +12,23 @@ Authors
 import logging
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Optional
-from typing import Union
+from typing import List, Optional, Union
 
 import numpy as np
 import torch
-from typing import List
 
 # speechbrain interface
 from speechbrain.inference.ASR import EncoderASR, EncoderDecoderASR
 
 # imports for CTC segmentation
 try:
-    from ctc_segmentation import ctc_segmentation
-    from ctc_segmentation import CtcSegmentationParameters
-    from ctc_segmentation import determine_utterance_segments
-    from ctc_segmentation import prepare_text
-    from ctc_segmentation import prepare_token_list
+    from ctc_segmentation import (
+        CtcSegmentationParameters,
+        ctc_segmentation,
+        determine_utterance_segments,
+        prepare_text,
+        prepare_token_list,
+    )
 except ImportError:
     print(
         "ImportError: "

--- a/speechbrain/augment/augmenter.py
+++ b/speechbrain/augment/augmenter.py
@@ -4,10 +4,12 @@ Authors
  * Mirco Ravanelli 2022
 """
 
-import random
 import logging
+import random
+
 import torch
 import torch.nn.functional as F
+
 from speechbrain.utils.callchains import lengths_arg_exists
 
 logger = logging.getLogger(__name__)

--- a/speechbrain/augment/codec.py
+++ b/speechbrain/augment/codec.py
@@ -15,6 +15,7 @@ Authors
 """
 
 import random
+
 import torch
 import torchaudio
 

--- a/speechbrain/augment/freq_domain.py
+++ b/speechbrain/augment/freq_domain.py
@@ -9,8 +9,9 @@ Authors:
 - Mirco Ravanelli (2023)
 """
 
-import torch
 import random
+
+import torch
 
 
 class SpectrogramDrop(torch.nn.Module):

--- a/speechbrain/augment/preparation.py
+++ b/speechbrain/augment/preparation.py
@@ -7,11 +7,12 @@ Authors:
 
 """
 
-import os
 import logging
+import os
+
 import torchaudio
-from speechbrain.utils.data_utils import download_file
-from speechbrain.utils.data_utils import get_all_files
+
+from speechbrain.utils.data_utils import download_file, get_all_files
 
 # Logger init
 logger = logging.getLogger(__name__)

--- a/speechbrain/augment/time_domain.py
+++ b/speechbrain/augment/time_domain.py
@@ -12,15 +12,17 @@ Authors:
 
 # Importing libraries
 import random
+
 import torch
 import torch.nn.functional as F
 import torchaudio
-from speechbrain.dataio.legacy import ExtendedCSVDataset
+
 from speechbrain.dataio.dataloader import make_dataloader
+from speechbrain.dataio.legacy import ExtendedCSVDataset
 from speechbrain.processing.signal_processing import (
     compute_amplitude,
-    dB_to_amplitude,
     convolve1d,
+    dB_to_amplitude,
     notch_filter,
     reverberate,
 )

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -10,38 +10,39 @@ Authors
  * Adel Moumen 2023
 """
 
-import os
-import sys
-import yaml
-import time
-import torch
-import shutil
-import logging
-import inspect
-import pathlib
 import argparse
+import inspect
+import logging
+import os
+import pathlib
+import shutil
+import sys
 import tempfile
+import time
 import warnings
 from contextlib import contextmanager
-import speechbrain as sb
+from dataclasses import dataclass
 from datetime import date
 from enum import Enum, auto
-from tqdm.contrib import tqdm
 from types import SimpleNamespace
-from torch.nn import SyncBatchNorm
-from torch.utils.data import DataLoader
-from torch.nn import DataParallel as DP
-from torch.utils.data import IterableDataset
-from torch.utils.data import DistributedSampler
-from torch.nn.parallel import DistributedDataParallel as DDP
+
+import torch
+import yaml
 from hyperpyyaml import resolve_references
+from torch.nn import DataParallel as DP
+from torch.nn import SyncBatchNorm
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.data import DataLoader, DistributedSampler, IterableDataset
+from tqdm.contrib import tqdm
+
+import speechbrain as sb
+from speechbrain.dataio.dataloader import LoopedLoader, SaveableDataLoader
+from speechbrain.dataio.sampler import (
+    DistributedSamplerWrapper,
+    ReproducibleRandomSampler,
+)
 from speechbrain.utils.optimizers import rm_vector_weight_decay
-from speechbrain.dataio.dataloader import LoopedLoader
-from speechbrain.dataio.dataloader import SaveableDataLoader
-from speechbrain.dataio.sampler import DistributedSamplerWrapper
-from speechbrain.dataio.sampler import ReproducibleRandomSampler
 from speechbrain.utils.profiling import prepare_profiler
-from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
 DEFAULT_LOG_CONFIG = os.path.dirname(os.path.abspath(__file__))

--- a/speechbrain/dataio/batch.py
+++ b/speechbrain/dataio/batch.py
@@ -5,15 +5,18 @@ Authors
 """
 
 import collections
+
 import torch
-from speechbrain.utils.data_utils import mod_default_collate
-from speechbrain.utils.data_utils import recursive_to
-from speechbrain.utils.data_utils import batch_pad_right
 from torch.utils.data._utils.collate import default_convert
 from torch.utils.data._utils.pin_memory import (
     pin_memory as recursive_pin_memory,
 )
 
+from speechbrain.utils.data_utils import (
+    batch_pad_right,
+    mod_default_collate,
+    recursive_to,
+)
 
 PaddedData = collections.namedtuple("PaddedData", ["data", "lengths"])
 

--- a/speechbrain/dataio/dataio.py
+++ b/speechbrain/dataio/dataio.py
@@ -12,17 +12,19 @@ Authors
  * Sylvain de Langen 2022
 """
 
-import os
-import torch
-import logging
-import numpy as np
-import pickle
-import hashlib
 import csv
-import time
-import torchaudio
+import hashlib
 import json
+import logging
+import os
+import pickle
 import re
+import time
+
+import numpy as np
+import torch
+import torchaudio
+
 from speechbrain.utils.torch_audio_backend import check_torchaudio_backend
 
 check_torchaudio_backend()

--- a/speechbrain/dataio/dataloader.py
+++ b/speechbrain/dataio/dataloader.py
@@ -35,23 +35,23 @@ Authors:
   * Aku Rouhe 2020
 """
 
-from torch.utils.data import DataLoader
-from torch.utils.data import IterableDataset
-from torch.utils.data.dataloader import _BaseDataLoaderIter
+import functools
 import logging
 import warnings
-import functools
-from torch.utils.data import DistributedSampler
-from speechbrain.dataio.batch import PaddedBatch, BatchsizeGuesser
+
+from torch.utils.data import DataLoader, DistributedSampler, IterableDataset
+from torch.utils.data.dataloader import _BaseDataLoaderIter
+
+from speechbrain.dataio.batch import BatchsizeGuesser, PaddedBatch
 from speechbrain.dataio.dataset import DynamicItemDataset
 from speechbrain.dataio.sampler import (
-    ReproducibleRandomSampler,
     DistributedSamplerWrapper,
+    ReproducibleRandomSampler,
 )
 from speechbrain.utils.checkpoints import (
-    register_checkpoint_hooks,
-    mark_as_saver,
     mark_as_loader,
+    mark_as_saver,
+    register_checkpoint_hooks,
 )
 
 # Optional support for webdataset

--- a/speechbrain/dataio/dataset.py
+++ b/speechbrain/dataio/dataset.py
@@ -5,15 +5,17 @@ Authors
   * Samuele Cornell 2020
 """
 
-import copy
 import contextlib
-from types import MethodType
-from torch.utils.data import Dataset
-from speechbrain.utils.data_pipeline import DataPipeline
-from speechbrain.dataio.dataio import load_data_json, load_data_csv
-from speechbrain.utils.data_utils import batch_shuffle
+import copy
 import logging
 import math
+from types import MethodType
+
+from torch.utils.data import Dataset
+
+from speechbrain.dataio.dataio import load_data_csv, load_data_json
+from speechbrain.utils.data_pipeline import DataPipeline
+from speechbrain.utils.data_utils import batch_shuffle
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/dataio/encoder.py
+++ b/speechbrain/dataio/encoder.py
@@ -6,14 +6,16 @@ Authors
 """
 
 import ast
-import torch
 import collections
 import itertools
 import logging
+
+import torch
+
 import speechbrain as sb
 from speechbrain.utils.checkpoints import (
-    mark_as_saver,
     mark_as_loader,
+    mark_as_saver,
     register_checkpoint_hooks,
 )
 

--- a/speechbrain/dataio/iterators.py
+++ b/speechbrain/dataio/iterators.py
@@ -9,6 +9,7 @@ import random
 from dataclasses import dataclass, field
 from functools import partial
 from typing import Any
+
 from speechbrain.dataio.batch import PaddedBatch
 
 

--- a/speechbrain/dataio/legacy.py
+++ b/speechbrain/dataio/legacy.py
@@ -1,13 +1,15 @@
 """SpeechBrain Extended CSV Compatibility."""
 
-from speechbrain.dataio.dataset import DynamicItemDataset
 import collections
 import csv
-import pickle
 import logging
+import pickle
+import re
+
 import torch
 import torchaudio
-import re
+
+from speechbrain.dataio.dataset import DynamicItemDataset
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/dataio/preprocess.py
+++ b/speechbrain/dataio/preprocess.py
@@ -1,6 +1,7 @@
 """Preprocessors for audio"""
 
 import torch
+
 from speechbrain.augment.time_domain import Resample
 
 

--- a/speechbrain/dataio/sampler.py
+++ b/speechbrain/dataio/sampler.py
@@ -11,20 +11,22 @@ Authors:
   * Adel Moumen 2023
 """
 
-import torch
 import logging
-from operator import itemgetter
-from torch.utils.data import (
-    RandomSampler,
-    WeightedRandomSampler,
-    DistributedSampler,
-    Sampler,
-)
-import numpy as np
-from typing import List
-from speechbrain.dataio.dataset import DynamicItemDataset
 from collections import Counter
+from operator import itemgetter
+from typing import List
+
+import numpy as np
+import torch
 from scipy.stats import lognorm
+from torch.utils.data import (
+    DistributedSampler,
+    RandomSampler,
+    Sampler,
+    WeightedRandomSampler,
+)
+
+from speechbrain.dataio.dataset import DynamicItemDataset
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/dataio/wer.py
+++ b/speechbrain/dataio/wer.py
@@ -10,6 +10,7 @@ Authors
 """
 
 import sys
+
 from speechbrain.utils import edit_distance
 
 

--- a/speechbrain/decoders/__init__.py
+++ b/speechbrain/decoders/__init__.py
@@ -2,6 +2,6 @@
 """
 
 from .ctc import *  # noqa
+from .scorer import *  # noqa
 from .seq2seq import *  # noqa
 from .transducer import *  # noqa
-from .scorer import *  # noqa

--- a/speechbrain/decoders/ctc.py
+++ b/speechbrain/decoders/ctc.py
@@ -7,16 +7,18 @@ Authors
  * Adel Moumen 2023, 2024
 """
 
-from itertools import groupby
-from speechbrain.dataio.dataio import length_to_mask
-import math
 import dataclasses
-import numpy as np
 import heapq
 import logging
-import torch
+import math
 import warnings
-from typing import Dict, List, Optional, Union, Any, Tuple
+from itertools import groupby
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import numpy as np
+import torch
+
+from speechbrain.dataio.dataio import length_to_mask
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/decoders/language_model.py
+++ b/speechbrain/decoders/language_model.py
@@ -11,17 +11,10 @@ Authors
 """
 
 import logging
-from typing import (
-    Collection,
-    Optional,
-    Set,
-    Tuple,
-    cast,
-)
+import math
+from typing import Collection, Optional, Set, Tuple, cast
 
 from pygtrie import CharTrie
-
-import math
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/decoders/scorer.py
+++ b/speechbrain/decoders/scorer.py
@@ -6,8 +6,9 @@ Authors:
  * Sung-Lin Yeh 2021
 """
 
-import torch
 import numpy as np
+import torch
+
 import speechbrain as sb
 from speechbrain.decoders.ctc import CTCPrefixScore
 

--- a/speechbrain/decoders/seq2seq.py
+++ b/speechbrain/decoders/seq2seq.py
@@ -9,10 +9,11 @@ Authors
 """
 
 import torch
+
 from speechbrain.decoders.utils import (
+    _update_mem,
     inflate_tensor,
     mask_by_condition,
-    _update_mem,
 )
 from speechbrain.utils.data_utils import undo_padding
 

--- a/speechbrain/decoders/transducer.py
+++ b/speechbrain/decoders/transducer.py
@@ -5,10 +5,11 @@ Author:
     Sung-Lin Yeh 2020
 """
 
-import torch
 from dataclasses import dataclass
 from functools import partial
-from typing import Optional, Any
+from typing import Any, Optional
+
+import torch
 
 
 @dataclass

--- a/speechbrain/inference/ASR.py
+++ b/speechbrain/inference/ASR.py
@@ -14,18 +14,20 @@ Authors:
  * Pradnya Kandarkar 2023
 """
 
-from dataclasses import dataclass
-from typing import Any, Optional, List, Tuple
+import functools
 import itertools
+from dataclasses import dataclass
+from typing import Any, List, Optional, Tuple
+
+import sentencepiece
 import torch
 import torchaudio
-import sentencepiece
+
 import speechbrain
 from speechbrain.inference.interfaces import Pretrained
-import functools
-from speechbrain.utils.fetching import fetch
 from speechbrain.utils.data_utils import split_path
 from speechbrain.utils.dynamic_chunk_training import DynChunkTrainConfig
+from speechbrain.utils.fetching import fetch
 from speechbrain.utils.streaming import split_fixed_chunks
 
 

--- a/speechbrain/inference/SLU.py
+++ b/speechbrain/inference/SLU.py
@@ -15,8 +15,9 @@ Authors:
 """
 
 import torch
-from speechbrain.inference.interfaces import Pretrained
+
 from speechbrain.inference.ASR import EncoderDecoderASR
+from speechbrain.inference.interfaces import Pretrained
 
 
 class EndToEndSLU(Pretrained):

--- a/speechbrain/inference/ST.py
+++ b/speechbrain/inference/ST.py
@@ -15,6 +15,7 @@ Authors:
 """
 
 import torch
+
 from speechbrain.inference.interfaces import Pretrained
 
 

--- a/speechbrain/inference/TTS.py
+++ b/speechbrain/inference/TTS.py
@@ -14,19 +14,20 @@ Authors:
  * Pradnya Kandarkar 2023
 """
 
-import re
 import logging
+import random
+import re
+
 import torch
 import torchaudio
-import random
-import speechbrain
-from speechbrain.utils.fetching import fetch
-from speechbrain.inference.interfaces import Pretrained
-from speechbrain.utils.text_to_sequence import text_to_sequence
-from speechbrain.inference.text import GraphemeToPhoneme
-from speechbrain.inference.encoders import MelSpectrogramEncoder
-from speechbrain.inference.classifiers import EncoderClassifier
 
+import speechbrain
+from speechbrain.inference.classifiers import EncoderClassifier
+from speechbrain.inference.encoders import MelSpectrogramEncoder
+from speechbrain.inference.interfaces import Pretrained
+from speechbrain.inference.text import GraphemeToPhoneme
+from speechbrain.utils.fetching import fetch
+from speechbrain.utils.text_to_sequence import text_to_sequence
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/inference/VAD.py
+++ b/speechbrain/inference/VAD.py
@@ -16,9 +16,10 @@ Authors:
 
 import torch
 import torchaudio
+
+from speechbrain.inference.interfaces import Pretrained
 from speechbrain.utils.data_utils import split_path
 from speechbrain.utils.fetching import fetch
-from speechbrain.inference.interfaces import Pretrained
 
 
 class VAD(Pretrained):

--- a/speechbrain/inference/__init__.py
+++ b/speechbrain/inference/__init__.py
@@ -1,7 +1,6 @@
 """Importing all the inference interfaces"""
 
 from . import *  # noqa
-
 from .ASR import *  # noqa
 from .classifiers import *  # noqa
 from .diarization import *  # noqa

--- a/speechbrain/inference/classifiers.py
+++ b/speechbrain/inference/classifiers.py
@@ -16,10 +16,11 @@ Authors:
 
 import torch
 import torchaudio
+
 import speechbrain
-from speechbrain.utils.fetching import fetch
-from speechbrain.utils.data_utils import split_path
 from speechbrain.inference.interfaces import Pretrained
+from speechbrain.utils.data_utils import split_path
+from speechbrain.utils.fetching import fetch
 
 
 class EncoderClassifier(Pretrained):

--- a/speechbrain/inference/diarization.py
+++ b/speechbrain/inference/diarization.py
@@ -15,6 +15,7 @@ Authors:
 """
 
 import torch
+
 from speechbrain.inference.interfaces import Pretrained
 
 

--- a/speechbrain/inference/encoders.py
+++ b/speechbrain/inference/encoders.py
@@ -15,6 +15,7 @@ Authors:
 """
 
 import torch
+
 from speechbrain.inference.interfaces import Pretrained
 
 

--- a/speechbrain/inference/enhancement.py
+++ b/speechbrain/inference/enhancement.py
@@ -16,6 +16,7 @@ Authors:
 
 import torch
 import torchaudio
+
 from speechbrain.inference.interfaces import Pretrained
 from speechbrain.utils.callchains import lengths_arg_exists
 

--- a/speechbrain/inference/interfaces.py
+++ b/speechbrain/inference/interfaces.py
@@ -14,23 +14,25 @@ Authors:
  * Pradnya Kandarkar 2023
 """
 
-import logging
 import hashlib
+import logging
 import sys
 import warnings
+from types import SimpleNamespace
+
 import torch
 import torchaudio
-from types import SimpleNamespace
-from torch.nn import SyncBatchNorm
-from torch.nn import DataParallel as DP
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.fetching import fetch
-from speechbrain.dataio.preprocess import AudioNormalizer
+from torch.nn import DataParallel as DP
+from torch.nn import SyncBatchNorm
 from torch.nn.parallel import DistributedDataParallel as DDP
+
+from speechbrain.dataio.batch import PaddedBatch, PaddedData
+from speechbrain.dataio.preprocess import AudioNormalizer
+from speechbrain.utils.data_pipeline import DataPipeline
 from speechbrain.utils.data_utils import split_path
 from speechbrain.utils.distributed import run_on_main
-from speechbrain.dataio.batch import PaddedBatch, PaddedData
-from speechbrain.utils.data_pipeline import DataPipeline
+from speechbrain.utils.fetching import fetch
 from speechbrain.utils.superpowers import import_from_path
 
 logger = logging.getLogger(__name__)

--- a/speechbrain/inference/interpretability.py
+++ b/speechbrain/inference/interpretability.py
@@ -15,13 +15,14 @@ Authors:
 """
 
 import torch
-import torchaudio
 import torch.nn.functional as F
+import torchaudio
+
 import speechbrain
-from speechbrain.utils.fetching import fetch
-from speechbrain.utils.data_utils import split_path
-from speechbrain.processing.NMF import spectral_phase
 from speechbrain.inference.interfaces import Pretrained
+from speechbrain.processing.NMF import spectral_phase
+from speechbrain.utils.data_utils import split_path
+from speechbrain.utils.fetching import fetch
 
 
 class PIQAudioInterpreter(Pretrained):

--- a/speechbrain/inference/metrics.py
+++ b/speechbrain/inference/metrics.py
@@ -15,6 +15,7 @@ Authors:
 """
 
 import torch
+
 from speechbrain.inference.interfaces import Pretrained
 
 

--- a/speechbrain/inference/separation.py
+++ b/speechbrain/inference/separation.py
@@ -15,11 +15,12 @@ Authors:
 """
 
 import torch
-import torchaudio
 import torch.nn.functional as F
-from speechbrain.utils.fetching import fetch
-from speechbrain.utils.data_utils import split_path
+import torchaudio
+
 from speechbrain.inference.interfaces import Pretrained
+from speechbrain.utils.data_utils import split_path
+from speechbrain.utils.fetching import fetch
 
 
 class SepformerSeparation(Pretrained):

--- a/speechbrain/inference/speaker.py
+++ b/speechbrain/inference/speaker.py
@@ -15,6 +15,7 @@ Authors:
 """
 
 import torch
+
 from speechbrain.inference.classifiers import EncoderClassifier
 
 

--- a/speechbrain/inference/text.py
+++ b/speechbrain/inference/text.py
@@ -14,11 +14,13 @@ Authors:
  * Pradnya Kandarkar 2023
 """
 
-import torch
 from itertools import chain
+
+import torch
+
 from speechbrain.inference.interfaces import (
-    Pretrained,
     EncodeDecodePipelineMixin,
+    Pretrained,
 )
 
 

--- a/speechbrain/inference/vocoders.py
+++ b/speechbrain/inference/vocoders.py
@@ -15,7 +15,9 @@ Authors:
 """
 
 import logging
+
 import torch
+
 from speechbrain.dataio.dataio import length_to_mask
 from speechbrain.inference.interfaces import Pretrained
 

--- a/speechbrain/k2_integration/__init__.py
+++ b/speechbrain/k2_integration/__init__.py
@@ -25,9 +25,11 @@ except ImportError:
     MSG += "Checkout: https://k2-fsa.github.io/k2/installation/from_wheels.html"
     raise ImportError(MSG)
 
-from . import utils
-from . import graph_compiler
-from . import lattice_decoder
-from . import lexicon
-from . import losses
-from . import prepare_lang
+from . import (
+    graph_compiler,
+    lattice_decoder,
+    lexicon,
+    losses,
+    prepare_lang,
+    utils,
+)

--- a/speechbrain/k2_integration/graph_compiler.py
+++ b/speechbrain/k2_integration/graph_compiler.py
@@ -10,11 +10,12 @@ Authors:
   * Georgios Karakasidis 2023
 """
 
+import abc
+import logging
 import os
 from typing import List, Optional, Tuple
-import abc
+
 import torch
-import logging
 
 from . import k2  # import k2 from ./__init__.py
 from . import lexicon

--- a/speechbrain/k2_integration/lattice_decoder.py
+++ b/speechbrain/k2_integration/lattice_decoder.py
@@ -10,17 +10,17 @@ Authors:
   * Georgios Karakasidis 2023
 """
 
+import logging
+from collections import OrderedDict
 from pathlib import Path
 from typing import Dict, List, Optional, Union
-from collections import OrderedDict
-
-from . import k2  # import k2 from ./__init__.py
-from speechbrain.utils.distributed import run_on_main
-from speechbrain.lm.arpa import arpa_to_fst
 
 import torch
-import logging
 
+from speechbrain.lm.arpa import arpa_to_fst
+from speechbrain.utils.distributed import run_on_main
+
+from . import k2  # import k2 from ./__init__.py
 from . import graph_compiler, utils
 
 logger = logging.getLogger(__name__)

--- a/speechbrain/k2_integration/lexicon.py
+++ b/speechbrain/k2_integration/lexicon.py
@@ -15,16 +15,16 @@ Authors:
   * Georgios Karakasidis 2023
 """
 
-import logging
-import re
-import os
 import csv
+import logging
+import os
+import re
 from pathlib import Path
-from typing import List, Union, Tuple, Optional
-
-from . import k2  # import k2 from ./__init__.py
+from typing import List, Optional, Tuple, Union
 
 import torch
+
+from . import k2  # import k2 from ./__init__.py
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/k2_integration/losses.py
+++ b/speechbrain/k2_integration/losses.py
@@ -7,9 +7,9 @@ Authors:
  * Georgios Karakasidis 2023
 """
 
-from . import k2  # import k2 from ./__init__.py
-
 import torch
+
+from . import k2  # import k2 from ./__init__.py
 
 
 def ctc_k2(

--- a/speechbrain/k2_integration/prepare_lang.py
+++ b/speechbrain/k2_integration/prepare_lang.py
@@ -11,15 +11,17 @@ Modified by:
 """
 
 
-from . import k2  # import k2 from ./__init__.py
-from .lexicon import read_lexicon, write_lexicon, EPS
+import logging
 import math
 import os
-import logging
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, Union
+
 import torch
+
+from . import k2  # import k2 from ./__init__.py
+from .lexicon import EPS, read_lexicon, write_lexicon
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/k2_integration/utils.py
+++ b/speechbrain/k2_integration/utils.py
@@ -9,10 +9,11 @@ Authors:
   * Georgios Karakasidis 2023
 """
 
-import os
 import logging
+import os
 from pathlib import Path
 from typing import List, Union
+
 import torch
 
 from . import k2  # import k2 from ./__init__.py

--- a/speechbrain/lobes/beamform_multimic.py
+++ b/speechbrain/lobes/beamform_multimic.py
@@ -5,16 +5,9 @@ Authors
 """
 
 import torch
-from speechbrain.processing.features import (
-    STFT,
-    ISTFT,
-)
 
-from speechbrain.processing.multi_mic import (
-    Covariance,
-    GccPhat,
-    DelaySum,
-)
+from speechbrain.processing.features import ISTFT, STFT
+from speechbrain.processing.multi_mic import Covariance, DelaySum, GccPhat
 
 
 class DelaySum_Beamformer(torch.nn.Module):

--- a/speechbrain/lobes/downsampling.py
+++ b/speechbrain/lobes/downsampling.py
@@ -7,6 +7,7 @@ Authors
 
 import torch
 import torchaudio.transforms as T
+
 from speechbrain.nnet.CNN import Conv1d
 from speechbrain.nnet.pooling import Pooling1d
 

--- a/speechbrain/lobes/features.py
+++ b/speechbrain/lobes/features.py
@@ -8,21 +8,23 @@ Authors
 """
 
 from dataclasses import dataclass
-import torch
 from typing import Optional
-from speechbrain.processing.features import (
-    STFT,
-    spectral_magnitude,
-    Filterbank,
-    DCT,
-    Deltas,
-    ContextWindow,
-)
-from speechbrain.utils.autocast import fwd_default_precision
-from speechbrain.utils.filter_analysis import FilterProperties
+
+import torch
+
 from speechbrain.nnet.CNN import GaborConv1d
 from speechbrain.nnet.normalization import PCEN
 from speechbrain.nnet.pooling import GaussianLowpassPooling
+from speechbrain.processing.features import (
+    DCT,
+    STFT,
+    ContextWindow,
+    Deltas,
+    Filterbank,
+    spectral_magnitude,
+)
+from speechbrain.utils.autocast import fwd_default_precision
+from speechbrain.utils.filter_analysis import FilterProperties
 
 
 class Fbank(torch.nn.Module):

--- a/speechbrain/lobes/models/CRDNN.py
+++ b/speechbrain/lobes/models/CRDNN.py
@@ -9,6 +9,7 @@ Authors
 """
 
 import torch
+
 import speechbrain as sb
 
 

--- a/speechbrain/lobes/models/Cnn14.py
+++ b/speechbrain/lobes/models/Cnn14.py
@@ -5,9 +5,9 @@
  * Francesco Paissan 2022
 """
 
+import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import torch
 
 
 def init_layer(layer):

--- a/speechbrain/lobes/models/ContextNet.py
+++ b/speechbrain/lobes/models/ContextNet.py
@@ -7,12 +7,13 @@ Authors
 
 import torch
 from torch.nn import Dropout
-from speechbrain.nnet.CNN import DepthwiseSeparableConv1d, Conv1d
-from speechbrain.nnet.linear import Linear
-from speechbrain.nnet.pooling import AdaptivePool
-from speechbrain.nnet.containers import Sequential
-from speechbrain.nnet.normalization import BatchNorm1d
+
 from speechbrain.nnet.activations import Swish
+from speechbrain.nnet.CNN import Conv1d, DepthwiseSeparableConv1d
+from speechbrain.nnet.containers import Sequential
+from speechbrain.nnet.linear import Linear
+from speechbrain.nnet.normalization import BatchNorm1d
+from speechbrain.nnet.pooling import AdaptivePool
 
 
 class ContextNet(Sequential):

--- a/speechbrain/lobes/models/DiffWave.py
+++ b/speechbrain/lobes/models/DiffWave.py
@@ -28,15 +28,16 @@ Authors
 # limitations under the License.
 # ==============================================================================
 
+from math import sqrt
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from speechbrain.nnet.CNN import Conv1d
-from speechbrain.nnet import linear
-from speechbrain.nnet.diffusion import DenoisingDiffusion
-from math import sqrt
 from torchaudio import transforms
 
+from speechbrain.nnet import linear
+from speechbrain.nnet.CNN import Conv1d
+from speechbrain.nnet.diffusion import DenoisingDiffusion
 
 Linear = linear.Linear
 ConvTranspose2d = nn.ConvTranspose2d

--- a/speechbrain/lobes/models/ECAPA_TDNN.py
+++ b/speechbrain/lobes/models/ECAPA_TDNN.py
@@ -7,10 +7,11 @@ Authors
 import torch  # noqa: F401
 import torch.nn as nn
 import torch.nn.functional as F
+
 from speechbrain.dataio.dataio import length_to_mask
 from speechbrain.nnet.CNN import Conv1d as _Conv1d
-from speechbrain.nnet.normalization import BatchNorm1d as _BatchNorm1d
 from speechbrain.nnet.linear import Linear
+from speechbrain.nnet.normalization import BatchNorm1d as _BatchNorm1d
 
 
 # Skip transpose as much as possible for efficiency

--- a/speechbrain/lobes/models/ESPnetVGG.py
+++ b/speechbrain/lobes/models/ESPnetVGG.py
@@ -7,6 +7,7 @@ Authors
 """
 
 import torch
+
 import speechbrain as sb
 
 

--- a/speechbrain/lobes/models/EnhanceResnet.py
+++ b/speechbrain/lobes/models/EnhanceResnet.py
@@ -5,8 +5,9 @@ Author
 """
 
 import torch
+
 import speechbrain as sb
-from speechbrain.processing.features import STFT, ISTFT, spectral_magnitude
+from speechbrain.processing.features import ISTFT, STFT, spectral_magnitude
 
 
 class EnhanceResnet(torch.nn.Module):

--- a/speechbrain/lobes/models/FastSpeech2.py
+++ b/speechbrain/lobes/models/FastSpeech2.py
@@ -7,21 +7,22 @@ Authors
 * Yingzhi Wang 2023
 """
 
+import numpy as np
 import torch
-from torch import nn
 import torch.nn.functional as F
+from torch import nn
 from torch.nn.modules.loss import _Loss
-from speechbrain.nnet import CNN, linear
-from speechbrain.nnet.embedding import Embedding
+
 from speechbrain.lobes.models.transformer.Transformer import (
-    TransformerEncoder,
     PositionalEncoding,
+    TransformerEncoder,
     get_key_padding_mask,
     get_mask_from_lengths,
 )
-from speechbrain.nnet.normalization import LayerNorm
+from speechbrain.nnet import CNN, linear
+from speechbrain.nnet.embedding import Embedding
 from speechbrain.nnet.losses import bce_loss
-import numpy as np
+from speechbrain.nnet.normalization import LayerNorm
 
 
 class EncoderPreNet(nn.Module):

--- a/speechbrain/lobes/models/HifiGAN.py
+++ b/speechbrain/lobes/models/HifiGAN.py
@@ -33,11 +33,12 @@ Authors
 # SOFTWARE.
 
 import torch
-import torch.nn.functional as F
 import torch.nn as nn
-import speechbrain as sb
-from speechbrain.nnet.CNN import Conv1d, ConvTranspose1d, Conv2d
+import torch.nn.functional as F
 from torchaudio import transforms
+
+import speechbrain as sb
+from speechbrain.nnet.CNN import Conv1d, Conv2d, ConvTranspose1d
 
 LRELU_SLOPE = 0.1
 

--- a/speechbrain/lobes/models/L2I.py
+++ b/speechbrain/lobes/models/L2I.py
@@ -5,9 +5,9 @@
  * Francesco Paissan 2022
 """
 
+import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import torch
 
 from speechbrain.lobes.models.PIQ import ResBlockAudio
 

--- a/speechbrain/lobes/models/MSTacotron2.py
+++ b/speechbrain/lobes/models/MSTacotron2.py
@@ -39,20 +39,22 @@ Authors
 #
 # *****************************************************************************
 
+import pickle
+from collections import namedtuple
 from math import sqrt
-from speechbrain.nnet.loss.guidedattn_loss import GuidedAttentionLoss
+
 import torch
 from torch import nn
 from torch.nn import functional as F
-from collections import namedtuple
-import pickle
+
 from speechbrain.lobes.models.Tacotron2 import (
+    Decoder,
+    Encoder,
     LinearNorm,
     Postnet,
-    Encoder,
-    Decoder,
     get_mask_from_lengths,
 )
+from speechbrain.nnet.loss.guidedattn_loss import GuidedAttentionLoss
 
 
 class Tacotron2(nn.Module):

--- a/speechbrain/lobes/models/MetricGAN.py
+++ b/speechbrain/lobes/models/MetricGAN.py
@@ -5,9 +5,10 @@ Authors:
 """
 
 import torch
-import speechbrain as sb
 from torch import nn
 from torch.nn.utils import spectral_norm
+
+import speechbrain as sb
 
 
 def xavier_init_layer(

--- a/speechbrain/lobes/models/MetricGAN_U.py
+++ b/speechbrain/lobes/models/MetricGAN_U.py
@@ -5,9 +5,10 @@ Authors:
 """
 
 import torch
-import speechbrain as sb
 from torch import nn
 from torch.nn.utils import spectral_norm
+
+import speechbrain as sb
 
 
 def xavier_init_layer(

--- a/speechbrain/lobes/models/RNNLM.py
+++ b/speechbrain/lobes/models/RNNLM.py
@@ -10,6 +10,7 @@ Authors
 
 import torch
 from torch import nn
+
 import speechbrain as sb
 
 

--- a/speechbrain/lobes/models/ResNet.py
+++ b/speechbrain/lobes/models/ResNet.py
@@ -10,8 +10,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from speechbrain.nnet.normalization import BatchNorm1d as _BatchNorm1d
 from speechbrain.nnet.linear import Linear
+from speechbrain.nnet.normalization import BatchNorm1d as _BatchNorm1d
 
 
 def conv3x3(in_planes, out_planes, stride=1):

--- a/speechbrain/lobes/models/Tacotron2.py
+++ b/speechbrain/lobes/models/Tacotron2.py
@@ -38,15 +38,17 @@ Authors
 #
 # *****************************************************************************
 
+from collections import namedtuple
 from math import sqrt
-from speechbrain.nnet.loss.guidedattn_loss import GuidedAttentionLoss
-from speechbrain.lobes.models.transformer.Transformer import (
-    get_mask_from_lengths,
-)
+
 import torch
 from torch import nn
 from torch.nn import functional as F
-from collections import namedtuple
+
+from speechbrain.lobes.models.transformer.Transformer import (
+    get_mask_from_lengths,
+)
+from speechbrain.nnet.loss.guidedattn_loss import GuidedAttentionLoss
 
 
 class LinearNorm(torch.nn.Module):

--- a/speechbrain/lobes/models/VanillaNN.py
+++ b/speechbrain/lobes/models/VanillaNN.py
@@ -5,6 +5,7 @@ Authors
 """
 
 import torch
+
 import speechbrain as sb
 
 

--- a/speechbrain/lobes/models/Xvector.py
+++ b/speechbrain/lobes/models/Xvector.py
@@ -8,11 +8,12 @@ Authors
 # import os
 import torch  # noqa: F401
 import torch.nn as nn
+
 import speechbrain as sb
-from speechbrain.nnet.pooling import StatisticsPooling
 from speechbrain.nnet.CNN import Conv1d
 from speechbrain.nnet.linear import Linear
 from speechbrain.nnet.normalization import BatchNorm1d
+from speechbrain.nnet.pooling import StatisticsPooling
 
 
 class Xvector(torch.nn.Module):

--- a/speechbrain/lobes/models/conv_tasnet.py
+++ b/speechbrain/lobes/models/conv_tasnet.py
@@ -3,9 +3,9 @@
 
 import torch
 import torch.nn as nn
-import speechbrain as sb
 import torch.nn.functional as F
 
+import speechbrain as sb
 from speechbrain.processing.signal_processing import overlap_and_add
 
 EPS = 1e-8

--- a/speechbrain/lobes/models/convolution.py
+++ b/speechbrain/lobes/models/convolution.py
@@ -6,7 +6,8 @@ Authors
 """
 
 import torch
-from speechbrain.nnet.CNN import Conv2d, Conv1d
+
+from speechbrain.nnet.CNN import Conv1d, Conv2d
 from speechbrain.nnet.containers import Sequential
 from speechbrain.nnet.normalization import LayerNorm
 from speechbrain.utils.filter_analysis import (

--- a/speechbrain/lobes/models/discrete/dac.py
+++ b/speechbrain/lobes/models/discrete/dac.py
@@ -9,10 +9,10 @@ Author
 
 """
 
+import logging
 import math
 from pathlib import Path
 from typing import List, Union
-import logging
 
 import numpy as np
 import torch

--- a/speechbrain/lobes/models/dual_path.py
+++ b/speechbrain/lobes/models/dual_path.py
@@ -8,19 +8,21 @@ Authors
  * Jianyuan Zhong 2020
 """
 
+import copy
 import math
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import copy
-from speechbrain.nnet.linear import Linear
-from speechbrain.lobes.models.transformer.Transformer import TransformerEncoder
-from speechbrain.lobes.models.transformer.Transformer import PositionalEncoding
-from speechbrain.lobes.models.transformer.Conformer import ConformerEncoder
+
 import speechbrain.nnet.RNN as SBRNN
-
+from speechbrain.lobes.models.transformer.Conformer import ConformerEncoder
+from speechbrain.lobes.models.transformer.Transformer import (
+    PositionalEncoding,
+    TransformerEncoder,
+)
 from speechbrain.nnet.activations import Swish
-
+from speechbrain.nnet.linear import Linear
 
 EPS = 1e-8
 
@@ -733,10 +735,10 @@ class DPTNetBlock(nn.Module):
         self, d_model, nhead, dim_feedforward=256, dropout=0, activation="relu"
     ):
         from torch.nn.modules.activation import MultiheadAttention
-        from torch.nn.modules.normalization import LayerNorm
         from torch.nn.modules.dropout import Dropout
-        from torch.nn.modules.rnn import LSTM
         from torch.nn.modules.linear import Linear
+        from torch.nn.modules.normalization import LayerNorm
+        from torch.nn.modules.rnn import LSTM
 
         super().__init__()
         self.self_attn = MultiheadAttention(d_model, nhead, dropout=dropout)

--- a/speechbrain/lobes/models/fairseq_wav2vec.py
+++ b/speechbrain/lobes/models/fairseq_wav2vec.py
@@ -9,12 +9,14 @@ Authors
  * Salima Mdhaffar 2021
 """
 
-import torch
 import logging
+
+import torch
 import torch.nn.functional as F
 from torch import nn
-from speechbrain.utils.data_utils import download_file
+
 from speechbrain.dataio.dataio import length_to_mask
+from speechbrain.utils.data_utils import download_file
 
 # We check if fairseq is installed.
 try:

--- a/speechbrain/lobes/models/flair/embeddings.py
+++ b/speechbrain/lobes/models/flair/embeddings.py
@@ -4,11 +4,12 @@ Authors
 * Sylvain de Langen 2024
 """
 
+from typing import List, Union
+
 import flair
+import torch
 from flair.data import Sentence
 from flair.embeddings import Embeddings
-from typing import List, Union
-import torch
 
 from speechbrain.utils.fetching import fetch
 

--- a/speechbrain/lobes/models/flair/sequencetagger.py
+++ b/speechbrain/lobes/models/flair/sequencetagger.py
@@ -4,10 +4,10 @@ Authors
 * Sylvain de Langen 2024
 """
 
+from typing import List, Union
+
 from flair.data import Sentence
 from flair.models import SequenceTagger
-
-from typing import List, Union
 
 from speechbrain.utils.fetching import fetch
 

--- a/speechbrain/lobes/models/g2p/__init__.py
+++ b/speechbrain/lobes/models/g2p/__init__.py
@@ -1,5 +1,4 @@
 from . import dataio  # noqa
 from . import homograph  # noqa
 from . import model  # noqa
-
 from .dataio import *  # noqa

--- a/speechbrain/lobes/models/g2p/dataio.py
+++ b/speechbrain/lobes/models/g2p/dataio.py
@@ -7,12 +7,14 @@ Authors
  * Artem Ploujnikov 2021 (minor refactoring only)
 """
 
-from functools import reduce
-from speechbrain.wordemb.util import expand_to_chars
-from torch import nn
-import speechbrain as sb
-import torch
 import re
+from functools import reduce
+
+import torch
+from torch import nn
+
+import speechbrain as sb
+from speechbrain.wordemb.util import expand_to_chars
 
 RE_MULTI_SPACE = re.compile(r"\s{2,}")
 

--- a/speechbrain/lobes/models/g2p/model.py
+++ b/speechbrain/lobes/models/g2p/model.py
@@ -5,16 +5,16 @@ Authors
  * Artem Ploujnikov 2021
 """
 
-from speechbrain.lobes.models.transformer.Transformer import (
-    TransformerInterface,
-    get_lookahead_mask,
-    get_key_padding_mask,
-)
-
 import torch
 from torch import nn
-from speechbrain.nnet.linear import Linear
+
+from speechbrain.lobes.models.transformer.Transformer import (
+    TransformerInterface,
+    get_key_padding_mask,
+    get_lookahead_mask,
+)
 from speechbrain.nnet import normalization
+from speechbrain.nnet.linear import Linear
 
 
 class AttentionSeq2Seq(nn.Module):

--- a/speechbrain/lobes/models/huggingface_transformers/__init__.py
+++ b/speechbrain/lobes/models/huggingface_transformers/__init__.py
@@ -12,12 +12,12 @@ except ImportError:
     MSG += "For more information, visit: https://huggingface.co/docs/transformers/installation"
     raise ImportError(MSG)
 
+from .encodec import *  # noqa
 from .gpt import *  # noqa
 from .hubert import *  # noqa
 from .huggingface import *  # noqa
+from .textencoder import *  # noqa
 from .wav2vec2 import *  # noqa
 from .wavlm import *  # noqa
-from .whisper import *  # noqa
-from .encodec import *  # noqa
 from .weighted_ssl import *  # noqa
-from .textencoder import *  # noqa
+from .whisper import *  # noqa

--- a/speechbrain/lobes/models/huggingface_transformers/discrete_hubert.py
+++ b/speechbrain/lobes/models/huggingface_transformers/discrete_hubert.py
@@ -12,9 +12,10 @@ Author
 """
 
 import logging
+
+import joblib
 import torch
 from huggingface_hub import hf_hub_download
-import joblib
 
 from speechbrain.lobes.models.huggingface_transformers.hubert import HuBERT
 

--- a/speechbrain/lobes/models/huggingface_transformers/discrete_wav2vec2.py
+++ b/speechbrain/lobes/models/huggingface_transformers/discrete_wav2vec2.py
@@ -12,9 +12,10 @@ Author
 """
 
 import logging
+
+import joblib
 import torch
 from huggingface_hub import hf_hub_download
-import joblib
 
 from speechbrain.lobes.models.huggingface_transformers.wav2vec2 import Wav2Vec2
 

--- a/speechbrain/lobes/models/huggingface_transformers/discrete_wavlm.py
+++ b/speechbrain/lobes/models/huggingface_transformers/discrete_wavlm.py
@@ -12,9 +12,10 @@ Author
 """
 
 import logging
+
+import joblib
 import torch
 from huggingface_hub import hf_hub_download
-import joblib
 
 from speechbrain.lobes.models.huggingface_transformers.wavlm import WavLM
 

--- a/speechbrain/lobes/models/huggingface_transformers/encodec.py
+++ b/speechbrain/lobes/models/huggingface_transformers/encodec.py
@@ -15,10 +15,12 @@ Authors
  * Artem Ploujnikov 2023
 """
 
-import torch
 import logging
+
+import torch
 from torch.nn import functional as F
-from speechbrain.dataio.dataio import length_to_mask, clean_padding_
+
+from speechbrain.dataio.dataio import clean_padding_, length_to_mask
 from speechbrain.lobes.models.huggingface_transformers.huggingface import (
     HFTransformersInterface,
 )

--- a/speechbrain/lobes/models/huggingface_transformers/gpt.py
+++ b/speechbrain/lobes/models/huggingface_transformers/gpt.py
@@ -9,12 +9,12 @@ Authors
 """
 
 import logging
+
 import torch
 
 from speechbrain.lobes.models.huggingface_transformers.huggingface import (
     HFTransformersInterface,
 )
-
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/lobes/models/huggingface_transformers/huggingface.py
+++ b/speechbrain/lobes/models/huggingface_transformers/huggingface.py
@@ -22,25 +22,26 @@ Authors
  * Ha Nguyen 2023
 """
 
-import os
-import torch
 import logging
+import os
 import pathlib
-from torch import nn
-from huggingface_hub import model_info
-from speechbrain.utils.fetching import fetch
-from speechbrain.dataio.dataio import length_to_mask
 
+import torch
+from huggingface_hub import model_info
+from torch import nn
 from transformers import (
     AutoConfig,
-    AutoTokenizer,
     AutoFeatureExtractor,
-    AutoModelForPreTraining,
     AutoModel,
-    AutoModelWithLMHead,
-    AutoModelForSeq2SeqLM,
     AutoModelForCausalLM,
+    AutoModelForPreTraining,
+    AutoModelForSeq2SeqLM,
+    AutoModelWithLMHead,
+    AutoTokenizer,
 )
+
+from speechbrain.dataio.dataio import length_to_mask
+from speechbrain.utils.fetching import fetch
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/lobes/models/huggingface_transformers/labse.py
+++ b/speechbrain/lobes/models/huggingface_transformers/labse.py
@@ -8,10 +8,11 @@ Authors
  * Ha Nguyen 2023
 """
 
-import torch
 import logging
-import torch.nn.functional as F
 import os
+
+import torch
+import torch.nn.functional as F
 
 from speechbrain.lobes.models.huggingface_transformers.huggingface import (
     HFTransformersInterface,

--- a/speechbrain/lobes/models/huggingface_transformers/llama2.py
+++ b/speechbrain/lobes/models/huggingface_transformers/llama2.py
@@ -9,16 +9,16 @@ Authors
 """
 
 import logging
-import torch
 
+import torch
 import torch.nn as nn
-from peft import prepare_model_for_kbit_training, LoraConfig, get_peft_model
+from bitsandbytes.nn import Linear4bit
+from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
+from transformers import BitsAndBytesConfig
+
 from speechbrain.lobes.models.huggingface_transformers.huggingface import (
     HFTransformersInterface,
 )
-from transformers import BitsAndBytesConfig
-
-from bitsandbytes.nn import Linear4bit
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/lobes/models/huggingface_transformers/mbart.py
+++ b/speechbrain/lobes/models/huggingface_transformers/mbart.py
@@ -8,8 +8,9 @@ Authors
  * Ha Nguyen 2023
 """
 
-import torch
 import logging
+
+import torch
 
 from speechbrain.lobes.models.huggingface_transformers.huggingface import (
     HFTransformersInterface,

--- a/speechbrain/lobes/models/huggingface_transformers/textencoder.py
+++ b/speechbrain/lobes/models/huggingface_transformers/textencoder.py
@@ -8,14 +8,14 @@ Authors
  * Sylvain de Langen 2024
 """
 
-import torch
 import logging
+from typing import Optional
+
+import torch
 
 from speechbrain.lobes.models.huggingface_transformers.huggingface import (
     HFTransformersInterface,
 )
-
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/lobes/models/huggingface_transformers/vocos.py
+++ b/speechbrain/lobes/models/huggingface_transformers/vocos.py
@@ -20,11 +20,13 @@ Authors
  * Artem Ploujnikov 2023
 """
 
-import torch
 import logging
-from torch import nn
-from speechbrain.dataio.dataio import length_to_mask
+
+import torch
 from huggingface_hub import hf_hub_download
+from torch import nn
+
+from speechbrain.dataio.dataio import length_to_mask
 
 try:
     from vocos import Vocos as VocosModel

--- a/speechbrain/lobes/models/huggingface_transformers/wav2vec2.py
+++ b/speechbrain/lobes/models/huggingface_transformers/wav2vec2.py
@@ -12,18 +12,18 @@ Authors
  * Ha Nguyen 2023
 """
 
-import torch
 import logging
+
 import numpy as np
+import torch
 import torch.nn.functional as F
-from speechbrain.lobes.models.huggingface_transformers.huggingface import (
-    HFTransformersInterface,
-)
-from speechbrain.lobes.models.huggingface_transformers.huggingface import (
-    make_padding_masks,
-)
 import transformers
 from transformers.models.wav2vec2.modeling_wav2vec2 import _compute_mask_indices
+
+from speechbrain.lobes.models.huggingface_transformers.huggingface import (
+    HFTransformersInterface,
+    make_padding_masks,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/lobes/models/huggingface_transformers/weighted_ssl.py
+++ b/speechbrain/lobes/models/huggingface_transformers/weighted_ssl.py
@@ -11,9 +11,11 @@ Authors
  * Adel Moumen 2023, 2024
 """
 
-import torch
 import logging
+
+import torch
 import torch.nn.functional as F
+
 from speechbrain.lobes.models.huggingface_transformers.huggingface import (
     HFTransformersInterface,
 )

--- a/speechbrain/lobes/models/huggingface_transformers/whisper.py
+++ b/speechbrain/lobes/models/huggingface_transformers/whisper.py
@@ -10,8 +10,9 @@ Authors
  * Ha Nguyen 2023
 """
 
-import torch
 import logging
+
+import torch
 from torch import nn
 
 from speechbrain.lobes.models.huggingface_transformers.huggingface import (

--- a/speechbrain/lobes/models/resepformer.py
+++ b/speechbrain/lobes/models/resepformer.py
@@ -4,17 +4,18 @@ Authors
  * Cem Subakan 2022
 """
 
-import torch
-import torch.nn as nn
-from speechbrain.lobes.models.dual_path import select_norm
-from speechbrain.lobes.models.transformer.Transformer import (
-    TransformerEncoder,
-    PositionalEncoding,
-    get_lookahead_mask,
-)
-import speechbrain.nnet.RNN as SBRNN
 import copy
 
+import torch
+import torch.nn as nn
+
+import speechbrain.nnet.RNN as SBRNN
+from speechbrain.lobes.models.dual_path import select_norm
+from speechbrain.lobes.models.transformer.Transformer import (
+    PositionalEncoding,
+    TransformerEncoder,
+    get_lookahead_mask,
+)
 
 EPS = torch.finfo(torch.get_default_dtype()).eps
 

--- a/speechbrain/lobes/models/segan_model.py
+++ b/speechbrain/lobes/models/segan_model.py
@@ -10,11 +10,12 @@ Authors
  * Francis Carter 2021
 """
 
+from math import floor
+
 import torch
 import torch.nn as nn
-import torch.utils.data
 import torch.nn.functional as F
-from math import floor
+import torch.utils.data
 
 
 class Generator(torch.nn.Module):

--- a/speechbrain/lobes/models/spacy/nlp.py
+++ b/speechbrain/lobes/models/spacy/nlp.py
@@ -4,10 +4,10 @@ Authors
 * Sylvain de Langen 2024
 """
 
+from typing import Iterable, Iterator, List, Union
+
 import spacy
 import spacy.tokens
-
-from typing import List, Union, Iterable, Iterator
 
 
 def _as_sentence(sentence: Union[str, List[str]]):

--- a/speechbrain/lobes/models/transformer/Branchformer.py
+++ b/speechbrain/lobes/models/transformer/Branchformer.py
@@ -9,15 +9,15 @@ Authors
 * Titouan Parcollet 2023
 """
 
-import torch
-import torch.nn as nn
 from typing import Optional
 
-from speechbrain.nnet.attention import RelPosMHAXL, MultiheadAttention
-from speechbrain.nnet.normalization import LayerNorm
-from speechbrain.lobes.models.convolution import ConvolutionalSpatialGatingUnit
+import torch
+import torch.nn as nn
 
+from speechbrain.lobes.models.convolution import ConvolutionalSpatialGatingUnit
+from speechbrain.nnet.attention import MultiheadAttention, RelPosMHAXL
 from speechbrain.nnet.hypermixing import HyperMixing
+from speechbrain.nnet.normalization import LayerNorm
 
 
 class ConvolutionBranch(nn.Module):

--- a/speechbrain/lobes/models/transformer/Conformer.py
+++ b/speechbrain/lobes/models/transformer/Conformer.py
@@ -7,24 +7,24 @@ Authors
 * Sylvain de Langen 2023
 """
 
+import warnings
 from dataclasses import dataclass
+from typing import List, Optional
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from typing import Optional, List
+
 import speechbrain as sb
-import warnings
-
-
+from speechbrain.nnet.activations import Swish
 from speechbrain.nnet.attention import (
-    RelPosMHAXL,
     MultiheadAttention,
     PositionalwiseFeedForward,
+    RelPosMHAXL,
 )
-from speechbrain.utils.dynamic_chunk_training import DynChunkTrainConfig
 from speechbrain.nnet.hypermixing import HyperMixing
 from speechbrain.nnet.normalization import LayerNorm
-from speechbrain.nnet.activations import Swish
+from speechbrain.utils.dynamic_chunk_training import DynChunkTrainConfig
 
 
 @dataclass

--- a/speechbrain/lobes/models/transformer/Transformer.py
+++ b/speechbrain/lobes/models/transformer/Transformer.py
@@ -5,18 +5,19 @@ Authors
 """
 
 import math
+from typing import Optional
+
+import numpy as np
 import torch
 import torch.nn as nn
+
 import speechbrain as sb
-from typing import Optional
-import numpy as np
-
-
-from .Conformer import ConformerEncoder
-from .Branchformer import BranchformerEncoder
 from speechbrain.nnet.activations import Swish
 from speechbrain.nnet.attention import RelPosEncXL
 from speechbrain.nnet.CNN import Conv1d
+
+from .Branchformer import BranchformerEncoder
+from .Conformer import ConformerEncoder
 
 
 class TransformerInterface(nn.Module):

--- a/speechbrain/lobes/models/transformer/TransformerASR.py
+++ b/speechbrain/lobes/models/transformer/TransformerASR.py
@@ -7,19 +7,21 @@ Authors
 """
 
 from dataclasses import dataclass
+from typing import Any, Optional
+
 import torch  # noqa 42
 from torch import nn
-from typing import Any, Optional
-from speechbrain.nnet.linear import Linear
-from speechbrain.nnet.containers import ModuleList
+
+from speechbrain.dataio.dataio import length_to_mask
 from speechbrain.lobes.models.transformer.Transformer import (
-    TransformerInterface,
-    get_lookahead_mask,
-    get_key_padding_mask,
     NormalizedEmbedding,
+    TransformerInterface,
+    get_key_padding_mask,
+    get_lookahead_mask,
 )
 from speechbrain.nnet.activations import Swish
-from speechbrain.dataio.dataio import length_to_mask
+from speechbrain.nnet.containers import ModuleList
+from speechbrain.nnet.linear import Linear
 from speechbrain.utils.dynamic_chunk_training import DynChunkTrainConfig
 
 

--- a/speechbrain/lobes/models/transformer/TransformerLM.py
+++ b/speechbrain/lobes/models/transformer/TransformerLM.py
@@ -8,15 +8,15 @@ Authors
 import torch  # noqa 42
 from torch import nn
 
+from speechbrain.lobes.models.transformer.Transformer import (
+    NormalizedEmbedding,
+    TransformerInterface,
+    get_key_padding_mask,
+    get_lookahead_mask,
+)
+from speechbrain.nnet.containers import ModuleList
 from speechbrain.nnet.linear import Linear
 from speechbrain.nnet.normalization import LayerNorm
-from speechbrain.nnet.containers import ModuleList
-from speechbrain.lobes.models.transformer.Transformer import (
-    TransformerInterface,
-    get_lookahead_mask,
-    get_key_padding_mask,
-    NormalizedEmbedding,
-)
 
 
 class TransformerLM(TransformerInterface):

--- a/speechbrain/lobes/models/transformer/TransformerSE.py
+++ b/speechbrain/lobes/models/transformer/TransformerSE.py
@@ -6,11 +6,12 @@ Authors
 
 import torch  # noqa E402
 from torch import nn
-from speechbrain.nnet.linear import Linear
+
 from speechbrain.lobes.models.transformer.Transformer import (
     TransformerInterface,
     get_lookahead_mask,
 )
+from speechbrain.nnet.linear import Linear
 
 
 class CNNTransformerSE(TransformerInterface):

--- a/speechbrain/lobes/models/transformer/TransformerST.py
+++ b/speechbrain/lobes/models/transformer/TransformerST.py
@@ -4,22 +4,23 @@ Authors
 * YAO FEI, CHENG 2021
 """
 
-import torch  # noqa 42
 import logging
-from torch import nn
 from typing import Optional
 
-from speechbrain.nnet.containers import ModuleList
+import torch  # noqa 42
+from torch import nn
+
+from speechbrain.lobes.models.transformer.Conformer import ConformerEncoder
 from speechbrain.lobes.models.transformer.Transformer import (
-    get_lookahead_mask,
-    get_key_padding_mask,
     NormalizedEmbedding,
     TransformerDecoder,
     TransformerEncoder,
+    get_key_padding_mask,
+    get_lookahead_mask,
 )
-from speechbrain.lobes.models.transformer.Conformer import ConformerEncoder
 from speechbrain.lobes.models.transformer.TransformerASR import TransformerASR
 from speechbrain.nnet.activations import Swish
+from speechbrain.nnet.containers import ModuleList
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/lobes/models/wav2vec.py
+++ b/speechbrain/lobes/models/wav2vec.py
@@ -8,19 +8,20 @@ Authors
 """
 
 import logging
-import torch
-import torch.nn.functional as F
-import torch.nn as nn
 import random
-import numpy as np
 
-from speechbrain.lobes.models.transformer.Transformer import PositionalEncoding
-from speechbrain.utils.data_utils import batch_pad_right
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
 from speechbrain.dataio.dataio import length_to_mask
 from speechbrain.lobes.models.convolution import ConvolutionFrontEnd
+from speechbrain.lobes.models.transformer.Transformer import PositionalEncoding
 from speechbrain.nnet.CNN import Conv1d
 from speechbrain.nnet.normalization import LayerNorm
 from speechbrain.nnet.quantisers import GumbelVectorQuantizer
+from speechbrain.utils.data_utils import batch_pad_right
 
 logger = logging.getLogger()
 

--- a/speechbrain/nnet/CNN.py
+++ b/speechbrain/nnet/CNN.py
@@ -9,14 +9,16 @@ Authors
  * Sarthak Yadav 2022
 """
 
-import math
-import torch
 import logging
+import math
+from typing import Tuple
+
 import numpy as np
+import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torchaudio
-from typing import Tuple
+
 from speechbrain.processing.signal_processing import (
     gabor_impulse_response,
     gabor_impulse_response_legacy_complex,

--- a/speechbrain/nnet/RNN.py
+++ b/speechbrain/nnet/RNN.py
@@ -8,15 +8,17 @@ Authors
  * Loren Lugosch 2020
 """
 
-import torch
 import logging
+from typing import Optional
+
+import torch
 import torch.nn as nn
+
 from speechbrain.nnet.attention import (
     ContentBasedAttention,
-    LocationAwareAttention,
     KeyValueAttention,
+    LocationAwareAttention,
 )
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/nnet/activations.py
+++ b/speechbrain/nnet/activations.py
@@ -5,8 +5,9 @@ Authors
  * Jianyuan Zhong 2020
 """
 
-import torch
 import logging
+
+import torch
 import torch.nn.functional as F
 
 logger = logging.getLogger(__name__)

--- a/speechbrain/nnet/attention.py
+++ b/speechbrain/nnet/attention.py
@@ -7,15 +7,16 @@ Authors
  * Samuele Cornell 2020
 """
 
-import torch
 import logging
-import torch.nn as nn
-import numpy as np
-from typing import Optional
-from speechbrain.dataio.dataio import length_to_mask
-import torch.nn.functional as F
 import math
+from typing import Optional
 
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from speechbrain.dataio.dataio import length_to_mask
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/nnet/autoencoders.py
+++ b/speechbrain/nnet/autoencoders.py
@@ -4,12 +4,14 @@ Authors
  * Artem Ploujnikov 2022
 """
 
+from collections import namedtuple
+
 import torch
 from torch import nn
-from collections import namedtuple
+
 from speechbrain.dataio.dataio import clean_padding
-from speechbrain.utils.data_utils import trim_as
 from speechbrain.processing.features import GlobalNorm
+from speechbrain.utils.data_utils import trim_as
 
 
 class Autoencoder(nn.Module):

--- a/speechbrain/nnet/complex_networks/c_CNN.py
+++ b/speechbrain/nnet/complex_networks/c_CNN.py
@@ -4,16 +4,18 @@ Authors
  * Titouan Parcollet 2020
 """
 
+import logging
+
 import torch
 import torch.nn as nn
-import logging
 import torch.nn.functional as F
+
 from speechbrain.nnet.CNN import get_padding_elem
 from speechbrain.nnet.complex_networks.c_ops import (
-    unitary_init,
-    complex_init,
     affect_conv_init,
     complex_conv_op,
+    complex_init,
+    unitary_init,
 )
 
 logger = logging.getLogger(__name__)

--- a/speechbrain/nnet/complex_networks/c_RNN.py
+++ b/speechbrain/nnet/complex_networks/c_RNN.py
@@ -4,8 +4,10 @@ Authors
  * Titouan Parcollet 2020
 """
 
-import torch
 import logging
+
+import torch
+
 from speechbrain.nnet.complex_networks.c_linear import CLinear
 from speechbrain.nnet.complex_networks.c_normalization import (
     CBatchNorm,

--- a/speechbrain/nnet/complex_networks/c_linear.py
+++ b/speechbrain/nnet/complex_networks/c_linear.py
@@ -4,14 +4,16 @@ Authors
  * Titouan Parcollet 2020
 """
 
-import torch
 import logging
+
+import torch
+
 from speechbrain.nnet.complex_networks.c_ops import (
     affect_init,
-    complex_init,
-    unitary_init,
-    complex_linear_op,
     check_complex_input,
+    complex_init,
+    complex_linear_op,
+    unitary_init,
 )
 
 logger = logging.getLogger(__name__)

--- a/speechbrain/nnet/complex_networks/c_normalization.py
+++ b/speechbrain/nnet/complex_networks/c_normalization.py
@@ -4,9 +4,10 @@ Authors
  * Titouan Parcollet 2020
 """
 
+import numpy as np
 import torch
 from torch.nn import Parameter
-import numpy as np
+
 from speechbrain.nnet.complex_networks.c_ops import multi_mean
 
 

--- a/speechbrain/nnet/complex_networks/c_ops.py
+++ b/speechbrain/nnet/complex_networks/c_ops.py
@@ -7,9 +7,9 @@ Authors
  * Titouan Parcollet 2020
 """
 
+import numpy as np
 import torch
 import torch.nn.functional as F
-import numpy as np
 
 
 def check_complex_input(input_shape):

--- a/speechbrain/nnet/containers.py
+++ b/speechbrain/nnet/containers.py
@@ -4,11 +4,13 @@ Authors
  * Peter Plantinga 2020
 """
 
-import torch
+import functools
 import inspect
 import logging
 import operator
-import functools
+
+import torch
+
 from speechbrain.nnet.linear import Linear
 from speechbrain.utils.callchains import lengths_arg_exists
 

--- a/speechbrain/nnet/diffusion.py
+++ b/speechbrain/nnet/diffusion.py
@@ -10,13 +10,15 @@ Authors
 """
 
 from collections import namedtuple
+
 import torch
 from torch import nn
 from torch.nn import functional as F
 from tqdm.auto import tqdm
-from speechbrain.utils.data_utils import unsqueeze_as
+
 from speechbrain.dataio.dataio import length_to_mask
 from speechbrain.utils import data_utils
+from speechbrain.utils.data_utils import unsqueeze_as
 
 
 class Diffuser(nn.Module):

--- a/speechbrain/nnet/dropout.py
+++ b/speechbrain/nnet/dropout.py
@@ -4,8 +4,9 @@ Authors
  * Mirco Ravanelli 2020
 """
 
-import torch  # noqa: F401
 import logging
+
+import torch  # noqa: F401
 import torch.nn as nn
 
 logger = logging.getLogger(__name__)

--- a/speechbrain/nnet/embedding.py
+++ b/speechbrain/nnet/embedding.py
@@ -4,8 +4,9 @@ Authors
  * Abdelwahab Heba 2020
 """
 
-import torch
 import logging
+
+import torch
 import torch.nn as nn
 
 logger = logging.getLogger(__name__)

--- a/speechbrain/nnet/hypermixing.py
+++ b/speechbrain/nnet/hypermixing.py
@@ -8,9 +8,8 @@ Authors
  * Juan Pablo Zuluaga 2023
 """
 
-from typing import Optional
-
 import math
+from typing import Optional
 
 import torch
 from torch import nn

--- a/speechbrain/nnet/linear.py
+++ b/speechbrain/nnet/linear.py
@@ -5,8 +5,9 @@ Authors
  * Davide Borra 2021
 """
 
-import torch
 import logging
+
+import torch
 import torch.nn as nn
 
 logger = logging.getLogger(__name__)

--- a/speechbrain/nnet/loss/si_snr_loss.py
+++ b/speechbrain/nnet/loss/si_snr_loss.py
@@ -8,8 +8,8 @@
  * Titouan Parcollet 2020
 """
 
-import torch
 import numpy as np
+import torch
 
 smallVal = np.finfo("float").eps  # To avoid divide by zero
 

--- a/speechbrain/nnet/loss/stoi_loss.py
+++ b/speechbrain/nnet/loss/stoi_loss.py
@@ -6,9 +6,10 @@ Authors:
     Szu-Wei, Fu 2020
 """
 
+import numpy as np
 import torch
 import torchaudio
-import numpy as np
+
 from speechbrain.utils.torch_audio_backend import check_torchaudio_backend
 
 check_torchaudio_backend()

--- a/speechbrain/nnet/loss/transducer_loss.py
+++ b/speechbrain/nnet/loss/transducer_loss.py
@@ -6,12 +6,13 @@ Authors
  * Titouan Parcollet 2023
 """
 
-import torch
-from torch.autograd import Function
-from torch.nn import Module
 import logging
 import math
 import warnings
+
+import torch
+from torch.autograd import Function
+from torch.nn import Module
 
 NUMBA_VERBOSE = 0
 

--- a/speechbrain/nnet/losses.py
+++ b/speechbrain/nnet/losses.py
@@ -9,19 +9,20 @@ Authors
  * Titouan Parcollet 2020
 """
 
-from collections import namedtuple
-import math
-import torch
-import logging
 import functools
+import logging
+import math
+from collections import namedtuple
+from itertools import permutations
+
 import numpy as np
+import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from itertools import permutations
+
 from speechbrain.dataio.dataio import length_to_mask
 from speechbrain.decoders.ctc import filter_ctc_output
 from speechbrain.utils.data_utils import unsqueeze_as
-
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/nnet/pooling.py
+++ b/speechbrain/nnet/pooling.py
@@ -9,8 +9,9 @@ Authors
  * Ha Nguyen 2023
 """
 
-import torch
 import logging
+
+import torch
 import torch.nn as nn
 import torch.nn.functional as F
 

--- a/speechbrain/nnet/quaternion_networks/q_CNN.py
+++ b/speechbrain/nnet/quaternion_networks/q_CNN.py
@@ -4,19 +4,21 @@ Authors
  * Titouan Parcollet 2020
 """
 
+import logging
+from typing import Tuple
+
 import torch
 import torch.nn as nn
-import logging
 import torch.nn.functional as F
+
 from speechbrain.nnet.CNN import get_padding_elem
 from speechbrain.nnet.quaternion_networks.q_ops import (
-    unitary_init,
-    quaternion_init,
     affect_conv_init,
     quaternion_conv_op,
     quaternion_conv_rotation_op,
+    quaternion_init,
+    unitary_init,
 )
-from typing import Tuple
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/nnet/quaternion_networks/q_RNN.py
+++ b/speechbrain/nnet/quaternion_networks/q_RNN.py
@@ -4,11 +4,13 @@ Authors
  * Titouan Parcollet 2020
 """
 
-import torch
 import logging
+from typing import Optional
+
+import torch
+
 from speechbrain.nnet.quaternion_networks.q_linear import QLinear
 from speechbrain.nnet.quaternion_networks.q_normalization import QBatchNorm
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/nnet/quaternion_networks/q_linear.py
+++ b/speechbrain/nnet/quaternion_networks/q_linear.py
@@ -4,16 +4,18 @@ Authors
  * Titouan Parcollet 2020
 """
 
-import torch
 import logging
+
+import torch
+
 from speechbrain.nnet.quaternion_networks.q_ops import (
+    QuaternionLinearCustomBackward,
     affect_init,
-    unitary_init,
+    check_quaternion_input,
     quaternion_init,
     quaternion_linear_op,
-    check_quaternion_input,
     quaternion_linear_rotation_op,
-    QuaternionLinearCustomBackward,
+    unitary_init,
 )
 
 logger = logging.getLogger(__name__)

--- a/speechbrain/nnet/quaternion_networks/q_ops.py
+++ b/speechbrain/nnet/quaternion_networks/q_ops.py
@@ -11,9 +11,10 @@ Authors
  * Titouan Parcollet 2020
 """
 
-import torch
 import math
+
 import numpy as np
+import torch
 import torch.nn.functional as F
 from scipy.stats import chi
 from torch.autograd import Variable

--- a/speechbrain/nnet/schedulers.py
+++ b/speechbrain/nnet/schedulers.py
@@ -7,12 +7,13 @@ Authors
  * Loren Lugosch 2020
 """
 
-import math
-import torch
 import logging
+import math
+
+import torch
+from torch import nn
 
 from speechbrain.utils import checkpoints
-from torch import nn
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/nnet/transducer/transducer_joint.py
+++ b/speechbrain/nnet/transducer/transducer_joint.py
@@ -4,8 +4,9 @@ Author
     Abdelwahab HEBA 2020
 """
 
-import torch
 import logging
+
+import torch
 import torch.nn as nn
 
 logger = logging.getLogger(__name__)

--- a/speechbrain/nnet/unet.py
+++ b/speechbrain/nnet/unet.py
@@ -30,17 +30,16 @@ Authors
  * Artem Ploujnikov 2022
 """
 
-from abc import abstractmethod
-
-from speechbrain.utils.data_utils import pad_divisible
-from .autoencoders import NormalizingAutoencoder
-
-
 import math
+from abc import abstractmethod
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
+from speechbrain.utils.data_utils import pad_divisible
+
+from .autoencoders import NormalizingAutoencoder
 
 
 def fixup(module, use_fixup_init=True):

--- a/speechbrain/nnet/utils.py
+++ b/speechbrain/nnet/utils.py
@@ -6,6 +6,7 @@ Authors
 """
 
 from torch import nn
+
 from speechbrain.dataio.dataio import length_to_mask
 
 

--- a/speechbrain/processing/NMF.py
+++ b/speechbrain/processing/NMF.py
@@ -5,8 +5,9 @@ Authors
 """
 
 import torch
-from speechbrain.processing.features import spectral_magnitude
+
 import speechbrain.processing.features as spf
+from speechbrain.processing.features import spectral_magnitude
 
 
 def spectral_phase(stft):

--- a/speechbrain/processing/PLDA_LDA.py
+++ b/speechbrain/processing/PLDA_LDA.py
@@ -20,10 +20,10 @@ Credits
     This code is adapted from: https://projets-lium.univ-lemans.fr/sidekit/
 """
 
-import numpy
 import copy
 import pickle
 
+import numpy
 from scipy import linalg
 
 STAT_TYPE = numpy.float64

--- a/speechbrain/processing/diarization.py
+++ b/speechbrain/processing/diarization.py
@@ -21,23 +21,23 @@ Authors
 import csv
 import numbers
 import warnings
-import scipy
-import pytest
-import numpy as np
 
+import numpy as np
+import pytest
+import scipy
 from scipy import sparse
-from scipy.sparse.linalg import eigsh
 from scipy.sparse.csgraph import connected_components
 from scipy.sparse.csgraph import laplacian as csgraph_laplacian
+from scipy.sparse.linalg import eigsh
 
 np.random.seed(1234)
 pytest.importorskip("sklearn")
 
 try:
     import sklearn
-    from sklearn.neighbors import kneighbors_graph
     from sklearn.cluster import SpectralClustering
     from sklearn.cluster._kmeans import k_means
+    from sklearn.neighbors import kneighbors_graph
 except ImportError:
     err_msg = "The optional dependency scikit-learn (sklearn) is used in this module\n"
     err_msg += "Cannot import scikit-learn. \n"

--- a/speechbrain/processing/features.py
+++ b/speechbrain/processing/features.py
@@ -34,18 +34,19 @@ Authors
  * Mirco Ravanelli 2020
 """
 
-import math
-import torch
 import logging
+import math
+
+import torch
+
+from speechbrain.dataio.dataio import length_to_mask
 from speechbrain.utils.checkpoints import (
-    mark_as_saver,
     mark_as_loader,
+    mark_as_saver,
     mark_as_transfer,
     register_checkpoint_hooks,
 )
-from speechbrain.dataio.dataio import length_to_mask
 from speechbrain.utils.filter_analysis import FilterProperties
-
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/processing/multi_mic.py
+++ b/speechbrain/processing/multi_mic.py
@@ -79,6 +79,7 @@ Authors:
 
 import torch
 from packaging import version
+
 import speechbrain.processing.decomposition as eig
 
 

--- a/speechbrain/processing/signal_processing.py
+++ b/speechbrain/processing/signal_processing.py
@@ -9,8 +9,9 @@ Authors
  * Sarthak Yadav 2022
 """
 
-import torch
 import math
+
+import torch
 from packaging import version
 
 

--- a/speechbrain/tokenizers/SentencePiece.py
+++ b/speechbrain/tokenizers/SentencePiece.py
@@ -4,14 +4,16 @@ Authors
  * Loren Lugosch 2020
 """
 
-import os.path
-import torch
-import logging
 import csv
 import json
+import logging
+import os.path
 from dataclasses import dataclass
 from typing import List
+
 import sentencepiece as spm
+import torch
+
 from speechbrain.dataio.dataio import merge_char
 from speechbrain.utils import edit_distance
 from speechbrain.utils.distributed import run_on_main

--- a/speechbrain/utils/Accuracy.py
+++ b/speechbrain/utils/Accuracy.py
@@ -5,6 +5,7 @@ Authors
 """
 
 import torch
+
 from speechbrain.dataio.dataio import length_to_mask
 
 

--- a/speechbrain/utils/DER.py
+++ b/speechbrain/utils/DER.py
@@ -12,6 +12,7 @@ Credits
 import os
 import re
 import subprocess
+
 import numpy as np
 
 FILE_IDS = re.compile(r"(?<=Speaker Diarization for).+(?=\*\*\*)")

--- a/speechbrain/utils/_workarounds.py
+++ b/speechbrain/utils/_workarounds.py
@@ -4,9 +4,10 @@ Authors
  * Aku Rouhe 2022
 """
 
-import torch
-import weakref
 import warnings
+import weakref
+
+import torch
 
 WEAKREF_MARKER = "WEAKREF"
 

--- a/speechbrain/utils/autocast.py
+++ b/speechbrain/utils/autocast.py
@@ -7,6 +7,7 @@ Authors
 
 import functools
 from typing import Callable, Optional
+
 import torch
 
 

--- a/speechbrain/utils/bertscore.py
+++ b/speechbrain/utils/bertscore.py
@@ -4,15 +4,16 @@ Authors
 * Sylvain de Langen 2024
 """
 
-from collections import defaultdict
-from typing import Iterable, Optional
-import torch
 import logging
 import math
+from collections import defaultdict
+from typing import Iterable, Optional
 
+import torch
+
+from speechbrain.lobes.models.huggingface_transformers import TextEncoder
 from speechbrain.utils.distances import cosine_similarity_matrix
 from speechbrain.utils.metric_stats import MetricStats
-from speechbrain.lobes.models.huggingface_transformers import TextEncoder
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/utils/checkpoints.py
+++ b/speechbrain/utils/checkpoints.py
@@ -48,24 +48,26 @@ Authors
  * Aku Rouhe 2020
 """
 
-import torch
 import collections
 import collections.abc
-import os
-import time
-import yaml
-import pathlib
 import inspect
-import shutil
 import logging
+import os
+import pathlib
+import shutil
+import time
 import warnings
+
+import torch
+import yaml
 from packaging import version
+
 import speechbrain.utils._workarounds as __wa
 from speechbrain.utils.distributed import (
-    main_process_only,
-    if_main_process,
     ddp_barrier,
     ddp_broadcast,
+    if_main_process,
+    main_process_only,
 )
 
 logger = logging.getLogger(__name__)

--- a/speechbrain/utils/data_pipeline.py
+++ b/speechbrain/utils/data_pipeline.py
@@ -25,6 +25,7 @@ Author:
 
 import inspect
 from dataclasses import dataclass
+
 from speechbrain.utils.depgraph import DependencyGraph
 
 

--- a/speechbrain/utils/data_utils.py
+++ b/speechbrain/utils/data_utils.py
@@ -8,19 +8,21 @@ Authors
  * Pierre Champion 2023
 """
 
+import collections.abc
+import csv
+import gzip
 import math
 import os
+import pathlib
 import re
-import csv
 import shutil
 import urllib.request
-import collections.abc
+from numbers import Number
+
 import torch
 import tqdm
-import pathlib
+
 import speechbrain as sb
-from numbers import Number
-import gzip
 
 
 def undo_padding(batch, lengths):

--- a/speechbrain/utils/dictionaries.py
+++ b/speechbrain/utils/dictionaries.py
@@ -3,9 +3,9 @@
 Authors
  * Sylvain de Langen 2024"""
 
+import json
 from collections import defaultdict
 from typing import Iterable
-import json
 
 
 class SynonymDictionary:

--- a/speechbrain/utils/distributed.py
+++ b/speechbrain/utils/distributed.py
@@ -8,8 +8,9 @@ Authors:
 
 import datetime
 import os
-import torch
 from functools import wraps
+
+import torch
 
 MAIN_PROC_ONLY = 0
 

--- a/speechbrain/utils/dynamic_chunk_training.py
+++ b/speechbrain/utils/dynamic_chunk_training.py
@@ -9,11 +9,12 @@ Authors
 * Sylvain de Langen 2023
 """
 
-import speechbrain as sb
 from dataclasses import dataclass
 from typing import Optional
 
 import torch
+
+import speechbrain as sb
 
 
 # NOTE: this configuration object is intended to be relatively specific to

--- a/speechbrain/utils/epoch_loop.py
+++ b/speechbrain/utils/epoch_loop.py
@@ -5,11 +5,15 @@ Authors
  * Davide Borra 2021
 """
 
-from .checkpoints import register_checkpoint_hooks
-from .checkpoints import mark_as_saver
-from .checkpoints import mark_as_loader
 import logging
+
 import yaml
+
+from .checkpoints import (
+    mark_as_loader,
+    mark_as_saver,
+    register_checkpoint_hooks,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/utils/fetching.py
+++ b/speechbrain/utils/fetching.py
@@ -6,13 +6,14 @@ Authors:
  * Andreas Nautsch 2022, 2023
 """
 
-import urllib.request
-import urllib.error
-import pathlib
 import logging
-from enum import Enum
-import huggingface_hub
+import pathlib
+import urllib.error
+import urllib.request
 from collections import namedtuple
+from enum import Enum
+
+import huggingface_hub
 from requests.exceptions import HTTPError
 
 logger = logging.getLogger(__name__)

--- a/speechbrain/utils/hpopt.py
+++ b/speechbrain/utils/hpopt.py
@@ -10,15 +10,15 @@ Authors
 """
 
 import importlib
-import logging
 import json
+import logging
 import os
-import speechbrain as sb
 import sys
-
 from datetime import datetime
+
 from hyperpyyaml import load_hyperpyyaml
 
+import speechbrain as sb
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/utils/importutils.py
+++ b/speechbrain/utils/importutils.py
@@ -5,11 +5,11 @@ Author
  * Sylvain de Langen 2024
 """
 
-from types import ModuleType
 import importlib
 import sys
-from typing import Optional
 import warnings
+from types import ModuleType
+from typing import Optional
 
 
 class LegacyModuleRedirect(ModuleType):

--- a/speechbrain/utils/kmeans.py
+++ b/speechbrain/utils/kmeans.py
@@ -5,8 +5,9 @@ Author
  * Pooneh Mousavi 2023
 """
 
-import os
 import logging
+import os
+
 from tqdm.contrib import tqdm
 
 try:

--- a/speechbrain/utils/logger.py
+++ b/speechbrain/utils/logger.py
@@ -6,14 +6,16 @@ Author
  * Aku Rouhe 2020
 """
 
-import sys
-import os
-import yaml
-import tqdm
 import logging
 import logging.config
 import math
+import os
+import sys
+
 import torch
+import tqdm
+import yaml
+
 from speechbrain.utils.data_utils import recursive_update
 from speechbrain.utils.superpowers import run_shell
 

--- a/speechbrain/utils/metric_stats.py
+++ b/speechbrain/utils/metric_stats.py
@@ -8,22 +8,24 @@ Authors:
  * Sahar Ghannay 2021
 """
 
-import torch
 from typing import Callable, Optional
+
+import torch
 from joblib import Parallel, delayed
+
+from speechbrain.dataio.dataio import (
+    extract_concepts_values,
+    merge_char,
+    split_word,
+)
+from speechbrain.dataio.wer import print_alignments, print_wer_summary
 from speechbrain.utils.data_utils import undo_padding
 from speechbrain.utils.edit_distance import (
     EDIT_SYMBOLS,
-    wer_summary,
-    wer_details_for_batch,
     _str_equals,
+    wer_details_for_batch,
+    wer_summary,
 )
-from speechbrain.dataio.dataio import (
-    merge_char,
-    split_word,
-    extract_concepts_values,
-)
-from speechbrain.dataio.wer import print_wer_summary, print_alignments
 
 
 class MetricStats:

--- a/speechbrain/utils/parameter_transfer.py
+++ b/speechbrain/utils/parameter_transfer.py
@@ -11,14 +11,15 @@ Authors
 
 import logging
 import pathlib
-from speechbrain.utils.distributed import run_on_main
-from speechbrain.utils.fetching import fetch, FetchFrom, FetchSource
+
 from speechbrain.utils.checkpoints import (
     DEFAULT_LOAD_HOOKS,
     DEFAULT_TRANSFER_HOOKS,
     PARAMFILE_EXT,
     get_default_hook,
 )
+from speechbrain.utils.distributed import run_on_main
+from speechbrain.utils.fetching import FetchFrom, FetchSource, fetch
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/utils/pretrained.py
+++ b/speechbrain/utils/pretrained.py
@@ -5,8 +5,8 @@ Authors
 * Artem Ploujnikov 2021
 """
 
-import os
 import logging
+import os
 import shutil
 
 logger = logging.getLogger(__name__)

--- a/speechbrain/utils/profiling.py
+++ b/speechbrain/utils/profiling.py
@@ -4,8 +4,9 @@ Author:
     * Titouan Parcollet 2024
 """
 
-from torch import profiler
 import os
+
+from torch import profiler
 
 
 def prepare_profiler(

--- a/speechbrain/utils/semdist.py
+++ b/speechbrain/utils/semdist.py
@@ -4,9 +4,11 @@ Authors
 * Sylvain de Langen 2024
 """
 
-from speechbrain.utils.metric_stats import MetricStats
-from typing import Literal, Callable, List
+from typing import Callable, List, Literal
+
 import torch
+
+from speechbrain.utils.metric_stats import MetricStats
 
 
 class BaseSemDistStats(MetricStats):

--- a/speechbrain/utils/streaming.py
+++ b/speechbrain/utils/streaming.py
@@ -5,8 +5,9 @@ Authors
 """
 
 import math
-import torch
 from typing import Callable
+
+import torch
 
 
 def split_fixed_chunks(x, chunk_size, dim=-1):

--- a/speechbrain/utils/superpowers.py
+++ b/speechbrain/utils/superpowers.py
@@ -9,10 +9,10 @@ Authors
  * Aku Rouhe 2021
 """
 
-import logging
-import subprocess
 import importlib
+import logging
 import pathlib
+import subprocess
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/utils/text_to_sequence.py
+++ b/speechbrain/utils/text_to_sequence.py
@@ -26,8 +26,8 @@
 #  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 # *****************************************************************************
-import re
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/utils/torch_audio_backend.py
+++ b/speechbrain/utils/torch_audio_backend.py
@@ -4,10 +4,11 @@ Authors
  * Mirco Ravanelli 2021
 """
 
-import platform
 import logging
-import torchaudio
+import platform
 from typing import Optional
+
+import torchaudio
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/utils/train_logger.py
+++ b/speechbrain/utils/train_logger.py
@@ -6,9 +6,11 @@ Authors
 """
 
 import logging
-import torch
 import os
-from speechbrain.utils.distributed import main_process_only, if_main_process
+
+import torch
+
+from speechbrain.utils.distributed import if_main_process, main_process_only
 
 logger = logging.getLogger(__name__)
 

--- a/speechbrain/wordemb/transformer.py
+++ b/speechbrain/wordemb/transformer.py
@@ -6,8 +6,8 @@ Authors
 * Artem Ploujnikov 2021
 """
 
-import torch
 import numpy as np
+import torch
 from torch import nn
 
 

--- a/templates/enhancement/mini_librispeech_prepare.py
+++ b/templates/enhancement/mini_librispeech_prepare.py
@@ -6,12 +6,13 @@ Authors:
  * Peter Plantinga, 2020
 """
 
-import os
 import json
-import shutil
 import logging
-from speechbrain.utils.data_utils import get_all_files, download_file
+import os
+import shutil
+
 from speechbrain.dataio.dataio import read_audio
+from speechbrain.utils.data_utils import download_file, get_all_files
 
 logger = logging.getLogger(__name__)
 MINILIBRI_TRAIN_URL = "http://www.openslr.org/resources/31/train-clean-5.tar.gz"

--- a/templates/enhancement/train.py
+++ b/templates/enhancement/train.py
@@ -19,10 +19,12 @@ Authors
  * Peter Plantinga 2021
 """
 import sys
+
 import torch
-import speechbrain as sb
 from hyperpyyaml import load_hyperpyyaml
 from mini_librispeech_prepare import prepare_mini_librispeech
+
+import speechbrain as sb
 
 
 # Brain class for speech enhancement training

--- a/templates/hyperparameter_optimization_speaker_id/train.py
+++ b/templates/hyperparameter_optimization_speaker_id/train.py
@@ -33,9 +33,11 @@ Authors
 """
 import os
 import sys
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
 from mini_librispeech_prepare import prepare_mini_librispeech
+
+import speechbrain as sb
 from speechbrain.utils import hpopt as hp
 
 

--- a/templates/speaker_id/custom_model.py
+++ b/templates/speaker_id/custom_model.py
@@ -12,11 +12,12 @@ Authors
 
 import torch  # noqa: F401
 import torch.nn as nn
+
 import speechbrain as sb
-from speechbrain.nnet.pooling import StatisticsPooling
 from speechbrain.nnet.CNN import Conv1d
 from speechbrain.nnet.linear import Linear
 from speechbrain.nnet.normalization import BatchNorm1d
+from speechbrain.nnet.pooling import StatisticsPooling
 
 
 class Xvector(torch.nn.Module):

--- a/templates/speaker_id/mini_librispeech_prepare.py
+++ b/templates/speaker_id/mini_librispeech_prepare.py
@@ -8,13 +8,14 @@ Authors:
  * Mirco Ravanelli, 2021
 """
 
-import os
 import json
-import shutil
-import random
 import logging
-from speechbrain.utils.data_utils import get_all_files, download_file
+import os
+import random
+import shutil
+
 from speechbrain.dataio.dataio import read_audio
+from speechbrain.utils.data_utils import download_file, get_all_files
 
 logger = logging.getLogger(__name__)
 MINILIBRI_TRAIN_URL = "http://www.openslr.org/resources/31/train-clean-5.tar.gz"

--- a/templates/speaker_id/train.py
+++ b/templates/speaker_id/train.py
@@ -26,9 +26,11 @@ Authors
 """
 import os
 import sys
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
 from mini_librispeech_prepare import prepare_mini_librispeech
+
+import speechbrain as sb
 
 
 # Brain class for speech enhancement training

--- a/templates/speech_recognition/ASR/train.py
+++ b/templates/speech_recognition/ASR/train.py
@@ -43,12 +43,14 @@ Authors
  * Samuele Cornell 2020
 """
 
-import sys
-import torch
 import logging
-import speechbrain as sb
+import sys
+
+import torch
 from hyperpyyaml import load_hyperpyyaml
 from mini_librispeech_prepare import prepare_mini_librispeech
+
+import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
 
 logger = logging.getLogger(__name__)

--- a/templates/speech_recognition/LM/custom_model.py
+++ b/templates/speech_recognition/LM/custom_model.py
@@ -15,6 +15,7 @@ Authors
 """
 
 import torch
+
 import speechbrain as sb
 
 

--- a/templates/speech_recognition/LM/train.py
+++ b/templates/speech_recognition/LM/train.py
@@ -12,14 +12,15 @@ Authors
  * Jianyuan Zhong 2021
  * Mirco Ravanelli 2021
 """
-import sys
 import logging
+import sys
+
 import torch
 from datasets import load_dataset
 from hyperpyyaml import load_hyperpyyaml
+
 import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
-
 
 logger = logging.getLogger(__name__)
 

--- a/templates/speech_recognition/Tokenizer/train.py
+++ b/templates/speech_recognition/Tokenizer/train.py
@@ -17,9 +17,11 @@ Authors
 """
 
 import sys
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
 from mini_librispeech_prepare import prepare_mini_librispeech
+
+import speechbrain as sb
 
 if __name__ == "__main__":
 

--- a/templates/speech_recognition/mini_librispeech_prepare.py
+++ b/templates/speech_recognition/mini_librispeech_prepare.py
@@ -6,12 +6,13 @@ Authors:
  * Mirco Ravanelli, 2021
 """
 
-import os
 import json
-import shutil
 import logging
-from speechbrain.utils.data_utils import get_all_files, download_file
+import os
+import shutil
+
 from speechbrain.dataio.dataio import read_audio
+from speechbrain.utils.data_utils import download_file, get_all_files
 
 logger = logging.getLogger(__name__)
 MINILIBRI_TRAIN_URL = "http://www.openslr.org/resources/31/train-clean-5.tar.gz"

--- a/tests/consistency/test_HF_repo.py
+++ b/tests/consistency/test_HF_repo.py
@@ -5,8 +5,9 @@ Authors
  * Andreas Nautsch 2022
 """
 
-import os
 import csv
+import os
+
 from speechbrain.utils.data_utils import download_file
 
 

--- a/tests/consistency/test_recipe.py
+++ b/tests/consistency/test_recipe.py
@@ -4,8 +4,9 @@ Authors
  * Mirco Ravanelli 2022
 """
 
-import os
 import csv
+import os
+
 from speechbrain.utils.data_utils import get_all_files, get_list_from_csv
 
 __skip_list = ["README.md", "setup", "full_inference.csv"]

--- a/tests/consistency/test_yaml.py
+++ b/tests/consistency/test_yaml.py
@@ -4,8 +4,9 @@ Authors
  * Mirco Ravanelli 2022
 """
 
-import os
 import csv
+import os
+
 from tests.consistency.test_recipe import __skip_list
 from tests.utils.check_yaml import check_yaml_vs_script
 

--- a/tests/integration/ASR_CTC/example_asr_ctc_experiment.py
+++ b/tests/integration/ASR_CTC/example_asr_ctc_experiment.py
@@ -8,8 +8,10 @@ Given the tiny dataset, the expected behavior is to overfit the training dataset
 """
 
 import pathlib
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 
 
 class CTCBrain(sb.Brain):

--- a/tests/integration/ASR_CTC/example_asr_ctc_experiment_complex_net.py
+++ b/tests/integration/ASR_CTC/example_asr_ctc_experiment_complex_net.py
@@ -8,8 +8,10 @@ Given the tiny dataset, the expected behavior is to overfit the training dataset
 """
 
 import pathlib
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 
 
 class CTCBrain(sb.Brain):

--- a/tests/integration/ASR_CTC/example_asr_ctc_experiment_quaternion_net.py
+++ b/tests/integration/ASR_CTC/example_asr_ctc_experiment_quaternion_net.py
@@ -8,8 +8,10 @@ Given the tiny dataset, the expected behavior is to overfit the training dataset
 """
 
 import pathlib
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 
 
 class CTCBrain(sb.Brain):

--- a/tests/integration/ASR_ConformerTransducer_streaming/example_asr_conformertransducer_streaming_experiment.py
+++ b/tests/integration/ASR_ConformerTransducer_streaming/example_asr_conformertransducer_streaming_experiment.py
@@ -7,9 +7,11 @@ Given the tiny dataset, the expected behavior is to overfit the training dataset
 (with a validation performance that stays high).
 """
 import pathlib
-import speechbrain as sb
-from hyperpyyaml import load_hyperpyyaml
+
 import torch
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 
 
 class ConformerTransducerBrain(sb.Brain):

--- a/tests/integration/ASR_Transducer/example_asr_transducer_experiment.py
+++ b/tests/integration/ASR_Transducer/example_asr_transducer_experiment.py
@@ -7,8 +7,10 @@ Given the tiny dataset, the expected behavior is to overfit the training dataset
 (with a validation performance that stays high).
 """
 import pathlib
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 
 
 class TransducerBrain(sb.Brain):

--- a/tests/integration/ASR_alignment_forward/example_asr_alignment_forward_experiment.py
+++ b/tests/integration/ASR_alignment_forward/example_asr_alignment_forward_experiment.py
@@ -7,8 +7,10 @@ Given the tiny dataset, the expected behavior is to overfit the training data
 """
 
 import pathlib
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 
 
 class AlignBrain(sb.Brain):

--- a/tests/integration/ASR_alignment_viterbi/example_asr_alignment_viterbi_experiment.py
+++ b/tests/integration/ASR_alignment_viterbi/example_asr_alignment_viterbi_experiment.py
@@ -7,8 +7,10 @@ Given the tiny dataset, the expected behavior is to overfit the training data
 """
 
 import pathlib
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 
 
 class AlignBrain(sb.Brain):

--- a/tests/integration/ASR_seq2seq/example_asr_seq2seq_experiment.py
+++ b/tests/integration/ASR_seq2seq/example_asr_seq2seq_experiment.py
@@ -7,8 +7,10 @@ Given the tiny dataset, the expected behavior is to overfit the training dataset
 (with a validation performance that stays high).
 """
 import pathlib
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 
 
 class seq2seqBrain(sb.Brain):

--- a/tests/integration/G2P/example_g2p.py
+++ b/tests/integration/G2P/example_g2p.py
@@ -8,8 +8,10 @@ tiny dataset, the expected behavior is to overfit the training dataset
 (with a validation performance that stays high).
 """
 import pathlib
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 
 
 class seq2seqBrain(sb.Brain):

--- a/tests/integration/LM_RNN/example_lm_rnn_experiment.py
+++ b/tests/integration/LM_RNN/example_lm_rnn_experiment.py
@@ -8,8 +8,10 @@ Given the tiny dataset, the expected behavior is to overfit the training dataset
 """
 import math
 import pathlib
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 
 
 class LMBrain(sb.Brain):

--- a/tests/integration/PLDA/example_plda_experiment.py
+++ b/tests/integration/PLDA/example_plda_experiment.py
@@ -1,13 +1,12 @@
 #!/usr/bin/python
 import os
 import pickle
+
 import numpy
 from numpy import linalg as LA
-from speechbrain.processing.PLDA_LDA import StatObject_SB  # noqa F401
-from speechbrain.processing.PLDA_LDA import PLDA
-from speechbrain.processing.PLDA_LDA import Ndx
-from speechbrain.processing.PLDA_LDA import fast_PLDA_scoring
 
+from speechbrain.processing.PLDA_LDA import StatObject_SB  # noqa F401
+from speechbrain.processing.PLDA_LDA import PLDA, Ndx, fast_PLDA_scoring
 
 # Load params file
 experiment_dir = os.path.dirname(os.path.abspath(__file__))

--- a/tests/integration/VAD/example_vad.py
+++ b/tests/integration/VAD/example_vad.py
@@ -4,10 +4,12 @@ The system is trained with the binary cross-entropy metric.
 """
 
 import os
-import torch
+
 import numpy as np
-import speechbrain as sb
+import torch
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 
 
 class VADBrain(sb.Brain):

--- a/tests/integration/augmentation/example_add_babble.py
+++ b/tests/integration/augmentation/example_add_babble.py
@@ -1,6 +1,8 @@
 import os
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.dataio.dataio import read_audio, write_audio
 
 output_folder = os.path.join("results", "add_babble")

--- a/tests/integration/augmentation/example_add_noise.py
+++ b/tests/integration/augmentation/example_add_noise.py
@@ -1,6 +1,8 @@
 import os
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.dataio.dataio import read_audio, write_audio
 
 output_folder = os.path.join("results", "add_noise")

--- a/tests/integration/augmentation/example_add_reverb.py
+++ b/tests/integration/augmentation/example_add_reverb.py
@@ -1,6 +1,8 @@
 import os
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.dataio.dataio import read_audio, write_audio
 
 output_folder = os.path.join("results", "add_reverb")

--- a/tests/integration/augmentation/example_do_clip.py
+++ b/tests/integration/augmentation/example_do_clip.py
@@ -1,6 +1,8 @@
 import os
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.dataio.dataio import read_audio, write_audio
 
 output_folder = os.path.join("results", "do_clip")

--- a/tests/integration/augmentation/example_drop_chunk.py
+++ b/tests/integration/augmentation/example_drop_chunk.py
@@ -1,6 +1,8 @@
 import os
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.dataio.dataio import read_audio, write_audio
 
 output_folder = os.path.join("results", "drop_chunk")

--- a/tests/integration/augmentation/example_drop_freq.py
+++ b/tests/integration/augmentation/example_drop_freq.py
@@ -1,6 +1,8 @@
 import os
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.dataio.dataio import read_audio, write_audio
 
 output_folder = os.path.join("results", "drop_freq")

--- a/tests/integration/augmentation/example_speed_perturb.py
+++ b/tests/integration/augmentation/example_speed_perturb.py
@@ -1,6 +1,8 @@
 import os
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.dataio.dataio import read_audio, write_audio
 
 output_folder = os.path.join("results", "speed_perturb")

--- a/tests/integration/autoencoder/example_auto_experiment.py
+++ b/tests/integration/autoencoder/example_auto_experiment.py
@@ -7,8 +7,10 @@ training data  (with a validation performance that stays high).
 """
 
 import pathlib
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 
 
 class AutoBrain(sb.Brain):

--- a/tests/integration/enhance_GAN/example_enhance_gan_experiment.py
+++ b/tests/integration/enhance_GAN/example_enhance_gan_experiment.py
@@ -3,10 +3,12 @@
 The generator and the discriminator are based on convolutional networks.
 """
 
-import torch
 import pathlib
-import speechbrain as sb
+
+import torch
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 
 
 class EnhanceGanBrain(sb.Brain):

--- a/tests/integration/sampling/example_sorting.py
+++ b/tests/integration/sampling/example_sorting.py
@@ -1,14 +1,16 @@
 """This minimal example checks on sampling with ascending/descending sorting and random shuffling; w/ & w/o DDP.
 """
 
-import os
-import torch
-import pickle
-import pathlib
 import itertools
-import speechbrain as sb
+import os
+import pathlib
+import pickle
+
+import torch
 import torch.multiprocessing as mp
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 
 
 class SamplingBrain(sb.Brain):

--- a/tests/integration/separation/example_conv_tasnet.py
+++ b/tests/integration/separation/example_conv_tasnet.py
@@ -4,11 +4,13 @@ The architecture is based on ConvTasnet and expects in input mixtures of two
 speakers.
 """
 
-import torch
 import pathlib
-import speechbrain as sb
+
+import torch
 import torch.nn.functional as F
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.nnet.losses import get_si_snr_with_pitwrapper
 
 

--- a/tests/integration/speaker_id/example_xvector_experiment.py
+++ b/tests/integration/speaker_id/example_xvector_experiment.py
@@ -4,8 +4,10 @@ x-vectors. The encoder is based on TDNNs. The classifier is a MLP.
 """
 
 import pathlib
-import speechbrain as sb
+
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 
 
 # Trains xvector model

--- a/tests/templates/fetching_ddp_dynbatch_finetuning/finetune.py
+++ b/tests/templates/fetching_ddp_dynbatch_finetuning/finetune.py
@@ -7,31 +7,29 @@ Does the following feature set work out together on some environment?
 Authors:
     * Andreas Nautsch 2023
 """
+import logging
 import os
 import sys
-import torch
-import logging
-import speechbrain as sb
 from copy import deepcopy
-from tqdm.contrib import tqdm
-from torch.utils.data import DataLoader
+
+import torch
+from ASR_template_train import ASR, dataio_prepare
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.inference.ASR import EncoderDecoderASR
-from speechbrain.utils.distributed import run_on_main, ddp_barrier
-from speechbrain.utils.data_utils import batch_pad_right
-from speechbrain.dataio.dataset import DynamicItemDataset
-from speechbrain.dataio.sampler import DynamicBatchSampler
+from torch.utils.data import DataLoader
+from tqdm.contrib import tqdm
+
+import speechbrain as sb
+from speechbrain.dataio.dataio import read_audio  # read_audio_multichannel,
 from speechbrain.dataio.dataloader import (
     LoopedLoader,
-    make_dataloader,
     distributed_loader_specifics,
+    make_dataloader,
 )
-from speechbrain.dataio.dataio import (
-    read_audio,
-    # read_audio_multichannel,
-)
-from ASR_template_train import ASR, dataio_prepare
-
+from speechbrain.dataio.dataset import DynamicItemDataset
+from speechbrain.dataio.sampler import DynamicBatchSampler
+from speechbrain.inference.ASR import EncoderDecoderASR
+from speechbrain.utils.data_utils import batch_pad_right
+from speechbrain.utils.distributed import ddp_barrier, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/tests/templates/fetching_ddp_dynbatch_finetuning/finetune_fetch_once.py
+++ b/tests/templates/fetching_ddp_dynbatch_finetuning/finetune_fetch_once.py
@@ -7,31 +7,29 @@ Does the following feature set work out together on some environment?
 Authors:
     * Andreas Nautsch 2023
 """
+import logging
 import os
 import sys
-import torch
-import logging
-import speechbrain as sb
 from copy import deepcopy
-from tqdm.contrib import tqdm
-from torch.utils.data import DataLoader
+
+import torch
+from ASR_template_train import ASR, dataio_prepare
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.inference.ASR import EncoderDecoderASR
-from speechbrain.utils.distributed import run_on_main, ddp_barrier
-from speechbrain.utils.data_utils import batch_pad_right
-from speechbrain.dataio.dataset import DynamicItemDataset
-from speechbrain.dataio.sampler import DynamicBatchSampler
+from torch.utils.data import DataLoader
+from tqdm.contrib import tqdm
+
+import speechbrain as sb
+from speechbrain.dataio.dataio import read_audio  # read_audio_multichannel,
 from speechbrain.dataio.dataloader import (
     LoopedLoader,
-    make_dataloader,
     distributed_loader_specifics,
+    make_dataloader,
 )
-from speechbrain.dataio.dataio import (
-    read_audio,
-    # read_audio_multichannel,
-)
-from ASR_template_train import ASR, dataio_prepare
-
+from speechbrain.dataio.dataset import DynamicItemDataset
+from speechbrain.dataio.sampler import DynamicBatchSampler
+from speechbrain.inference.ASR import EncoderDecoderASR
+from speechbrain.utils.data_utils import batch_pad_right
+from speechbrain.utils.distributed import ddp_barrier, run_on_main
 
 logger = logging.getLogger(__name__)
 

--- a/tests/templates/fetching_ddp_dynbatch_finetuning/multisource_mini_recipe.py
+++ b/tests/templates/fetching_ddp_dynbatch_finetuning/multisource_mini_recipe.py
@@ -8,9 +8,11 @@ Authors:
 """
 
 import sys
+
 import torch
-import speechbrain as sb
 from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
 from speechbrain.utils.distributed import run_on_main
 
 

--- a/tests/templates/fetching_ddp_dynbatch_finetuning/single_node_pretrained.py
+++ b/tests/templates/fetching_ddp_dynbatch_finetuning/single_node_pretrained.py
@@ -8,11 +8,11 @@ Authors:
     * Andreas Nautsch 2023
 """
 import logging
-import speechbrain as sb
 from copy import deepcopy
+
+import speechbrain as sb
 from speechbrain.inference.ASR import EncoderDecoderASR
 from speechbrain.utils.fetching import FetchFrom, FetchSource
-
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unittests/test_RNN.py
+++ b/tests/unittests/test_RNN.py
@@ -1,11 +1,12 @@
+from collections import OrderedDict
+
 import torch
 import torch.nn
-from collections import OrderedDict
 
 
 def test_RNN(device):
 
-    from speechbrain.nnet.RNN import RNN, GRU, LSTM, LiGRU, QuasiRNN, RNNCell
+    from speechbrain.nnet.RNN import GRU, LSTM, RNN, LiGRU, QuasiRNN, RNNCell
 
     # Check RNN
     inputs = torch.randn(4, 2, 7, device=device)

--- a/tests/unittests/test_arpa.py
+++ b/tests/unittests/test_arpa.py
@@ -2,8 +2,9 @@ import pytest
 
 
 def test_read_arpa():
-    from speechbrain.lm.arpa import read_arpa
     import io
+
+    from speechbrain.lm.arpa import read_arpa
 
     with io.StringIO() as f:
         print("Anything can be here", file=f)
@@ -93,8 +94,9 @@ def test_read_arpa():
 
 def test_weird_arpa_formats():
     # We've decided to not be picky about ARPA format
-    from speechbrain.lm.arpa import read_arpa
     import io
+
+    from speechbrain.lm.arpa import read_arpa
 
     with io.StringIO() as f:
         print("Anything can be here", file=f)

--- a/tests/unittests/test_augment.py
+++ b/tests/unittests/test_augment.py
@@ -1,6 +1,8 @@
 import os
+
 import torch
 import torchaudio
+
 from speechbrain.dataio.dataio import write_audio
 
 
@@ -490,8 +492,8 @@ def test_SpectrogramDrop():
 
 
 def test_augment_pipeline():
-    from speechbrain.augment.time_domain import DropFreq, DropChunk
     from speechbrain.augment.augmenter import Augmenter
+    from speechbrain.augment.time_domain import DropChunk, DropFreq
 
     freq_dropper = DropFreq()
     chunk_dropper = DropChunk(drop_start=100, drop_end=16000, noise_factor=0)

--- a/tests/unittests/test_batching.py
+++ b/tests/unittests/test_batching.py
@@ -1,11 +1,12 @@
+import numpy as np
 import pytest
 import torch
-import numpy as np
 
 
 def test_batch_pad_right_to(device):
-    from speechbrain.utils.data_utils import batch_pad_right
     import random
+
+    from speechbrain.utils.data_utils import batch_pad_right
 
     n_channels = 40
     batch_lens = [1, 5]

--- a/tests/unittests/test_categorical_encoder.py
+++ b/tests/unittests/test_categorical_encoder.py
@@ -131,8 +131,8 @@ def test_categorical_encoder_saving(tmpdir):
 
 
 def test_categorical_encoder_from_dataset():
-    from speechbrain.dataio.encoder import CategoricalEncoder
     from speechbrain.dataio.dataset import DynamicItemDataset
+    from speechbrain.dataio.encoder import CategoricalEncoder
 
     encoder = CategoricalEncoder()
     data = {

--- a/tests/unittests/test_checkpoints.py
+++ b/tests/unittests/test_checkpoints.py
@@ -1,5 +1,5 @@
-import torch
 import pytest
+import torch
 
 
 def test_checkpointer(tmpdir, device):
@@ -102,10 +102,12 @@ def test_checkpointer(tmpdir, device):
 
 
 def test_recovery_custom_io(tmpdir):
-    from speechbrain.utils.checkpoints import register_checkpoint_hooks
-    from speechbrain.utils.checkpoints import mark_as_saver
-    from speechbrain.utils.checkpoints import mark_as_loader
-    from speechbrain.utils.checkpoints import Checkpointer
+    from speechbrain.utils.checkpoints import (
+        Checkpointer,
+        mark_as_loader,
+        mark_as_saver,
+        register_checkpoint_hooks,
+    )
 
     @register_checkpoint_hooks
     class CustomRecoverable:
@@ -318,10 +320,12 @@ def test_torch_meta(tmpdir, device):
 
 
 def test_checkpoint_hook_register(tmpdir):
-    from speechbrain.utils.checkpoints import register_checkpoint_hooks
-    from speechbrain.utils.checkpoints import mark_as_saver
-    from speechbrain.utils.checkpoints import mark_as_loader
-    from speechbrain.utils.checkpoints import Checkpointer
+    from speechbrain.utils.checkpoints import (
+        Checkpointer,
+        mark_as_loader,
+        mark_as_saver,
+        register_checkpoint_hooks,
+    )
 
     # First a proper interface:
     @register_checkpoint_hooks
@@ -426,6 +430,7 @@ def test_torch_defaults(tmpdir, device):
 
 def parallel_checkpoint(rank, world_size, tmpdir):
     import os
+
     from speechbrain.utils.checkpoints import Checkpointer
 
     os.environ["RANK"] = str(rank)

--- a/tests/unittests/test_conformer.py
+++ b/tests/unittests/test_conformer.py
@@ -9,11 +9,11 @@ def test_streaming_conformer_layer(device):
     from speechbrain.lobes.models.transformer.Conformer import (
         ConformerEncoderLayer,
     )
-    from speechbrain.nnet.attention import RelPosEncXL
-    from speechbrain.utils.dynamic_chunk_training import DynChunkTrainConfig
     from speechbrain.lobes.models.transformer.TransformerASR import (
         make_transformer_src_mask,
     )
+    from speechbrain.nnet.attention import RelPosEncXL
+    from speechbrain.utils.dynamic_chunk_training import DynChunkTrainConfig
 
     TOLERATED_MEAN_ERROR = 1.0e-6
 

--- a/tests/unittests/test_core.py
+++ b/tests/unittests/test_core.py
@@ -11,8 +11,9 @@ def test_parse_arguments():
 
 def test_brain(device):
     import torch
-    from speechbrain.core import Brain, Stage
     from torch.optim import SGD
+
+    from speechbrain.core import Brain, Stage
 
     model = torch.nn.Linear(in_features=10, out_features=10, device=device)
 

--- a/tests/unittests/test_ctc_segmentation.py
+++ b/tests/unittests/test_ctc_segmentation.py
@@ -1,5 +1,6 @@
-from speechbrain.inference.ASR import EncoderDecoderASR
 import pytest
+
+from speechbrain.inference.ASR import EncoderDecoderASR
 
 pytest.importorskip(
     "speechbrain.alignment.ctc_segmentation",
@@ -28,8 +29,11 @@ def test_CTCSegmentation(asr_model: EncoderDecoderASR):
     randomly fail.
     """
     import numpy as np
-    from speechbrain.alignment.ctc_segmentation import CTCSegmentation
-    from speechbrain.alignment.ctc_segmentation import CTCSegmentationTask
+
+    from speechbrain.alignment.ctc_segmentation import (
+        CTCSegmentation,
+        CTCSegmentationTask,
+    )
 
     # speech either from the test audio file or random
     # example file included in the speechbrain repository

--- a/tests/unittests/test_data_io.py
+++ b/tests/unittests/test_data_io.py
@@ -1,5 +1,6 @@
-import torch
 import os
+
+import torch
 
 
 def test_read_audio_info(tmpdir, device):

--- a/tests/unittests/test_data_pipeline.py
+++ b/tests/unittests/test_data_pipeline.py
@@ -84,7 +84,7 @@ def test_data_pipeline():
 
 
 def test_takes_provides():
-    from speechbrain.utils.data_pipeline import takes, provides
+    from speechbrain.utils.data_pipeline import provides, takes
 
     @takes("a")
     @provides("b")
@@ -103,7 +103,7 @@ def test_takes_provides():
 
 
 def test_MIMO_pipeline():
-    from speechbrain.utils.data_pipeline import DataPipeline, takes, provides
+    from speechbrain.utils.data_pipeline import DataPipeline, provides, takes
 
     @takes("text", "other-text")
     @provides("reversed", "concat")

--- a/tests/unittests/test_dataloader.py
+++ b/tests/unittests/test_dataloader.py
@@ -1,5 +1,5 @@
-import torch
 import pytest
+import torch
 
 
 def test_saveable_dataloader(tmpdir, device):

--- a/tests/unittests/test_dataset.py
+++ b/tests/unittests/test_dataset.py
@@ -1,6 +1,7 @@
 def test_dynamic_item_dataset():
-    from speechbrain.dataio.dataset import DynamicItemDataset
     import operator
+
+    from speechbrain.dataio.dataset import DynamicItemDataset
 
     data = {
         "utt1": {"foo": -1, "bar": 0, "text": "hello world"},
@@ -27,8 +28,9 @@ def test_dynamic_item_dataset():
 
 
 def test_filtered_sorted_dynamic_item_dataset():
-    from speechbrain.dataio.dataset import DynamicItemDataset
     import operator
+
+    from speechbrain.dataio.dataset import DynamicItemDataset
 
     data = {
         "utt1": {"foo": -1, "bar": 0, "text": "hello world"},

--- a/tests/unittests/test_dependency_graph.py
+++ b/tests/unittests/test_dependency_graph.py
@@ -3,8 +3,8 @@ import pytest
 
 def test_dependency_graph():
     from speechbrain.utils.depgraph import (
-        DependencyGraph,
         CircularDependencyError,
+        DependencyGraph,
     )
 
     dg = DependencyGraph()

--- a/tests/unittests/test_distances.py
+++ b/tests/unittests/test_distances.py
@@ -1,5 +1,6 @@
-import torch
 import math
+
+import torch
 
 
 def test_cosine_similarity_matrix_simple(device):

--- a/tests/unittests/test_edit_distance.py
+++ b/tests/unittests/test_edit_distance.py
@@ -27,7 +27,7 @@ def test_accumulatable_wer_stats():
 
 
 def test_op_table():
-    from speechbrain.utils.edit_distance import op_table, EDIT_SYMBOLS
+    from speechbrain.utils.edit_distance import EDIT_SYMBOLS, op_table
 
     assert len(op_table([1, 2, 3], [1, 2, 4])) == 4
     assert len(op_table([1, 2, 3], [1, 2, 4])[0]) == 4
@@ -39,7 +39,7 @@ def test_op_table():
 
 
 def test_alignment():
-    from speechbrain.utils.edit_distance import alignment, EDIT_SYMBOLS
+    from speechbrain.utils.edit_distance import EDIT_SYMBOLS, alignment
 
     I = EDIT_SYMBOLS["ins"]  # noqa: E741, here I is a good var name
     D = EDIT_SYMBOLS["del"]
@@ -50,7 +50,7 @@ def test_alignment():
 
 
 def test_count_ops():
-    from speechbrain.utils.edit_distance import count_ops, EDIT_SYMBOLS
+    from speechbrain.utils.edit_distance import EDIT_SYMBOLS, count_ops
 
     I = EDIT_SYMBOLS["ins"]  # noqa: E741, here I is a good var name
     D = EDIT_SYMBOLS["del"]

--- a/tests/unittests/test_features.py
+++ b/tests/unittests/test_features.py
@@ -38,8 +38,7 @@ def test_context_window(device):
 
 
 def test_istft(device):
-    from speechbrain.processing.features import STFT
-    from speechbrain.processing.features import ISTFT
+    from speechbrain.processing.features import ISTFT, STFT
 
     fs = 16000
     inp = torch.randn([10, 16000], device=device)

--- a/tests/unittests/test_g2p.py
+++ b/tests/unittests/test_g2p.py
@@ -20,8 +20,8 @@ def _batch_fake_probs(indexes, count):
 
 
 def test_subsequence_loss():
-    from speechbrain.nnet.losses import nll_loss
     from speechbrain.lobes.models.g2p.homograph import SubsequenceLoss
+    from speechbrain.nnet.losses import nll_loss
 
     phn_dim = 4
     phns = torch.tensor(

--- a/tests/unittests/test_hpopt.py
+++ b/tests/unittests/test_hpopt.py
@@ -2,9 +2,10 @@ import pytest
 
 
 def test_hpopt_generic():
-    from io import StringIO
-    from speechbrain.utils import hpopt as hp
     import json
+    from io import StringIO
+
+    from speechbrain.utils import hpopt as hp
 
     output = StringIO()
 
@@ -44,8 +45,9 @@ def test_hpopt_orion():
 
 def test_hpopt_context():
     import json
-    from speechbrain.utils import hpopt as hp
     from io import StringIO
+
+    from speechbrain.utils import hpopt as hp
 
     output = StringIO()
     reporter = hp.GenericHyperparameterOptimizationReporter(

--- a/tests/unittests/test_k2.py
+++ b/tests/unittests/test_k2.py
@@ -1,11 +1,13 @@
+import logging
 import os
-import pytest
-import tempfile
 import shutil
-import torch
+import tempfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
-import logging
+
+import pytest
+import torch
+
 from speechbrain.k2_integration import k2
 
 logger = logging.getLogger(__name__)

--- a/tests/unittests/test_losses.py
+++ b/tests/unittests/test_losses.py
@@ -1,5 +1,5 @@
-import torch
 import pytest
+import torch
 
 
 def test_nll(device):
@@ -76,9 +76,10 @@ def test_classification_error(device):
 
 
 def test_pitwrapper(device):
-    from speechbrain.nnet.losses import PitWrapper
     import torch
     from torch import nn
+
+    from speechbrain.nnet.losses import PitWrapper
 
     base_loss = nn.MSELoss(reduction="none")
     pit = PitWrapper(base_loss)

--- a/tests/unittests/test_metrics.py
+++ b/tests/unittests/test_metrics.py
@@ -1,11 +1,12 @@
+import math
+
 import torch
 import torch.nn
-import math
 
 
 def test_metric_stats(device):
-    from speechbrain.utils.metric_stats import MetricStats
     from speechbrain.nnet.losses import l1_loss
+    from speechbrain.utils.metric_stats import MetricStats
 
     l1_stats = MetricStats(metric=l1_loss)
     l1_stats.append(
@@ -82,8 +83,8 @@ def test_weighted_error_rate_stats():
 
 
 def test_synonym_dict_error_rate_stats():
-    from speechbrain.utils.metric_stats import ErrorRateStats
     from speechbrain.utils.dictionaries import SynonymDictionary
+    from speechbrain.utils.metric_stats import ErrorRateStats
 
     syn_dict = SynonymDictionary()
     syn_dict.add_synonym_set({"a", "a'"})
@@ -190,6 +191,7 @@ def test_minDCF(device):
 
 def test_classification_stats():
     import pytest
+
     from speechbrain.utils.metric_stats import ClassificationStats
 
     stats = ClassificationStats()
@@ -206,6 +208,7 @@ def test_classification_stats():
 
 def test_categorized_classification_stats():
     import pytest
+
     from speechbrain.utils.metric_stats import ClassificationStats
 
     stats = ClassificationStats()
@@ -239,6 +242,7 @@ def test_categorized_classification_stats():
 
 def test_classification_stats_report():
     from io import StringIO
+
     from speechbrain.utils.metric_stats import ClassificationStats
 
     stats = ClassificationStats()

--- a/tests/unittests/test_ngram_lm.py
+++ b/tests/unittests/test_ngram_lm.py
@@ -1,6 +1,7 @@
 def test_backoff_ngram_lm():
-    from speechbrain.lm.ngram import BackoffNgramLM
     import math
+
+    from speechbrain.lm.ngram import BackoffNgramLM
 
     HALF = math.log(0.5)
     ngrams = {

--- a/tests/unittests/test_rescorer.py
+++ b/tests/unittests/test_rescorer.py
@@ -1,6 +1,7 @@
 def test_rnnlmrescorer(tmpdir, device):
     import torch
     from sentencepiece import SentencePieceProcessor
+
     from speechbrain.lobes.models.RNNLM import RNNLM
     from speechbrain.utils.parameter_transfer import Pretrainer
 
@@ -31,7 +32,7 @@ def test_rnnlmrescorer(tmpdir, device):
     pretrainer.collect_files()
     pretrainer.load_collected()
 
-    from speechbrain.decoders.scorer import RNNLMRescorer, RescorerBuilder
+    from speechbrain.decoders.scorer import RescorerBuilder, RNNLMRescorer
 
     rnnlm_rescorer = RNNLMRescorer(
         language_model=lm_model,
@@ -78,6 +79,7 @@ def test_rnnlmrescorer(tmpdir, device):
 def test_transformerlmrescorer(tmpdir, device):
     import torch
     from sentencepiece import SentencePieceProcessor
+
     from speechbrain.lobes.models.transformer.TransformerLM import TransformerLM
     from speechbrain.utils.parameter_transfer import Pretrainer
 
@@ -108,8 +110,8 @@ def test_transformerlmrescorer(tmpdir, device):
     pretrainer.load_collected()
 
     from speechbrain.decoders.scorer import (
-        TransformerLMRescorer,
         RescorerBuilder,
+        TransformerLMRescorer,
     )
 
     transformerlm_rescorer = TransformerLMRescorer(
@@ -201,6 +203,7 @@ def test_huggingfacelmrescorer(device):
 def test_rescorerbuilder(tmpdir, device):
     import torch
     from sentencepiece import SentencePieceProcessor
+
     from speechbrain.lobes.models.RNNLM import RNNLM
     from speechbrain.utils.parameter_transfer import Pretrainer
 
@@ -232,9 +235,9 @@ def test_rescorerbuilder(tmpdir, device):
     pretrainer.load_collected()
 
     from speechbrain.decoders.scorer import (
-        RNNLMRescorer,
-        RescorerBuilder,
         HuggingFaceLMRescorer,
+        RescorerBuilder,
+        RNNLMRescorer,
     )
 
     rnnlm_rescorer = RNNLMRescorer(

--- a/tests/unittests/test_samplers.py
+++ b/tests/unittests/test_samplers.py
@@ -2,12 +2,13 @@ import torch
 
 
 def test_ConcatDatasetBatchSampler(device):
-    from torch.utils.data import TensorDataset, ConcatDataset, DataLoader
-    from speechbrain.dataio.sampler import (
-        ReproducibleRandomSampler,
-        ConcatDatasetBatchSampler,
-    )
     import numpy as np
+    from torch.utils.data import ConcatDataset, DataLoader, TensorDataset
+
+    from speechbrain.dataio.sampler import (
+        ConcatDatasetBatchSampler,
+        ReproducibleRandomSampler,
+    )
 
     datasets = []
     for i in range(3):
@@ -48,10 +49,10 @@ def test_ConcatDatasetBatchSampler(device):
     np.testing.assert_array_equal(non_cat_data.T, concat_data)
 
     # check DynamicBatchSampler
-    from speechbrain.dataio.sampler import DynamicBatchSampler
-    from speechbrain.dataio.dataset import DynamicItemDataset
-    from speechbrain.dataio.dataloader import SaveableDataLoader
     from speechbrain.dataio.batch import PaddedBatch
+    from speechbrain.dataio.dataloader import SaveableDataLoader
+    from speechbrain.dataio.dataset import DynamicItemDataset
+    from speechbrain.dataio.sampler import DynamicBatchSampler
 
     max_batch_length = 4
     num_buckets = 5

--- a/tests/unittests/test_schedulers.py
+++ b/tests/unittests/test_schedulers.py
@@ -30,9 +30,10 @@ def test_NewBobScheduler():
 
 def test_WarmAndExpDecayLRSchedule():
 
-    from speechbrain.nnet.schedulers import WarmAndExpDecayLRSchedule
-    from speechbrain.nnet.linear import Linear
     import torch
+
+    from speechbrain.nnet.linear import Linear
+    from speechbrain.nnet.schedulers import WarmAndExpDecayLRSchedule
 
     model = Linear(input_size=3, n_neurons=4)
     optim = torch.optim.Adam(model.parameters(), lr=1)

--- a/tests/unittests/test_signal_processing.py
+++ b/tests/unittests/test_signal_processing.py
@@ -3,10 +3,14 @@ import torch
 
 def test_normalize(device):
 
-    from speechbrain.processing.signal_processing import compute_amplitude
-    from speechbrain.processing.signal_processing import rescale
     import random
+
     import numpy as np
+
+    from speechbrain.processing.signal_processing import (
+        compute_amplitude,
+        rescale,
+    )
 
     for scale in ["dB", "linear"]:
         for amp_type in ["peak", "avg"]:

--- a/tests/unittests/test_superpowers.py
+++ b/tests/unittests/test_superpowers.py
@@ -1,4 +1,5 @@
 import sys
+
 import pytest
 
 

--- a/tests/unittests/test_tokenizer.py
+++ b/tests/unittests/test_tokenizer.py
@@ -1,4 +1,5 @@
 import os
+
 import torch
 
 

--- a/tests/unittests/test_transformer_src_tgt_masks.py
+++ b/tests/unittests/test_transformer_src_tgt_masks.py
@@ -4,11 +4,12 @@ import torch.nn
 
 def test_make_transformer_src_tgt_masks(device):
 
+    from numpy import inf
+
     from speechbrain.lobes.models.transformer.TransformerASR import (
         make_transformer_src_tgt_masks,
     )
     from speechbrain.utils.dynamic_chunk_training import DynChunkTrainConfig
-    from numpy import inf
 
     config = DynChunkTrainConfig(chunk_size=4, left_context_size=3)
 
@@ -67,10 +68,11 @@ def test_make_transformer_src_mask(device):
 
 def test_get_lookahead_mask(device):
 
+    from numpy import inf
+
     from speechbrain.lobes.models.transformer.Transformer import (
         get_lookahead_mask,
     )
-    from numpy import inf
 
     # fmt: off
     # flake8: noqa

--- a/tests/utils/check_HF_repo.py
+++ b/tests/utils/check_HF_repo.py
@@ -5,8 +5,9 @@ Authors
  * Andreas Nautsch 2022, 2023
 """
 
-import os
 import csv
+import os
+
 from speechbrain.utils.data_utils import download_file
 from tests.consistency.test_recipe import __skip_list
 

--- a/tests/utils/check_docstrings.py
+++ b/tests/utils/check_docstrings.py
@@ -5,6 +5,7 @@ Authors
 """
 
 import re
+
 from speechbrain.utils.data_utils import get_all_files
 
 

--- a/tests/utils/check_url.py
+++ b/tests/utils/check_url.py
@@ -8,8 +8,10 @@ Authors
 import os
 import re
 import time
+
 import requests
 from tqdm.contrib import tqdm
+
 from speechbrain.utils.data_utils import get_all_files
 
 

--- a/tests/utils/check_yaml.py
+++ b/tests/utils/check_yaml.py
@@ -7,6 +7,7 @@ Authors
 
 import os
 import re
+
 from speechbrain.core import run_opt_defaults
 
 

--- a/tests/utils/recipe_tests.py
+++ b/tests/utils/recipe_tests.py
@@ -5,14 +5,16 @@ Authors
  * Andreas Nautsch 2022, 2023
 """
 
-import os
-import re
 import csv
-import sys
+import os
 import pydoc
-from time import time
+import re
 import subprocess as sp
+import sys
+from time import time
+
 from hyperpyyaml import load_hyperpyyaml
+
 from speechbrain.utils.data_utils import download_file  # noqa: F401
 
 __skip_list = ["README.md", "setup"]

--- a/tests/utils/refactoring_checks.py
+++ b/tests/utils/refactoring_checks.py
@@ -10,22 +10,24 @@ Authors
  * Andreas Nautsch, 2022, 2023
 """
 
-import os
-import sys
-from tqdm import tqdm
-import yaml
-import torch  # noqa
 import importlib  # noqa
+import os
 import subprocess
-import speechbrain  # noqa
-from glob import glob
+import sys
 from copy import deepcopy
-from torch.utils.data import DataLoader
+from glob import glob
+
+import torch  # noqa
+import yaml
 from hyperpyyaml import load_hyperpyyaml
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+
+import speechbrain  # noqa
+from speechbrain.dataio.dataloader import LoopedLoader, make_dataloader
+from speechbrain.inference.interfaces import foreign_class  # noqa
 from speechbrain.utils.distributed import run_on_main  # noqa
 from speechbrain.utils.train_logger import FileTrainLogger
-from speechbrain.inference.interfaces import foreign_class  # noqa
-from speechbrain.dataio.dataloader import LoopedLoader, make_dataloader
 
 
 def init(

--- a/tools/compute_wer.py
+++ b/tools/compute_wer.py
@@ -36,8 +36,8 @@ Usage
 Authors:
  * Aku Rouhe 2020
 """
-import speechbrain.utils.edit_distance as edit_distance
 import speechbrain.dataio.wer as wer_io
+import speechbrain.utils.edit_distance as edit_distance
 
 
 # These internal utilities read Kaldi-style text/utt2spk files:

--- a/tools/g2p.py
+++ b/tools/g2p.py
@@ -58,15 +58,16 @@ Authors
 import itertools
 import math
 import os
-import speechbrain as sb
 import sys
 import traceback
-
-from cmd import Cmd
 from argparse import ArgumentParser
+from cmd import Cmd
+
 from hyperpyyaml import load_hyperpyyaml
-from speechbrain.inference.text import GraphemeToPhoneme
 from tqdm.auto import tqdm
+
+import speechbrain as sb
+from speechbrain.inference.text import GraphemeToPhoneme
 
 MSG_MODEL_NOT_FOUND = "Model path not found"
 MSG_HPARAMS_NOT_FILE = "Hyperparameters file not found"

--- a/tools/profiling/profile.py
+++ b/tools/profiling/profile.py
@@ -13,26 +13,27 @@ Author:
 """
 
 import sys
-import torch
-import speechbrain as sb
-from hyperpyyaml import load_hyperpyyaml
-from speechbrain.utils.profiling import (
-    profile_report,
-    export,
-    report_time,
-    report_memory,
-)
+from typing import List, Optional
 
-from speechbrain.inference.interfaces import Pretrained
-from speechbrain.inference.ASR import EncoderDecoderASR, EncoderASR
-from speechbrain.inference.SLU import EndToEndSLU
+import torch
+from hyperpyyaml import load_hyperpyyaml
+
+import speechbrain as sb
+from speechbrain.inference.ASR import EncoderASR, EncoderDecoderASR
 from speechbrain.inference.classifiers import EncoderClassifier
+from speechbrain.inference.enhancement import SpectralMaskEnhancement
+from speechbrain.inference.interfaces import Pretrained
+from speechbrain.inference.metrics import SNREstimator
+from speechbrain.inference.separation import SepformerSeparation
+from speechbrain.inference.SLU import EndToEndSLU
 from speechbrain.inference.speaker import SpeakerRecognition
 from speechbrain.inference.VAD import VAD
-from speechbrain.inference.separation import SepformerSeparation
-from speechbrain.inference.enhancement import SpectralMaskEnhancement
-from speechbrain.inference.metrics import SNREstimator
-from typing import Optional, List
+from speechbrain.utils.profiling import (
+    export,
+    profile_report,
+    report_memory,
+    report_time,
+)
 
 
 def get_funcs_to_unary_input_classifier(

--- a/tools/readme_builder.py
+++ b/tools/readme_builder.py
@@ -15,9 +15,10 @@ Authors:
     - Mirco Ravanelli 2023
 """
 
+import argparse
 import csv
 import re
-import argparse
+
 from speechbrain.utils.data_utils import get_all_files
 
 


### PR DESCRIPTION
Adds `isort` to the linters. This is a nice way to ensure consistency and make imports easier to find.

The initial version of this PR just uses the defaults from `isort` but if anyone has opinions there are other ways to sort.

Default sorting is alphabetical within 3 sections:

1. Standard library imports
2. Third party imports
3. Internal imports

There are options, such as sort by length, different sections etc. so if anyone wants a different sort, they should speak up.