### PR TITLE
Fix compatibility for torchaudio versions without `.io`

### DIFF
--- a/speechbrain/inference/ASR.py
+++ b/speechbrain/inference/ASR.py
@@ -549,7 +549,7 @@ class WhisperASR(Pretrained):
         return languages, lang_probs
 
     def _get_audio_stream(
-        self, streamer: torchaudio.io.StreamReader, frames_per_chunk: int
+        self, streamer: "torchaudio.io.StreamReader", frames_per_chunk: int
     ):
         """From a :class:`torchaudio.io.StreamReader`, identifies the audio
         stream and returns an iterable stream of chunks (after resampling and
@@ -990,7 +990,7 @@ class StreamingASR(Pretrained):
         self.filter_props = self.hparams.fea_streaming_extractor.properties
 
     def _get_audio_stream(
-        self, streamer: torchaudio.io.StreamReader, frames_per_chunk: int
+        self, streamer: "torchaudio.io.StreamReader", frames_per_chunk: int
     ):
         """From a :class:`torchaudio.io.StreamReader`, identifies the audio
         stream and returns an iterable stream of chunks (after resampling and


### PR DESCRIPTION
## What does this PR do?

`torchaudio.io` doesn't exist in older torchaudio versions. Since this is an optional dependency for `StreamingASR`, this unnecessarily breaks older versions. The Python interpreter doesn't bother evaluating forward references (in quotes) so this effectively solves the issue.

This issue was brought up by #2531 but does not close the issue.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
