### PR TITLE
Fixes #2656: Remove EOS from SoundChoice

### DIFF
--- a/speechbrain/inference/text.py
+++ b/speechbrain/inference/text.py
@@ -94,9 +94,29 @@ class GraphemeToPhoneme(Pretrained, EncodeDecodePipelineMixin):
         model_outputs = self.mods.model(**model_inputs)
         decoded_output = self.decode_output(model_outputs)
         phonemes = decoded_output["phonemes"]
+        phonemes = self._remove_eos(phonemes)
         if single:
             phonemes = phonemes[0]
         return phonemes
+
+    def _remove_eos(self, phonemes):
+        """Removes the EOS character from the end of the sequence,
+        if encountered
+
+        Arguments
+        ---------
+        phonemes : list
+            a list of phomemic transcriptions
+
+        Returns
+        -------
+        result : list
+            phonemes, without <eos>
+        """
+        return [
+            item[:-1] if item and item[-1] == "<eos>" else item
+            for item in phonemes
+        ]
 
     def _update_graphemes(self, model_inputs):
         grapheme_sequence_mode = getattr(self.hparams, "grapheme_sequence_mode")


### PR DESCRIPTION
## What does this PR do?
Removes EOS from SoundChoice G2P
Fixes #2656

Breaking change: `GraphemeToPhoneme` will no longer output the <eos> token - any code relying on it will break.

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
