### PR TITLE
Tentative fix for Windows `--editable` installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,10 @@ import setuptools
 # https://github.com/pypa/pip/issues/7953.
 site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
 
-with open("README.md") as f:
+with open("README.md", encoding="utf-8") as f:
     long_description = f.read()
 
-with open(os.path.join("speechbrain", "version.txt")) as f:
+with open(os.path.join("speechbrain", "version.txt"), encoding="utf-8") as f:
     version = f.read().strip()
 
 setup(


### PR DESCRIPTION
## What does this PR do?

Fixes(?) the issue mentioned in the last comment of #2536. On Windows, the default is not UTF-8, so some users are facing issues when using `--editable` installs. Regular wheel installs would not reproduce the problem since those do not run `setup.py`.  
There might still be problematic `open()`s so perhaps all of them should explicitly use `encoding="utf-8"` someday.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
