### PR TITLE
Critical: Fix DDP barriers

### DIFF
--- a/speechbrain/utils/distributed.py
+++ b/speechbrain/utils/distributed.py
@@ -276,7 +276,7 @@ def ddp_init_group(run_opts):
 
     # Switch to the right context ; this is needed for DDP barriers
     # otherwise, everything before an instance of `Brain(...)`
-    # is going to have `LOCAL_RANK` equal to 0. 
+    # is going to have `LOCAL_RANK` equal to 0.
     local_rank = int(os.environ.get("LOCAL_RANK", "0"))
     device = torch.device(f"cuda:{local_rank}")
     torch.cuda.set_device(device)


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

-->

This PR aims at fixing an issue with DDP barrier. Indeed, in the current develop version of SpeechBrain this current code snippet doesn't work:
```python
  from speechbrain.utils.distributed import get_rank, rank_prefixed_message, is_distributed_initialized, if_main_process, ddp_barrier

  logger.info(rank_prefixed_message(f"main={if_main_process()}"), main_process_only=False)
  
  if if_main_process():
      import time 
      time.sleep(10)
  logger.info(rank_prefixed_message("barrier 1 reached"), main_process_only=False)
  ddp_barrier()
  if if_main_process():
      import time 
      time.sleep(10)
  logger.info(rank_prefixed_message("barrier 2 reached"), main_process_only=False)
  ddp_barrier()
  
  logger.info(rank_prefixed_message("finished"), main_process_only=False)


  torch.distributed.destroy_process_group()
```
while it should! In the current dev version, the rank1 is reaching the end of the program and doesn't wait in the second DDP barrier. It does wait in the first for the main proc, but does not in the second. I went into debugging mode and found that the LOCAL_RANK of each proc is 0, which happen as we do not instantiate `Brain()` and thus the cuda device stream is never set to the actual LOCAL_RANK. I found that explicitly setting `torch.cuda.set_device(device)` in `ddp_init_group` was solving the issue. When you call `torch.cuda.current_device()` you get the right LOCAL_RANK value (which was not the case as it was just returning the LOCAL_RANK 0). 

Another example with `run_on_main`:
```python
from speechbrain.utils.distributed import get_rank, rank_prefixed_message, is_distributed_initialized, if_main_process, ddp_barrier

def bar():
    import time
    time.sleep(10)
    logger.info(rank_prefixed_message("SB is so good."), main_process_only=False)

def foo():
    bar()

run_on_main(
    foo
)
run_on_main(
    foo
)
logger.info(rank_prefixed_message("end."), main_process_only=False)
```
The second rank is rightly awaiting for `foo` to get executed and wait for the DDP barriers. 

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
