### PR TITLE
Pin transient dep conllu to 4.x to workaround broken upstream

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -30,7 +30,7 @@ jobs:
               run: |
                   pip install uv
                   uv pip install --system ctc-segmentation  # ctc-segmentation is funky with uv due to their oldest-supported-numpy dependency
-                  uv pip install --system -r requirements.txt torch==2.2.1+cpu torchaudio==2.2.1+cpu --extra-index-url https://download.pytorch.org/whl/cpu k2==1.24.4.dev20240223+cpu.torch2.2.1 --find-links https://k2-fsa.github.io/k2/cpu.html kaldilm==1.15.1 spacy==3.7.4 flair==0.13.1 gensim==4.3.2 conllu<5.0.0
+                  uv pip install --system -r requirements.txt torch==2.2.1+cpu torchaudio==2.2.1+cpu --extra-index-url https://download.pytorch.org/whl/cpu k2==1.24.4.dev20240223+cpu.torch2.2.1 --find-links https://k2-fsa.github.io/k2/cpu.html kaldilm==1.15.1 spacy==3.7.4 flair==0.13.1 gensim==4.3.2 'conllu<5.0.0'
                   uv pip install --system --editable . --no-deps  # already installed pinned deps from requirements.txt, we're good
             - name: Install sox
               run: |

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -30,7 +30,7 @@ jobs:
               run: |
                   pip install uv
                   uv pip install --system ctc-segmentation  # ctc-segmentation is funky with uv due to their oldest-supported-numpy dependency
-                  uv pip install --system -r requirements.txt torch==2.2.1+cpu torchaudio==2.2.1+cpu --extra-index-url https://download.pytorch.org/whl/cpu k2==1.24.4.dev20240223+cpu.torch2.2.1 --find-links https://k2-fsa.github.io/k2/cpu.html kaldilm==1.15.1 spacy==3.7.4 flair==0.13.1 gensim==4.3.2
+                  uv pip install --system -r requirements.txt torch==2.2.1+cpu torchaudio==2.2.1+cpu --extra-index-url https://download.pytorch.org/whl/cpu k2==1.24.4.dev20240223+cpu.torch2.2.1 --find-links https://k2-fsa.github.io/k2/cpu.html kaldilm==1.15.1 spacy==3.7.4 flair==0.13.1 gensim==4.3.2 conllu<5.0.0
                   uv pip install --system --editable . --no-deps  # already installed pinned deps from requirements.txt, we're good
             - name: Install sox
               run: |

--- a/.github/workflows/verify-docs-gen.yml
+++ b/.github/workflows/verify-docs-gen.yml
@@ -24,7 +24,7 @@ jobs:
               run: |
                   pip install uv
                   uv pip install --system ctc-segmentation  # ctc-segmentation is funky with uv due to their oldest-supported-numpy dependency
-                  uv pip install --system -r requirements.txt -r docs/docs-requirements.txt torch==2.2.1+cpu torchaudio==2.2.1+cpu --extra-index-url https://download.pytorch.org/whl/cpu k2==1.24.4.dev20240223+cpu.torch2.2.1 --find-links https://k2-fsa.github.io/k2/cpu.html kaldilm==1.15.1 spacy==3.7.4 flair==0.13.1 gensim==4.3.2 conllu<5.0.0
+                  uv pip install --system -r requirements.txt -r docs/docs-requirements.txt torch==2.2.1+cpu torchaudio==2.2.1+cpu --extra-index-url https://download.pytorch.org/whl/cpu k2==1.24.4.dev20240223+cpu.torch2.2.1 --find-links https://k2-fsa.github.io/k2/cpu.html kaldilm==1.15.1 spacy==3.7.4 flair==0.13.1 gensim==4.3.2 'conllu<5.0.0'
                   uv pip install --system --editable . --no-deps  # already installed pinned deps from requirements.txt, we're good
             - name: Generate docs
               run: |

--- a/.github/workflows/verify-docs-gen.yml
+++ b/.github/workflows/verify-docs-gen.yml
@@ -24,7 +24,7 @@ jobs:
               run: |
                   pip install uv
                   uv pip install --system ctc-segmentation  # ctc-segmentation is funky with uv due to their oldest-supported-numpy dependency
-                  uv pip install --system -r requirements.txt -r docs/docs-requirements.txt torch==2.2.1+cpu torchaudio==2.2.1+cpu --extra-index-url https://download.pytorch.org/whl/cpu k2==1.24.4.dev20240223+cpu.torch2.2.1 --find-links https://k2-fsa.github.io/k2/cpu.html kaldilm==1.15.1 spacy==3.7.4 flair==0.13.1 gensim==4.3.2
+                  uv pip install --system -r requirements.txt -r docs/docs-requirements.txt torch==2.2.1+cpu torchaudio==2.2.1+cpu --extra-index-url https://download.pytorch.org/whl/cpu k2==1.24.4.dev20240223+cpu.torch2.2.1 --find-links https://k2-fsa.github.io/k2/cpu.html kaldilm==1.15.1 spacy==3.7.4 flair==0.13.1 gensim==4.3.2 conllu<5.0.0
                   uv pip install --system --editable . --no-deps  # already installed pinned deps from requirements.txt, we're good
             - name: Generate docs
               run: |

--- a/docs/docs-requirements.txt
+++ b/docs/docs-requirements.txt
@@ -1,8 +1,8 @@
 better-apidoc>=0.3.1
+conllu<5.0.0
 ctc-segmentation>=1.7.0
 fairseq
 flair==0.13.1
-conllu<5.0.0
 https://github.com/kpu/kenlm/archive/master.zip
 numba>=0.54.1
 pyctcdecode

--- a/docs/docs-requirements.txt
+++ b/docs/docs-requirements.txt
@@ -2,6 +2,7 @@ better-apidoc>=0.3.1
 ctc-segmentation>=1.7.0
 fairseq
 flair==0.13.1
+conllu<5.0.0
 https://github.com/kpu/kenlm/archive/master.zip
 numba>=0.54.1
 pyctcdecode


### PR DESCRIPTION
## What does this PR do?

CI is currently broken on develop due to a transient dependency of flair, which is installed as part of the CI process.

Reported the issue upstream, can unpin once it is solved there: https://github.com/EmilStenstrom/conllu/issues/96

If the upstream issue is fixed before this is merged feel free to close.
