### PR TITLE
Less aggressive SpecAug to reduce(?) divergence

### DIFF
--- a/recipes/LibriSpeech/ASR/transducer/hparams/conformer_transducer.yaml
+++ b/recipes/LibriSpeech/ASR/transducer/hparams/conformer_transducer.yaml
@@ -183,16 +183,16 @@ wav_augment: !new:speechbrain.augment.augmenter.Augmenter
 
 # Time Drop
 time_drop: !new:speechbrain.augment.freq_domain.SpectrogramDrop
-   drop_length_low: 15
-   drop_length_high: 25
+   drop_length_low: 12
+   drop_length_high: 20
    drop_count_low: 5
    drop_count_high: 5
    replace: "zeros"
 
 # Frequency Drop
 freq_drop: !new:speechbrain.augment.freq_domain.SpectrogramDrop
-   drop_length_low: 25
-   drop_length_high: 35
+   drop_length_low: 20
+   drop_length_high: 25
    drop_count_low: 2
    drop_count_high: 2
    replace: "zeros"


### PR DESCRIPTION
## What does this PR do?

Fixes #2533 (potentially; not verified).

This is a reduction of ~20% of the freq-wise and the time-wise SpecAugment, because we found out those seem too aggressive and would make it so that some samples had very few features unmasked.

This is a WIP that hasn't been tested extensively.

TODO:

- [x] Check whether the final model has a similar (or better) WER.
- [x] Check whether the model training actually becomes reliable (need to test over a bunch of trains, usually visible at ~1.5 epochs). 

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
