### PR TITLE
Allow EncodeClassifier.from_hparams() to load private HF models

### DIFF
--- a/speechbrain/inference/interfaces.py
+++ b/speechbrain/inference/interfaces.py
@@ -501,7 +501,7 @@ class Pretrained(torch.nn.Module):
             pretrainer.set_collect_in(savedir)
             # For distributed setups, have this here:
             run_on_main(
-                pretrainer.collect_files, kwargs={"default_source": source}
+                pretrainer.collect_files, kwargs={"default_source": source, "use_auth_token": use_auth_token}
             )
             # Load on the CPU. Later the params can be moved elsewhere by specifying
             if not download_only:

--- a/speechbrain/utils/parameter_transfer.py
+++ b/speechbrain/utils/parameter_transfer.py
@@ -170,7 +170,7 @@ class Pretrainer:
         else:
             return split(path)
 
-    def collect_files(self, default_source=None, internal_ddp_handling=False):
+    def collect_files(self, default_source=None, internal_ddp_handling=False, use_auth_token=False):
         """Fetches parameters from known paths with fallback default_source
 
         The actual parameter files may reside elsewhere, but this ensures a
@@ -226,7 +226,7 @@ class Pretrainer:
                         "source": source,
                         "overwrite": False,
                         "save_filename": save_filename,
-                        "use_auth_token": False,
+                        "use_auth_token": use_auth_token,
                         "revision": None,
                     },
                 )
@@ -238,7 +238,7 @@ class Pretrainer:
                     savedir=self.collect_in,
                     overwrite=False,
                     save_filename=save_filename,
-                    use_auth_token=False,
+                    use_auth_token=use_auth_token,
                     revision=None,
                 )
             else:
@@ -249,7 +249,7 @@ class Pretrainer:
                     savedir=self.collect_in,
                     overwrite=False,
                     save_filename=save_filename,
-                    use_auth_token=False,
+                    use_auth_token=use_auth_token,
                     revision=None,
                 )
             loadable_paths[name] = path


### PR DESCRIPTION
## What does this PR do?

Pass `use_auth_token` from `EncoderClassifier.from_hparams()` to `Pretrainer.collect_files()` to allow loading of private HF models.

Fixes #2634

<details>
  <summary><b>Before submitting</b></summary>

- [X] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [X] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
