### PR TITLE
Exclude the `tests` package from setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,9 @@ setup(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",
     ],
-    packages=setuptools.find_packages(),
+    # we don't want to ship the tests package. for future proofing, also
+    # exclude any tests subpackage (if we ever define __init__.py there)
+    packages=setuptools.find_packages(exclude=["tests", "tests.*"]),
     package_data={"speechbrain": ["version.txt", "log-config.yaml"]},
     install_requires=[
         "hyperpyyaml",


### PR DESCRIPTION
## What does this PR do?

Supersedes #2492 which was invalid because subpackages must be specified.

Fixes #2491.

An empty tests package would get shipped both with normal and editable installs (even though the tests package is empty anyway in the `.whl` for some reason).

The PR excludes `tests/` and any future subpackage we may specify there with the rationale described in the added comment.

Rerunning `pip install --editable .` is required for the changes to take effect.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
