### PR TITLE
Try forcing omegaconf to 2.0.6 to see if it fixes doc building

### DIFF
--- a/docs/docs-requirements.txt
+++ b/docs/docs-requirements.txt
@@ -4,6 +4,7 @@ fairseq @ git+https://github.com/facebookresearch/fairseq.git@v0.12.3
 flair==0.13.1
 https://github.com/kpu/kenlm/archive/master.zip
 numba>=0.54.1
+omegaconf==2.0.6
 pyctcdecode
 recommonmark>=0.7.1
 scikit-learn


### PR DESCRIPTION
## What does this PR do?

The issue is that the pinned omegaconf version for latest releases of fairseq has dependency metadata that pip now consider invalids. This results in failed dependency solving when installing fairseq, because all candidate versions get rejected. Hopefully, pinning a specific version of `omegaconf` as a direct dependency should force pip to consider this version instead of ignoring it for the above reason.

Will check if #2657 still reproduces once merged. This is a minor CI-only change so I will merge without a review if tests pass.