### PR TITLE
Kmeans fix

### DIFF
--- a/speechbrain/utils/kmeans.py
+++ b/speechbrain/utils/kmeans.py
@@ -185,8 +185,8 @@ def train(
                 )
                 save_model(model, checkpoint_path)
 
-        if len(features_list) > 0:
-            model = model.fit(features_list)
+        if len(features_list) >= kmeans_batch_size:
+            model = model.partial_fit(features_list)
 
 
 def save_model(model, checkpoint_path):

--- a/speechbrain/utils/kmeans.py
+++ b/speechbrain/utils/kmeans.py
@@ -119,7 +119,31 @@ def fetch_kmeans_model(
         compute_labels=True,
         init_size=None,
     )
+def process_chunks(data, chunk_size, model):
+    """Process data in chunks of a specified size.
 
+    Args:
+        data (list): 
+            The list of integers to be processed.
+        chunk_size (int): 
+            The size of each chunk.
+        model : MiniBatchKMeans
+            The initial kmeans model for training.
+
+    return:
+        model : MiniBatchKMeans
+            The initial kmeans model for training.
+    """
+    for i in range(0, len(data), chunk_size):
+        chunk = data[i:i + chunk_size]
+
+        # Skip processing if the chunk size is smaller than chunk_size
+        if len(chunk) < chunk_size:
+            break
+    
+        model = model.partial_fit(chunk)
+
+    return model
 
 def train(
     model,
@@ -168,7 +192,7 @@ def train(
 
             # train a kmeans model on a single batch if  features_list reaches the kmeans_batch_size.
             if len(features_list) >= kmeans_batch_size:
-                model = model.partial_fit(features_list)
+                model = process_chunks(features_list,kmeans_batch_size,model)
                 iteration += 1
                 features_list = []
 
@@ -186,7 +210,7 @@ def train(
                 save_model(model, checkpoint_path)
 
         if len(features_list) >= kmeans_batch_size:
-            model = model.partial_fit(features_list)
+            model = process_chunks(features_list,kmeans_batch_size,model)
 
 
 def save_model(model, checkpoint_path):

--- a/speechbrain/utils/kmeans.py
+++ b/speechbrain/utils/kmeans.py
@@ -168,7 +168,7 @@ def train(
 
             # train a kmeans model on a single batch if  features_list reaches the kmeans_batch_size.
             if len(features_list) >= kmeans_batch_size:
-                model = model.fit(features_list)
+                model = model.partial_fit(features_list)
                 iteration += 1
                 features_list = []
 

--- a/speechbrain/utils/kmeans.py
+++ b/speechbrain/utils/kmeans.py
@@ -143,8 +143,6 @@ def process_chunks(data, chunk_size, model):
     
         model = model.partial_fit(chunk)
 
-    return model
-
 def train(
     model,
     train_set,

--- a/speechbrain/utils/kmeans.py
+++ b/speechbrain/utils/kmeans.py
@@ -190,7 +190,7 @@ def train(
 
             # train a kmeans model on a single batch if  features_list reaches the kmeans_batch_size.
             if len(features_list) >= kmeans_batch_size:
-                model = process_chunks(features_list,kmeans_batch_size,model)
+                process_chunks(features_list,kmeans_batch_size,model)
                 iteration += 1
                 features_list = []
 
@@ -208,7 +208,7 @@ def train(
                 save_model(model, checkpoint_path)
 
         if len(features_list) >= kmeans_batch_size:
-            model = process_chunks(features_list,kmeans_batch_size,model)
+           process_chunks(features_list,kmeans_batch_size,model)
 
 
 def save_model(model, checkpoint_path):


### PR DESCRIPTION
## What does this PR do?
Fix the partial_fit bug introduced in kmeans.py  which causes only the last batch used for training the k-means. It is related to this bug:
https://github.com/speechbrain/speechbrain/issues/2602
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

-->

Fixes #<issue_number>

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
