### PR TITLE
Incorrect check on concat original start index

### DIFF
--- a/speechbrain/augment/augmenter.py
+++ b/speechbrain/augment/augmenter.py
@@ -364,7 +364,7 @@ class Augmenter(torch.nn.Module):
         if self.concat_original:
 
             # Check start index
-            if self.concat_start_index >= x.shape[0]:
+            if self.concat_start_index >= x_original.shape[0]:
                 self.skip_concat = True
                 pass
             else:


### PR DESCRIPTION
## What does this PR do?
In the `Augmenter` class we allow the users to concatenate the original signals (the input batch) after augmentation. Furthermore, we allow them to select a subset of the original batch to concatenate via `concat_start_index` and `concat_end_index`.  This PR fixes a bug in the concatenation validation logic where we check to see if the `concat_start_index` exceeds the size of the input batch before performing the concatenation. Instead of checking the batch size of the original signal `x_original.shape[0]`, we are currently checking the batch size of the subset of the input that the user has selected for augmentation `x.shape[0]` which got changed when we did `x = x[self.augment_start_index : self.augment_end_index_batch]`. This will skip the concatenation of the original signal when the batch dimension of the slice the user selects for augmentation is smaller than or equal to `concat_start_index`. These two have nothing to do with each other, this is a mistake.

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

-->


<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
