### PR TITLE
`gh-action-pypi-publish@master` was deprecated, switch to `release/v1`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         run: python -m build --sdist --wheel --outdir dist/
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_KEY }}


### PR DESCRIPTION
## What does this PR do?

See #2658. It does **not** resolve it (see slack/the primary mail warning), but it fixes a warning brought up by it.  
The `gh-action-pypi-publish` action strongly recommends against targeting `@master` and suggests targeting `@release/v1` instead.  
This targets the latest version of the action in the `v1` series. I am assuming the intent of that branch is to have reasonable backwards compatibility...