### PR TITLE
Fixes a typo in the head comment.

### DIFF
--- a/recipes/WSJ0Mix/separation/train.py
+++ b/recipes/WSJ0Mix/separation/train.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env/python3
-"""Recipe for training a neural speech separation system on wsjmix the
+"""Recipe for training a neural speech separation system on the wsjmix
 dataset. The system employs an encoder, a decoder, and a masking network.
 
 To run this recipe, do the following:


### PR DESCRIPTION
Fixes a typo in the head comment.

No dependencies are required for this change.

No breaking changes introduced.

The code adheres to project-specific code style and conventions.