### PR TITLE
AISHELL recipe fixes for `TransformerASR` causality, warn if the user doesn't specify `causal`

### DIFF
--- a/recipes/AISHELL-1/ASR/transformer/hparams/train_ASR_transformer.yaml
+++ b/recipes/AISHELL-1/ASR/transformer/hparams/train_ASR_transformer.yaml
@@ -126,6 +126,7 @@ Transformer: !new:speechbrain.lobes.models.transformer.TransformerASR.Transforme
     dropout: !ref <transformer_dropout>
     activation: !ref <activation>
     normalize_before: True
+    causal: False
 
 tokenizer: !new:sentencepiece.SentencePieceProcessor
 

--- a/recipes/AISHELL-1/ASR/transformer/hparams/train_ASR_transformer_with_wav2vect.yaml
+++ b/recipes/AISHELL-1/ASR/transformer/hparams/train_ASR_transformer_with_wav2vect.yaml
@@ -119,6 +119,7 @@ Transformer: !new:speechbrain.lobes.models.transformer.TransformerASR.Transforme
     dropout: !ref <transformer_dropout>
     activation: !ref <activation>
     normalize_before: True
+    causal: False
 
 tokenizer: !new:sentencepiece.SentencePieceProcessor
 

--- a/speechbrain/lobes/models/transformer/TransformerASR.py
+++ b/speechbrain/lobes/models/transformer/TransformerASR.py
@@ -6,6 +6,7 @@ Authors
 * Luca Della Libera 2024
 """
 
+import logging
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -23,6 +24,8 @@ from speechbrain.nnet.activations import Swish
 from speechbrain.nnet.containers import ModuleList
 from speechbrain.nnet.linear import Linear
 from speechbrain.utils.dynamic_chunk_training import DynChunkTrainConfig
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -256,11 +259,20 @@ class TransformerASR(TransformerInterface):
         branchformer_activation: Optional[nn.Module] = nn.GELU,
         attention_type: Optional[str] = "regularMHA",
         max_length: Optional[int] = 2500,
-        causal: Optional[bool] = True,
+        causal: Optional[bool] = None,
         csgu_linear_units: Optional[int] = 3072,
         gate_activation: Optional[nn.Module] = nn.Identity,
         use_linear_after_conv: Optional[bool] = False,
     ):
+        if causal is None:
+            logger.warning(
+                "`causal` not specified for `TransformerASR`, assuming `True` for compatibility. "
+                "We strongly recommend that you explicitly set this. "
+                "If you are using a model or recipe defined before v1.0, it might now be BROKEN! "
+                "If so, please see https://github.com/speechbrain/speechbrain/issues/2604"
+            )
+            causal = True
+
         super().__init__(
             d_model=d_model,
             nhead=nhead,


### PR DESCRIPTION
## What does this PR do?

See #2604. The issue may only be closed when relevant HF PRs are merged.

This PR:
1. Sets `causal: False` for affected AISHELL recipes, as this is how they were originally trained (`TransformerASR` causality was broken for the MHA masks). This should be safe to change because, for the model configurations in AISHELL, the causal parameter doesn't affect anything but the MHA.
2. Basically very strongly encourages the user to set `causal` appropriately, by warning if it is unspecified when constructing the `TransformerASR`. It still defaults to `True`, and links to the above issue with all the details. I figure this is OK because virtually all recipes define `causal` manually anyway, it should be worth it.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
