### PR TITLE
Temporarily pin max scipy version due to removed function breaking a dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ packaging
 pandas>=1.0.1
 pre-commit>=2.3.0
 pygtrie>=2.1,<3.0
-scipy>=1.4.1
+scipy>=1.4.1,<1.13.0
 sentencepiece>=0.1.91
 SoundFile; sys_platform == 'win32'
 torch>=1.9.0


### PR DESCRIPTION
## What does this PR do?

gensim, an indirect dependency of SB (through flair, which is optional but installed in CI), is currently broken with SciPy `1.13.0`, pending the merge for https://github.com/piskvorky/gensim/pull/3524. In the mean time, fix CI by pinning scipy < `1.13.0`.

This is not otherwise a major problem for users outside of CI because flair is only imported if you use functionality from `lobes/models/flair`.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
