### PR TITLE
Make `collect_in` optional for `Pretrainer`, disable it by default

### DIFF
--- a/speechbrain/inference/classifiers.py
+++ b/speechbrain/inference/classifiers.py
@@ -270,7 +270,7 @@ class AudioClassifier(Pretrained):
         text_lab = self.hparams.label_encoder.decode_torch(index)
         return out_probs, score, index, text_lab
 
-    def classify_file(self, path, savedir="audio_cache"):
+    def classify_file(self, path, savedir=None):
         """Classifies the given audiofile into the given set of labels.
 
         Arguments
@@ -297,7 +297,7 @@ class AudioClassifier(Pretrained):
             fl,
             source=source,
             savedir=savedir,
-            local_strategy=LocalStrategy.NO_LINK,
+            local_strategy=LocalStrategy.SYMLINK,
         )
 
         batch, fs_file = torchaudio.load(path)

--- a/speechbrain/inference/interfaces.py
+++ b/speechbrain/inference/interfaces.py
@@ -48,7 +48,7 @@ def foreign_class(
     use_auth_token=False,
     download_only=False,
     huggingface_cache_dir=None,
-    local_strategy: LocalStrategy = LocalStrategy.NO_LINK,
+    local_strategy: LocalStrategy = LocalStrategy.SYMLINK,
     **kwargs,
 ):
     """Fetch and load an interface from an outside source
@@ -278,7 +278,7 @@ class Pretrained(torch.nn.Module):
             for p in self.mods.parameters():
                 p.requires_grad = False
 
-    def load_audio(self, path, savedir="."):
+    def load_audio(self, path, savedir=None):
         """Load an audio file with this model's input spec
 
         When using a speech model, it is important to use the same type of data,
@@ -293,7 +293,7 @@ class Pretrained(torch.nn.Module):
             fl,
             source=source,
             savedir=savedir,
-            local_strategy=LocalStrategy.NO_LINK,
+            local_strategy=LocalStrategy.SYMLINK,
         )
         signal, sr = torchaudio.load(str(path), channels_first=False)
         return self.audio_normalizer(signal, sr)
@@ -405,7 +405,7 @@ class Pretrained(torch.nn.Module):
         download_only=False,
         huggingface_cache_dir=None,
         overrides_must_match=True,
-        local_strategy: LocalStrategy = LocalStrategy.NO_LINK,
+        local_strategy: LocalStrategy = LocalStrategy.SYMLINK,
         **kwargs,
     ):
         """Fetch and load based from outside source based on HyperPyYAML file

--- a/speechbrain/inference/interpretability.py
+++ b/speechbrain/inference/interpretability.py
@@ -132,7 +132,7 @@ class PIQAudioInterpreter(Pretrained):
 
         return x_int_sound_domain, text_lab
 
-    def interpret_file(self, path, savedir="audio_cache"):
+    def interpret_file(self, path, savedir=None):
         """Classifies the given audiofile into the given set of labels.
         It also provides the interpretation in the audio domain.
 
@@ -157,7 +157,7 @@ class PIQAudioInterpreter(Pretrained):
             fl,
             source=source,
             savedir=savedir,
-            local_strategy=LocalStrategy.NO_LINK,
+            local_strategy=LocalStrategy.SYMLINK,
         )
 
         batch, fs_file = torchaudio.load(path)

--- a/speechbrain/inference/separation.py
+++ b/speechbrain/inference/separation.py
@@ -81,7 +81,7 @@ class SepformerSeparation(Pretrained):
             est_source = est_source[:, :T_origin, :]
         return est_source
 
-    def separate_file(self, path, savedir="audio_cache"):
+    def separate_file(self, path, savedir=None):
         """Separate sources from file.
 
         Arguments
@@ -101,7 +101,7 @@ class SepformerSeparation(Pretrained):
             fl,
             source=source,
             savedir=savedir,
-            local_strategy=LocalStrategy.NO_LINK,
+            local_strategy=LocalStrategy.SYMLINK,
         )
 
         batch, fs_file = torchaudio.load(path)

--- a/speechbrain/inference/text.py
+++ b/speechbrain/inference/text.py
@@ -234,7 +234,6 @@ class GPTResponseGenerator(ResponseGenerator):
 
     >>> tmpdir = getfixture("tmpdir")
     >>> res_gen_model = GPTResponseGenerator.from_hparams(source="speechbrain/MultiWOZ-GPT-Response_Generation",
-    ... savedir="tmpdir",
     ... pymodule_file="custom.py")  # doctest: +SKIP
     >>> response = res_gen_model.generate_response("I want to book a table for dinner")  # doctest: +SKIP
     """
@@ -350,7 +349,6 @@ class Llama2ResponseGenerator(ResponseGenerator):
 
     >>> tmpdir = getfixture("tmpdir")
     >>> res_gen_model = Llama2ResponseGenerator.from_hparams(source="speechbrain/MultiWOZ-Llama2-Response_Generation",
-    ... savedir="tmpdir",
     ... pymodule_file="custom.py")  # doctest: +SKIP
     >>> response = res_gen_model.generate_response("I want to book a table for dinner")  # doctest: +SKIP
     """

--- a/speechbrain/utils/parameter_transfer.py
+++ b/speechbrain/utils/parameter_transfer.py
@@ -344,7 +344,7 @@ class Pretrainer:
                 paramfiles[name] = self.collect_in / filename
             else:
                 raise ValueError(
-                    f'Pretrainer could not locate file `{name}` for loading! (hint: `Pretrainer.collect_in` no longer defaults to "model_checkpoints", is your code expecting that file to be there?)'
+                    f'Pretrainer has never collected `{name}`, did you forget a call to `collect_files`? Could not fall back to `collect_in`, as it was not specified (default is no longer "model_checkpoints").'
                 )
         self._call_load_hooks(paramfiles)
 

--- a/speechbrain/utils/parameter_transfer.py
+++ b/speechbrain/utils/parameter_transfer.py
@@ -10,6 +10,8 @@ Authors
 """
 
 import pathlib
+import platform
+import warnings
 
 from speechbrain.utils.checkpoints import (
     DEFAULT_LOAD_HOOKS,
@@ -27,13 +29,20 @@ logger = get_logger(__name__)
 class Pretrainer:
     """Orchestrates pretraining
 
-    First collects parameter file symlinks into the given directory. Then
-    calls load hooks for each of those parameter files.
+    First optionally collects files from some source (local directory,
+    HuggingFace repository, base URL), into the `collect_in` directory, if
+    specified.
+
+    Then, calls load hooks for each of those files.
 
     Arguments
     ---------
-    collect_in : str or Path
-        Path to directory where the parameter file symlinks are collected.
+    collect_in : str or Path, optional
+        Path to directory where the files are to be collected.
+        If `None`, then files will be referred to from cache or directly, if
+        possible (URLs will fail). There will not be a centralized target
+        directory with all the files.
+
     loadables : mapping
         Mapping from loadable key to object. This connects the keys to
         the actual object instances.
@@ -56,14 +65,16 @@ class Pretrainer:
 
     def __init__(
         self,
-        collect_in="./model_checkpoints",
+        collect_in=None,
         loadables=None,
         paths=None,
         custom_hooks=None,
         conditions=None,
     ):
         self.loadables = {}
-        self.collect_in = pathlib.Path(collect_in)
+
+        self.set_collect_in(collect_in)
+
         if loadables is not None:
             self.add_loadables(loadables)
         self.paths = {}
@@ -79,7 +90,7 @@ class Pretrainer:
 
     def set_collect_in(self, path):
         """Change the collecting path"""
-        self.collect_in = pathlib.Path(path)
+        self.collect_in = pathlib.Path(path) if path is not None else None
 
     def add_loadables(self, loadables):
         """Update the loadables dict from the given mapping.
@@ -174,7 +185,7 @@ class Pretrainer:
         self,
         default_source=None,
         use_auth_token=False,
-        local_strategy: LocalStrategy = LocalStrategy.NO_LINK,
+        local_strategy: LocalStrategy = LocalStrategy.SYMLINK,
     ):
         """Fetches parameters from known paths with fallback default_source
 
@@ -190,14 +201,16 @@ class Pretrainer:
         ---------
         default_source : str or Path or FetchSource
             This is used for each loadable which doesn't have a path already
-            specified. If the loadable has key "asr", then the file to look for is
-            default_source/asr.ckpt
+            specified.
+            e.g. if the loadable has key `"asr"`, then the file to look for is
+            `<default_source>/asr.ckpt`
         use_auth_token : bool (default: False)
             If true Huggingface's auth_token will be used to load private models from the HuggingFace Hub,
             default is False because the majority of models are public.
         local_strategy : speechbrain.utils.fetching.LocalStrategy
             The fetching strategy to use, which controls the behavior of remote file
             fetching with regards to symlinking and copying.
+            Ignored if a `collect_in` directory was not specified.
             See :func:`speechbrain.utils.fetching.fetch` for further details.
 
         Returns
@@ -207,10 +220,25 @@ class Pretrainer:
             parameters can be loaded. This is not used in this class, but
             can possibly be helpful.
         """
-        logger.debug(
-            f"Collecting files (or symlinks) for pretraining in {self.collect_in}."
-        )
-        self.collect_in.mkdir(exist_ok=True)
+
+        if self.collect_in is not None:
+            logger.debug(
+                f"Collecting files (or symlinks) for pretraining in {self.collect_in}."
+            )
+            self.collect_in.mkdir(exist_ok=True)
+
+            if (
+                platform.system() == "Windows"
+                and local_strategy == LocalStrategy.SYMLINK
+            ):
+                warnings.warn(
+                    "Requested Pretrainer collection using symlinks on Windows. This might not work; see `LocalStrategy` documentation. Consider unsetting `collect_in` in Pretrainer to avoid symlinking altogether."
+                )
+        else:
+            logger.debug(
+                "Fetching files for pretraining (no collection directory set)"
+            )
+
         loadable_paths = {}
         for name in self.loadables:
             if not self.is_loadable(name):
@@ -238,11 +266,32 @@ class Pretrainer:
                 "local_strategy": local_strategy,
             }
 
-            # path needs to be available only if it is a local source w/o symlink
-            run_on_main(fetch, kwargs=fetch_kwargs)
+            path = None
 
-            # we need the path; regardless of rank
-            path = fetch(**fetch_kwargs)
+            def run_fetch(**kwargs):
+                """Very basic local wrapper to fetch to store the path in a
+                local of collect_files
+
+                Arguments
+                ---------
+                **kwargs : dict
+                    Arguments to forward to fetch"""
+                nonlocal path
+                path = fetch(**kwargs)
+
+            # run fetch() on the main process, potentially performing downloading
+            # which we do NOT want to happen concurrently.
+            #
+            # then, if there are any non-main processes, run fetch() on them to
+            # resolve the path.
+            #
+            # path needs to be available only if it is a local source w/o symlink
+            run_on_main(
+                run_fetch,
+                kwargs=fetch_kwargs,
+                post_func=run_fetch,
+                post_kwargs=fetch_kwargs,
+            )
 
             loadable_paths[name] = path
             if isinstance(source, FetchSource):
@@ -285,13 +334,18 @@ class Pretrainer:
             if not self.is_loadable(name):
                 continue
             filename = name + PARAMFILE_EXT
-            paramfiles[name] = self.collect_in / filename
 
             if name in self.is_local:
                 logger.debug(
-                    f"Redirecting (loading from local path): {paramfiles[name]} -> {self.paths[name]}"
+                    f"Redirecting (loading from local path): {name} -> {self.paths[name]}"
                 )
                 paramfiles[name] = self.paths[name]
+            elif self.collect_in is not None:
+                paramfiles[name] = self.collect_in / filename
+            else:
+                raise ValueError(
+                    f'Pretrainer could not locate file `{name}` for loading! (hint: `Pretrainer.collect_in` no longer defaults to "model_checkpoints", is your code expecting that file to be there?)'
+                )
         self._call_load_hooks(paramfiles)
 
     def _call_load_hooks(self, paramfiles):


### PR DESCRIPTION
## What does this PR do?

Fixes #2723

- `collect_in`, the collection directory for `Pretrainer`, is now optional.
    - i.e. when `None`, collected files will just be referred to locally/from cache if possible.
- **Breaking change:** `collect_in` now defaults to `None` instead of the `"model_checkpoints"` directory.
    - If `collect_files` fails to locate a specific file and `collect_in` is `None`, it will fail and hint at this breaking change to help the user (in case their code was implicitly relying on `"model_checkpoints"` being used).
- When `collect_in` *is* specified under Windows and the chosen strategy is `SYMLINK`, a warning will be emitted and suggest removing `collect_in` to avoid errors.
- `fetch` in `Pretrainer` now only runs once (not twice) on the main DDP process.

This means that for inference interfaces, not setting a `savedir` does not require the creation of a directory. But when specifying one, it will use symlinks by default.

**Changes to other things:**

- More `savedir` usages now default to `None`.
- For these cases, the `local_fetch` strategy is defaulted to `SYMLINK` again. This is because that strategy is disabled whenever the `savedir` is unspecified.

Example with inference interfaces, specifying a savedir:

```
In [1]: import torchaudio
   ...: from speechbrain.inference.speaker import EncoderClassifier
   ...: classifier = EncoderClassifier.from_hparams(source="speechbrain/spkrec-ecapa-voxceleb", savedir="test2")
   ...: signal, fs =torchaudio.load('/home/sdelang/projects/src/python/speechbrain/tests/samples/ASR/spk1_snt1.wav')
   ...: embeddings = classifier.encode_batch(signal)
INFO:speechbrain.utils.fetching:Fetch hyperparams.yaml: Fetching from HuggingFace Hub 'speechbrain/spkrec-ecapa-voxceleb' if not cached
INFO:speechbrain.utils.fetching:Fetch custom.py: Fetching from HuggingFace Hub 'speechbrain/spkrec-ecapa-voxceleb' if not cached
INFO:speechbrain.utils.fetching:Fetch embedding_model.ckpt: Fetching from HuggingFace Hub 'speechbrain/spkrec-ecapa-voxceleb' if not cached
INFO:speechbrain.utils.fetching:Fetch mean_var_norm_emb.ckpt: Fetching from HuggingFace Hub 'speechbrain/spkrec-ecapa-voxceleb' if not cached
INFO:speechbrain.utils.fetching:Fetch classifier.ckpt: Fetching from HuggingFace Hub 'speechbrain/spkrec-ecapa-voxceleb' if not cached
INFO:speechbrain.utils.fetching:Fetch label_encoder.txt: Fetching from HuggingFace Hub 'speechbrain/spkrec-ecapa-voxceleb' if not cached
INFO:speechbrain.utils.parameter_transfer:Loading pretrained files for: embedding_model, mean_var_norm_emb, classifier, label_encoder

In [2]: %ls -lah test2
total 76K
drwxr-xr-x 2 sdelang sdelang   7 23 oct.  10:32 ./
drwxr-xr-x 9 sdelang sdelang  10 23 oct.  10:32 ../
lrwxrwxrwx 1 sdelang sdelang 146 23 oct.  10:32 classifier.ckpt -> /home/sdelang/.cache/huggingface/hub/models--speechbrain--spkrec-ecapa-voxceleb/snapshots/eac27266f68caa806381260bd44ace38b136c76a/classifier.ckpt
lrwxrwxrwx 1 sdelang sdelang 151 23 oct.  10:32 embedding_model.ckpt -> /home/sdelang/.cache/huggingface/hub/models--speechbrain--spkrec-ecapa-voxceleb/snapshots/eac27266f68caa806381260bd44ace38b136c76a/embedding_model.ckpt
lrwxrwxrwx 1 sdelang sdelang 147 23 oct.  10:32 hyperparams.yaml -> /home/sdelang/.cache/huggingface/hub/models--speechbrain--spkrec-ecapa-voxceleb/snapshots/eac27266f68caa806381260bd44ace38b136c76a/hyperparams.yaml
lrwxrwxrwx 1 sdelang sdelang 148 23 oct.  10:32 label_encoder.ckpt -> /home/sdelang/.cache/huggingface/hub/models--speechbrain--spkrec-ecapa-voxceleb/snapshots/eac27266f68caa806381260bd44ace38b136c76a/label_encoder.txt
lrwxrwxrwx 1 sdelang sdelang 153 23 oct.  10:32 mean_var_norm_emb.ckpt -> /home/sdelang/.cache/huggingface/hub/models--speechbrain--spkrec-ecapa-voxceleb/snapshots/eac27266f68caa806381260bd44ace38b136c76a/mean_var_norm_emb.ckpt
```

Example not specifying a savedir (with debug logging):

```
In [1]: import torchaudio
   ...: import logging; logging.basicConfig(level=logging.DEBUG)
   ...: from speechbrain.inference.speaker import EncoderClassifier
   ...: classifier = EncoderClassifier.from_hparams(source="speechbrain/spkrec-ecapa-voxceleb")
   ...: signal, fs =torchaudio.load('/home/sdelang/projects/src/python/speechbrain/tests/samples/ASR/spk1_snt1.wav')
   ...: embeddings = classifier.encode_batch(signal)
DEBUG:speechbrain.utils.checkpoints:Registered checkpoint save hook for _speechbrain_save
DEBUG:speechbrain.utils.checkpoints:Registered checkpoint load hook for _speechbrain_load
DEBUG:speechbrain.utils.checkpoints:Registered checkpoint save hook for save
DEBUG:speechbrain.utils.checkpoints:Registered checkpoint load hook for load
DEBUG:speechbrain.utils.checkpoints:Registered checkpoint save hook for _save
DEBUG:speechbrain.utils.checkpoints:Registered checkpoint load hook for _recover
INFO:speechbrain.utils.fetching:Fetch hyperparams.yaml: Fetching from HuggingFace Hub 'speechbrain/spkrec-ecapa-voxceleb' if not cached
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): huggingface.co:443
DEBUG:urllib3.connectionpool:https://huggingface.co:443 "HEAD /speechbrain/spkrec-ecapa-voxceleb/resolve/main/hyperparams.yaml HTTP/1.1" 200 0
INFO:speechbrain.utils.fetching:Fetch custom.py: Fetching from HuggingFace Hub 'speechbrain/spkrec-ecapa-voxceleb' if not cached
DEBUG:urllib3.connectionpool:https://huggingface.co:443 "HEAD /speechbrain/spkrec-ecapa-voxceleb/resolve/main/custom.py HTTP/1.1" 404 0
DEBUG:speechbrain.utils.checkpoints:Registered checkpoint save hook for _save
DEBUG:speechbrain.utils.checkpoints:Registered checkpoint load hook for _load
DEBUG:speechbrain.utils.checkpoints:Registered parameter transfer hook for _load
DEBUG:speechbrain.utils.checkpoints:Registered checkpoint save hook for save
DEBUG:speechbrain.utils.checkpoints:Registered checkpoint load hook for load_if_possible
DEBUG:speechbrain.utils.parameter_transfer:Fetching files for pretraining (no collection directory set)
INFO:speechbrain.utils.fetching:Fetch embedding_model.ckpt: Fetching from HuggingFace Hub 'speechbrain/spkrec-ecapa-voxceleb' if not cached
DEBUG:urllib3.connectionpool:https://huggingface.co:443 "HEAD /speechbrain/spkrec-ecapa-voxceleb/resolve/main/embedding_model.ckpt HTTP/1.1" 302 0
DEBUG:speechbrain.utils.parameter_transfer:Set local path in self.paths["embedding_model"] = /home/sdelang/.cache/huggingface/hub/models--speechbrain--spkrec-ecapa-voxceleb/snapshots/eac27266f68caa806381260bd44ace38b136c76a/embedding_model.ckpt
INFO:speechbrain.utils.fetching:Fetch mean_var_norm_emb.ckpt: Fetching from HuggingFace Hub 'speechbrain/spkrec-ecapa-voxceleb' if not cached
DEBUG:urllib3.connectionpool:https://huggingface.co:443 "HEAD /speechbrain/spkrec-ecapa-voxceleb/resolve/main/mean_var_norm_emb.ckpt HTTP/1.1" 200 0
DEBUG:speechbrain.utils.parameter_transfer:Set local path in self.paths["mean_var_norm_emb"] = /home/sdelang/.cache/huggingface/hub/models--speechbrain--spkrec-ecapa-voxceleb/snapshots/eac27266f68caa806381260bd44ace38b136c76a/mean_var_norm_emb.ckpt
INFO:speechbrain.utils.fetching:Fetch classifier.ckpt: Fetching from HuggingFace Hub 'speechbrain/spkrec-ecapa-voxceleb' if not cached
DEBUG:urllib3.connectionpool:https://huggingface.co:443 "HEAD /speechbrain/spkrec-ecapa-voxceleb/resolve/main/classifier.ckpt HTTP/1.1" 302 0
DEBUG:speechbrain.utils.parameter_transfer:Set local path in self.paths["classifier"] = /home/sdelang/.cache/huggingface/hub/models--speechbrain--spkrec-ecapa-voxceleb/snapshots/eac27266f68caa806381260bd44ace38b136c76a/classifier.ckpt
INFO:speechbrain.utils.fetching:Fetch label_encoder.txt: Fetching from HuggingFace Hub 'speechbrain/spkrec-ecapa-voxceleb' if not cached
DEBUG:urllib3.connectionpool:https://huggingface.co:443 "HEAD /speechbrain/spkrec-ecapa-voxceleb/resolve/main/label_encoder.txt HTTP/1.1" 200 0
DEBUG:speechbrain.utils.parameter_transfer:Set local path in self.paths["label_encoder"] = /home/sdelang/.cache/huggingface/hub/models--speechbrain--spkrec-ecapa-voxceleb/snapshots/eac27266f68caa806381260bd44ace38b136c76a/label_encoder.txt
INFO:speechbrain.utils.parameter_transfer:Loading pretrained files for: embedding_model, mean_var_norm_emb, classifier, label_encoder
DEBUG:speechbrain.utils.parameter_transfer:Redirecting (loading from local path): embedding_model -> /home/sdelang/.cache/huggingface/hub/models--speechbrain--spkrec-ecapa-voxceleb/snapshots/eac27266f68caa806381260bd44ace38b136c76a/embedding_model.ckpt
DEBUG:speechbrain.utils.parameter_transfer:Redirecting (loading from local path): mean_var_norm_emb -> /home/sdelang/.cache/huggingface/hub/models--speechbrain--spkrec-ecapa-voxceleb/snapshots/eac27266f68caa806381260bd44ace38b136c76a/mean_var_norm_emb.ckpt
DEBUG:speechbrain.utils.parameter_transfer:Redirecting (loading from local path): classifier -> /home/sdelang/.cache/huggingface/hub/models--speechbrain--spkrec-ecapa-voxceleb/snapshots/eac27266f68caa806381260bd44ace38b136c76a/classifier.ckpt
DEBUG:speechbrain.utils.parameter_transfer:Redirecting (loading from local path): label_encoder -> /home/sdelang/.cache/huggingface/hub/models--speechbrain--spkrec-ecapa-voxceleb/snapshots/eac27266f68caa806381260bd44ace38b136c76a/label_encoder.txt
DEBUG:speechbrain.dataio.encoder:Loaded categorical encoding from /home/sdelang/.cache/huggingface/hub/models--speechbrain--spkrec-ecapa-voxceleb/snapshots/eac27266f68caa806381260bd44ace38b136c76a/label_encoder.txt
```

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
