### PR TITLE
fix issue with ctc_forward_step

### DIFF
--- a/speechbrain/alignment/ctc_segmentation.py
+++ b/speechbrain/alignment/ctc_segmentation.py
@@ -250,11 +250,14 @@ class CTCSegmentation:
         self._encode = self.asr_model.encode_batch
 
         if isinstance(asr_model, EncoderDecoderASR):
-            if not hasattr(asr_model.hparams, "scorer") or not hasattr(
-                asr_model.hparams.scorer.full_scorers, "ctc"
-            ):
+            if not hasattr(asr_model.hparams, "scorer"):
                 raise AttributeError(
-                    "``ScorerBuilder`` and ``CTCScorer`` module are required for CTC segmentation."
+                    "``ScorerBuilder`` module is required for CTC segmentation."
+                )
+
+            if not hasattr(asr_model.hparams.scorer.full_scorers, "ctc"):
+                raise AttributeError(
+                    "``CTCScorer`` module is required for CTC segmentation."
                 )
 
             def ctc_forward_step(x: torch.Tensor) -> torch.Tensor:

--- a/speechbrain/alignment/ctc_segmentation.py
+++ b/speechbrain/alignment/ctc_segmentation.py
@@ -249,7 +249,8 @@ class CTCSegmentation:
         self.asr_model = asr_model
         self._encode = self.asr_model.encode_batch
         if isinstance(asr_model, EncoderDecoderASR):
-            # Assumption: we assume that scorer contains the CTC module
+            # Assumption: we assume that there's a ``ScorerBuilder`` object
+            # which a ``CTCScorer`` object.
             def ctc_forward_step(x):
                 """Forward step for CTC module."""
                 module = self.asr_model.hparams.scorer.full_scorers["ctc"]

--- a/speechbrain/alignment/ctc_segmentation.py
+++ b/speechbrain/alignment/ctc_segmentation.py
@@ -248,10 +248,16 @@ class CTCSegmentation:
             )
         self.asr_model = asr_model
         self._encode = self.asr_model.encode_batch
+
         if isinstance(asr_model, EncoderDecoderASR):
-            # Assumption: we assume that there's a ``ScorerBuilder`` object
-            # which a ``CTCScorer`` object.
-            def ctc_forward_step(x):
+            if not hasattr(asr_model.hparams, "scorer") or not hasattr(
+                asr_model.hparams.scorer.full_scorers, "ctc"
+            ):
+                raise AttributeError(
+                    "``ScorerBuilder`` and ``CTCScorer`` module are required for CTC segmentation."
+                )
+
+            def ctc_forward_step(x: torch.Tensor) -> torch.Tensor:
                 """Forward step for CTC module."""
                 module = self.asr_model.hparams.scorer.full_scorers["ctc"]
                 logits = module.ctc_fc(x)

--- a/speechbrain/alignment/ctc_segmentation.py
+++ b/speechbrain/alignment/ctc_segmentation.py
@@ -250,12 +250,12 @@ class CTCSegmentation:
         self._encode = self.asr_model.encode_batch
 
         if isinstance(asr_model, EncoderDecoderASR):
-            if not hasattr(asr_model.hparams, "scorer"):
+            if not hasattr(self.asr_model.hparams, "scorer"):
                 raise AttributeError(
                     "``ScorerBuilder`` module is required for CTC segmentation."
                 )
 
-            if not hasattr(asr_model.hparams.scorer.full_scorers, "ctc"):
+            if "ctc" not in self.asr_model.hparams.scorer.full_scorers:
                 raise AttributeError(
                     "``CTCScorer`` module is required for CTC segmentation."
                 )


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

-->
This PR aims to fix one issue with the `ctc_segmentation` module due to the introduction of the new beam search part. Indeed, there's no longer the function `ctc_forward_step` inside the beam search. To address this issue, I added new code to make it work with SB 1.0.

Fixes #2440

repro:
```python
from speechbrain.inference.ASR import EncoderDecoderASR
from speechbrain.alignment.ctc_segmentation import CTCSegmentation
# load an ASR model
pre_trained = "speechbrain/asr-transformer-transformerlm-librispeech"
asr_model = EncoderDecoderASR.from_hparams(source=pre_trained)
aligner = CTCSegmentation(asr_model, kaldi_style_text=False)
# load data
audio_path = "/content/speechbrain/tests/samples/single-mic/example1.wav"
text = ["THE BIRCH CANOE", "SLID ON THE", "SMOOTH PLANKS"]
segments = aligner(audio_path, text, name="example1")
```
### Before
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
[<ipython-input-4-cb3639878d03>](https://localhost:8080/#) in <cell line: 6>()
      4 pre_trained = "speechbrain/asr-transformer-transformerlm-librispeech"
      5 asr_model = EncoderDecoderASR.from_hparams(source=pre_trained)
----> 6 aligner = CTCSegmentation(asr_model, kaldi_style_text=False)
      7 # load data
      8 audio_path = "/content/speechbrain/tests/samples/single-mic/example1.wav"

1 frames
[/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py](https://localhost:8080/#) in __getattr__(self, name)
   1693             if name in modules:
   1694                 return modules[name]
-> 1695         raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
   1696 
   1697     def __setattr__(self, name: str, value: Union[Tensor, 'Module']) -> None:

AttributeError: 'S2STransformerBeamSearcher' object has no attribute 'ctc_forward_step'
```
### After
```
The dictionary has 5000 tokens with a max length of 15. This may lead to low alignment performance and low accuracy.
example1_0000 example1 0.78 1.61 -5.7213 THE BIRCH CANOE
example1_0001 example1 1.61 1.85 -11.5366 SLID ON THE
example1_0002 example1 1.85 2.81 -3.2060 SMOOTH PLANKS
```


<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
