### PR TITLE
Mock some doc dependencies

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,12 @@ intersphinx_mapping = {
 autodoc_default_options = {}
 
 # Autodoc mock extra dependencies:
-autodoc_mock_imports = []
+autodoc_mock_imports = [
+    "fairseq",
+    "flair",
+    "kenlm",
+    "spacy",
+]
 
 # Order of API items:
 autodoc_member_order = "bysource"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,12 +100,10 @@ default_role = "code"
 
 def run_apidoc(app):
     """Generate API documentation"""
-    import better_apidoc
-
-    better_apidoc.APP = app
-    better_apidoc.main(
+    from sphinx.apidoc import main
+    main(
         [
-            "better-apidoc",
+            "sphinx-apidoc",
             "-t",
             "_apidoc_templates",
             "--force",

--- a/docs/docs-requirements.txt
+++ b/docs/docs-requirements.txt
@@ -1,14 +1,10 @@
 better-apidoc>=0.3.1
 ctc-segmentation>=1.7.0
-fairseq @ git+https://github.com/facebookresearch/fairseq.git@v0.12.3
-flair==0.13.1
-https://github.com/kpu/kenlm/archive/master.zip
 numba>=0.54.1
 pyctcdecode
 recommonmark>=0.7.1
 scikit-learn
 six
-spacy==3.7.4
 sphinx-rtd-theme>=0.4.3
 Sphinx>=3.4.3
 transformers


### PR DESCRIPTION
Curious to see if it still builds fine -- that'd probably help make the CI break way less often, as some of these dependencies broke more than once in the past.

Shouldn't change anything functional.

I am, however, noticing that `better-apidoc` didn't handle `autodoc_mock_imports` at the time, which is why it wasn't used. However, that didn't get updated in a while... Perhaps we should move to upstream if any similar functionality made it upstream (although the author's work didn't make it).  
Making this a draft since it's probably not working.