### PR TITLE
Fix Separation and Enhancement recipes behavior when NaN encountered

### DIFF
--- a/recipes/Aishell1Mix/separation/train.py
+++ b/recipes/Aishell1Mix/separation/train.py
@@ -165,7 +165,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0.).to(self.device)
+                    loss.data = torch.tensor(0.0).to(self.device)
             else:
                 predictions, targets = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN, noise
@@ -197,7 +197,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0.).to(self.device)
+                    loss.data = torch.tensor(0.0).to(self.device)
         self.optimizer.zero_grad()
 
         return loss.detach().cpu()

--- a/recipes/Aishell1Mix/separation/train.py
+++ b/recipes/Aishell1Mix/separation/train.py
@@ -165,7 +165,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0).to(self.device)
+                    loss.data = torch.tensor(0.).to(self.device)
             else:
                 predictions, targets = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN, noise
@@ -197,7 +197,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0).to(self.device)
+                    loss.data = torch.tensor(0.).to(self.device)
         self.optimizer.zero_grad()
 
         return loss.detach().cpu()

--- a/recipes/BinauralWSJ0Mix/separation/train.py
+++ b/recipes/BinauralWSJ0Mix/separation/train.py
@@ -253,7 +253,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0.).to(self.device)
+                    loss.data = torch.tensor(0.0).to(self.device)
             else:
                 predictions, targets = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN, noise
@@ -285,7 +285,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0.).to(self.device)
+                    loss.data = torch.tensor(0.0).to(self.device)
         self.optimizer.zero_grad()
 
         return loss.detach().cpu()

--- a/recipes/BinauralWSJ0Mix/separation/train.py
+++ b/recipes/BinauralWSJ0Mix/separation/train.py
@@ -253,7 +253,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0).to(self.device)
+                    loss.data = torch.tensor(0.).to(self.device)
             else:
                 predictions, targets = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN, noise
@@ -285,7 +285,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0).to(self.device)
+                    loss.data = torch.tensor(0.).to(self.device)
         self.optimizer.zero_grad()
 
         return loss.detach().cpu()

--- a/recipes/DNS/enhancement/train.py
+++ b/recipes/DNS/enhancement/train.py
@@ -183,7 +183,7 @@ class Enhancement(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0).to(self.device)
+                    loss.data = torch.tensor(0.).to(self.device)
             else:
                 predictions, clean = self.compute_forward(
                     noisy, clean, sb.Stage.TRAIN, noise
@@ -215,7 +215,7 @@ class Enhancement(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0).to(self.device)
+                    loss.data = torch.tensor(0.).to(self.device)
         self.optimizer.zero_grad()
 
         return loss.detach().cpu()

--- a/recipes/DNS/enhancement/train.py
+++ b/recipes/DNS/enhancement/train.py
@@ -183,7 +183,7 @@ class Enhancement(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0.).to(self.device)
+                    loss.data = torch.tensor(0.0).to(self.device)
             else:
                 predictions, clean = self.compute_forward(
                     noisy, clean, sb.Stage.TRAIN, noise
@@ -215,7 +215,7 @@ class Enhancement(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0.).to(self.device)
+                    loss.data = torch.tensor(0.0).to(self.device)
         self.optimizer.zero_grad()
 
         return loss.detach().cpu()

--- a/recipes/LibriMix/separation/train.py
+++ b/recipes/LibriMix/separation/train.py
@@ -167,7 +167,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0.).to(self.device)
+                    loss.data = torch.tensor(0.0).to(self.device)
             else:
                 predictions, targets = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN, noise
@@ -199,7 +199,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0.).to(self.device)
+                    loss.data = torch.tensor(0.0).to(self.device)
         self.optimizer.zero_grad()
 
         return loss.detach().cpu()

--- a/recipes/LibriMix/separation/train.py
+++ b/recipes/LibriMix/separation/train.py
@@ -167,7 +167,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0).to(self.device)
+                    loss.data = torch.tensor(0.).to(self.device)
             else:
                 predictions, targets = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN, noise
@@ -199,7 +199,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0).to(self.device)
+                    loss.data = torch.tensor(0.).to(self.device)
         self.optimizer.zero_grad()
 
         return loss.detach().cpu()

--- a/recipes/REAL-M/sisnr-estimation/train.py
+++ b/recipes/REAL-M/sisnr-estimation/train.py
@@ -217,7 +217,7 @@ class Separation(sb.Brain):
                                 self.nonfinite_count
                             )
                         )
-                        loss.data = torch.tensor(0).to(self.device)
+                        loss.data = torch.tensor(0.).to(self.device)
 
             else:
                 # get the oracle snrs, estimated snrs, and the source estimates
@@ -245,7 +245,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0).to(self.device)
+                    loss.data = torch.tensor(0.).to(self.device)
 
         self.optimizer.zero_grad()
 

--- a/recipes/REAL-M/sisnr-estimation/train.py
+++ b/recipes/REAL-M/sisnr-estimation/train.py
@@ -217,7 +217,7 @@ class Separation(sb.Brain):
                                 self.nonfinite_count
                             )
                         )
-                        loss.data = torch.tensor(0.).to(self.device)
+                        loss.data = torch.tensor(0.0).to(self.device)
 
             else:
                 # get the oracle snrs, estimated snrs, and the source estimates
@@ -245,7 +245,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0.).to(self.device)
+                    loss.data = torch.tensor(0.0).to(self.device)
 
         self.optimizer.zero_grad()
 

--- a/recipes/WHAMandWHAMR/enhancement/train.py
+++ b/recipes/WHAMandWHAMR/enhancement/train.py
@@ -199,7 +199,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0).to(self.device)
+                    loss.data = torch.tensor(0.).to(self.device)
             else:
                 predictions, targets = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN, noise
@@ -231,7 +231,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0).to(self.device)
+                    loss.data = torch.tensor(0.).to(self.device)
         self.optimizer.zero_grad()
 
         return loss.detach().cpu()

--- a/recipes/WHAMandWHAMR/enhancement/train.py
+++ b/recipes/WHAMandWHAMR/enhancement/train.py
@@ -199,7 +199,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0.).to(self.device)
+                    loss.data = torch.tensor(0.0).to(self.device)
             else:
                 predictions, targets = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN, noise
@@ -231,7 +231,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0.).to(self.device)
+                    loss.data = torch.tensor(0.0).to(self.device)
         self.optimizer.zero_grad()
 
         return loss.detach().cpu()

--- a/recipes/WHAMandWHAMR/separation/train.py
+++ b/recipes/WHAMandWHAMR/separation/train.py
@@ -162,7 +162,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0.).to(self.device)
+                    loss.data = torch.tensor(0.0).to(self.device)
             else:
                 predictions, targets = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN, noise
@@ -194,7 +194,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0.).to(self.device)
+                    loss.data = torch.tensor(0.0).to(self.device)
         self.optimizer.zero_grad()
 
         return loss.detach().cpu()

--- a/recipes/WHAMandWHAMR/separation/train.py
+++ b/recipes/WHAMandWHAMR/separation/train.py
@@ -162,7 +162,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0).to(self.device)
+                    loss.data = torch.tensor(0.).to(self.device)
             else:
                 predictions, targets = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN, noise
@@ -194,7 +194,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0).to(self.device)
+                    loss.data = torch.tensor(0.).to(self.device)
         self.optimizer.zero_grad()
 
         return loss.detach().cpu()

--- a/recipes/WSJ0Mix/separation/train.py
+++ b/recipes/WSJ0Mix/separation/train.py
@@ -148,7 +148,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0).to(self.device)
+                    loss.data = torch.tensor(0.).to(self.device)
             else:
                 predictions, targets = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN
@@ -180,7 +180,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0).to(self.device)
+                    loss.data = torch.tensor(0.).to(self.device)
         self.optimizer.zero_grad()
 
         return loss.detach().cpu()

--- a/recipes/WSJ0Mix/separation/train.py
+++ b/recipes/WSJ0Mix/separation/train.py
@@ -148,7 +148,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0.).to(self.device)
+                    loss.data = torch.tensor(0.0).to(self.device)
             else:
                 predictions, targets = self.compute_forward(
                     mixture, targets, sb.Stage.TRAIN
@@ -180,7 +180,7 @@ class Separation(sb.Brain):
                             self.nonfinite_count
                         )
                     )
-                    loss.data = torch.tensor(0.).to(self.device)
+                    loss.data = torch.tensor(0.0).to(self.device)
         self.optimizer.zero_grad()
 
         return loss.detach().cpu()


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

-->

Separation and enhancement models replace NaN by 0 during the loss calculation of each training step. Since each value of the calculated loss requires grad, encountering a NaN during training would lead to this behavior : 


> 23%|██▎       | 4528/20000 [20:38<1:04:42,  3.99it/s, train_loss=-17]
 23%|██▎       | 4528/20000 [20:38<1:04:42,  3.99it/s, train_loss=-17]
 23%|██▎       | 4529/20000 [20:38<1:08:23,  3.77it/s, train_loss=-17]
 23%|██▎       | 4529/20000 [20:38<1:08:23,  3.77it/s, train_loss=-17]
 23%|██▎       | 4530/20000 [20__main__ - infinite loss or empty loss! it happened 1 times so far - skipping this batch
:38<1:09:43,  3.70it/s, train_loss=-17]
                                                                      

 >23%|██▎       | 4530/20000 [20:38<1:09:43,  3.70it/s, train_loss=-17]
 23%|██▎       | 4530/20000 [20:39<1:10:32,  3.65it/s, train_loss=-17]
speechbrain.core - Exception:
Traceback (most recent call last):
  File "/home/src/speechbrain/recipes/WSJ0Mix/8k/separation/train_vanilla.py", line 672, in <module>
    separator.fit(
  File "/home/src/speechbrain/speechbrain/core.py", line 1582, in fit
    self._fit_train(train_set=train_set, epoch=epoch, enable=enable)
  File "/home/src/speechbrain/speechbrain/core.py", line 1407, in _fit_train
    loss = self.fit_batch(batch)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/src/speechbrain/recipes/WSJ0Mix/8k/separation/train_vanilla.py", line 181, in fit_batch
    loss.data = torch.tensor(0).to(self.device)
    ^^^^^^^^^
RuntimeError: data set to a tensor that requires gradients must be floating point or complex dtype


This PR simply changes the dtype of 0s in the loss, from integer to float to avoid this problem.

>99%|█████████▉| 19805/20000 [1:30:26<00:48,  4.00it/s, train_loss=-18.9]
 99%|█████████▉| 19806/20000 [1:3__main__ - infinite loss or empty loss! it happened 2 times so far - skipping this batch
0:26<00:51,  3.76it/s, train_loss=-18.9]
                                                                         

> 99%|█████████▉| 19806/20000 [1:30:26<00:51,  3.76it/s, train_loss=-18.9]
 99%|█████████▉| 19806/20000 [1:30:27<00:51,  3.76it/s, train_loss=-18.9]
 99%|█████████▉| 19807/20000 [1:30:27<00:42,  4.50it/s, train_loss=-18.9]
 99%|█████████▉| 19807/20000 [1:30:27<00:42,  4.50it/s, train_loss=-18.9]


The training successfully resumes after the changes (this was tested on the separation recipe).

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
