### PR TITLE
Skip lazy imports when the caller is inspect.py

### DIFF
--- a/speechbrain/utils/importutils.py
+++ b/speechbrain/utils/importutils.py
@@ -48,11 +48,6 @@ class LazyModule(ModuleType):
         """Ensures that the target module is imported and available as
         `self.lazy_module`, also returning it.
 
-        When the function responsible for the import attempt is found to be
-        `inspect.py`, we raise an `AttributeError` here. This is because some
-        code will inadvertently cause our modules to be imported, such as some
-        of PyTorch's op registering machinery.
-
         Arguments
         ---------
         stacklevel : int
@@ -60,6 +55,14 @@ class LazyModule(ModuleType):
             occur, relative to the **caller** of this function (e.g. if in
             function `f` you call `_ensure_module(1)`, it will refer to the
             function that called `f`).
+
+        Raises
+        ------
+        AttributeError
+            When the function responsible for the import attempt is found to be
+            `inspect.py`, we raise an `AttributeError` here. This is because
+            some code will inadvertently cause our modules to be imported, such
+            as some of PyTorch's op registering machinery.
         """
 
         importer_frame = None

--- a/speechbrain/utils/importutils.py
+++ b/speechbrain/utils/importutils.py
@@ -44,7 +44,7 @@ class LazyModule(ModuleType):
         self.lazy_module = None
         self.package = package
 
-    def _ensure_module(self, stacklevel: int) -> ModuleType:
+    def ensure_module(self, stacklevel: int) -> ModuleType:
         """Ensures that the target module is imported and available as
         `self.lazy_module`, also returning it.
 
@@ -53,7 +53,7 @@ class LazyModule(ModuleType):
         stacklevel : int
             The stack trace level of the function that caused the import to
             occur, relative to the **caller** of this function (e.g. if in
-            function `f` you call `_ensure_module(1)`, it will refer to the
+            function `f` you call `ensure_module(1)`, it will refer to the
             function that called `f`).
 
         Raises
@@ -105,7 +105,7 @@ class LazyModule(ModuleType):
 
     def __getattr__(self, attr):
         # NOTE: exceptions here get eaten and not displayed
-        return getattr(self._ensure_module(1), attr)
+        return getattr(self.ensure_module(1), attr)
 
 
 class DeprecatedModuleRedirect(LazyModule):
@@ -157,15 +157,15 @@ class DeprecatedModuleRedirect(LazyModule):
         warnings.warn(
             warning_text,
             # category=DeprecationWarning,
-            stacklevel=4,  # _ensure_module <- __getattr__ <- python <- user
+            stacklevel=4,  # ensure_module <- __getattr__ <- python <- user
         )
 
-    def _ensure_module(self, stacklevel: int) -> ModuleType:
+    def ensure_module(self, stacklevel: int) -> ModuleType:
         should_warn = self.lazy_module is None
 
         # can fail with exception if the module shouldn't be imported, so only
         # actually emit the warning later
-        module = super()._ensure_module(stacklevel + 1)
+        module = super().ensure_module(stacklevel + 1)
 
         if should_warn:
             self._redirection_warn()

--- a/tests/unittests/test_imports.py
+++ b/tests/unittests/test_imports.py
@@ -1,0 +1,17 @@
+import hyperpyyaml
+import pytest
+
+
+@pytest.mark.filterwarnings(
+    "ignore:Module 'speechbrain.pretrained' was deprecated"
+)
+def test_lazy_pretrained_hparams():
+    """Test the lazy redirection for `pretrained` through a YAML to ensure that
+    `hyperpyyaml`'s magic does not break there"""
+
+    yaml = hyperpyyaml.load_hyperpyyaml(
+        """\
+test_pretrained: !name:speechbrain.pretrained.interfaces.Pretrained
+"""
+    )
+    assert yaml["test_pretrained"] is not None


### PR DESCRIPTION
## What does this PR do?

This avoids having certain inspect functions import our lazy modules when we don't want them to. `getframeinfo` in particular appears to do it, and this gets called by PyTorch at some point. IPython might also be doing it but autocomplete still seems to work.

This does not appear to break anything. Added test for hyperpyyaml to ensure we're not breaking that.

Fixes the issue where the redirection warning was emitted even if you weren't using `speechbrain.pretrained`, and prevents some lazy imports from forcefully being imported.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
