### PR TITLE
Doc fix attempt again by bumping omegaconf version

### DIFF
--- a/docs/docs-requirements.txt
+++ b/docs/docs-requirements.txt
@@ -4,7 +4,7 @@ fairseq @ git+https://github.com/facebookresearch/fairseq.git@v0.12.3
 flair==0.13.1
 https://github.com/kpu/kenlm/archive/master.zip
 numba>=0.54.1
-omegaconf==2.0.6
+omegaconf==2.3.0
 pyctcdecode
 recommonmark>=0.7.1
 scikit-learn


### PR DESCRIPTION
## What does this PR do?

Take two, see #2657 #2671 -- if this passes it should be ok even if fairseq might not fully be compatible, as long as it succeeds to build the docs...