### PR TITLE
Fix device error in VAD inference

### DIFF
--- a/speechbrain/inference/VAD.py
+++ b/speechbrain/inference/VAD.py
@@ -582,12 +582,12 @@ class VAD(Pretrained):
             segment, _ = torchaudio.load(
                 audio_file, frame_offset=begin_sample, num_frames=seg_len
             )
-
+            segment = segment.to(self.device)
             # Create chunks
             segment_chunks = self.create_chunks(
                 segment, chunk_size=chunk_len, chunk_stride=chunk_len
             )
-
+            
             # Energy computation within each chunk
             energy_chunks = segment_chunks.abs().sum(-1) + eps
             energy_chunks = energy_chunks.log()

--- a/speechbrain/inference/VAD.py
+++ b/speechbrain/inference/VAD.py
@@ -587,7 +587,7 @@ class VAD(Pretrained):
             segment_chunks = self.create_chunks(
                 segment, chunk_size=chunk_len, chunk_stride=chunk_len
             )
-            
+
             # Energy computation within each chunk
             energy_chunks = segment_chunks.abs().sum(-1) + eps
             energy_chunks = energy_chunks.log()


### PR DESCRIPTION
This correction solves the error raised when using GPU to run the VAD pipeline: The model would be on GPU while the segment is loaded on CPU.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

-->

Fixes #<issue_number>

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
