### PR TITLE
Make calls to "open" deterministic (code from Samsung AI Center Cambridge)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,10 @@ repos:
     hooks:
       - id: flake8
         types: [python]
-        additional_dependencies: ['pydoclint==0.4.1', 'pycodestyle==2.11.0']
+        additional_dependencies:
+          - pydoclint==0.4.1
+          - pycodestyle==2.11.0
+          - flake8-encodings==0.5.1
 
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.35.1

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,6 +1,7 @@
 black==24.3.0
 click==8.1.7
 flake8==7.0.0
+flake8-encodings==0.5.1
 isort==5.13.2
 pycodestyle==2.11.0
 pydoclint==0.4.1

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,7 +1,6 @@
 black==24.3.0
 click==8.1.7
 flake8==7.0.0
-flake8-encodings==0.5.1
 isort==5.13.2
 pycodestyle==2.11.0
 pydoclint==0.4.1

--- a/recipes/AISHELL-1/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/AISHELL-1/ASR/CTC/train_with_wav2vec.py
@@ -166,7 +166,7 @@ class ASR(sb.Brain):
                 stats_meta={"Epoch loaded": self.hparams.epoch_counter.current},
                 test_stats=stage_stats,
             )
-            with open(self.hparams.cer_file, "w") as w:
+            with open(self.hparams.cer_file, "w", encoding="utf-8") as w:
                 self.cer_metric.write_stats(w)
 
     def init_optimizers(self):
@@ -318,7 +318,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/AISHELL-1/ASR/seq2seq/train.py
+++ b/recipes/AISHELL-1/ASR/seq2seq/train.py
@@ -141,7 +141,7 @@ class ASR(sb.Brain):
                 stats_meta={"Epoch loaded": self.hparams.epoch_counter.current},
                 test_stats=stage_stats,
             )
-            with open(self.hparams.cer_file, "w") as w:
+            with open(self.hparams.cer_file, "w", encoding="utf-8") as w:
                 self.cer_metric.write_stats(w)
 
 
@@ -260,7 +260,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/AISHELL-1/ASR/transformer/train.py
+++ b/recipes/AISHELL-1/ASR/transformer/train.py
@@ -204,7 +204,7 @@ class ASR(sb.core.Brain):
                 stats_meta={"Epoch loaded": self.hparams.epoch_counter.current},
                 test_stats=stage_stats,
             )
-            with open(self.hparams.cer_file, "w") as w:
+            with open(self.hparams.cer_file, "w", encoding="utf-8") as w:
                 self.cer_metric.write_stats(w)
 
             # save the averaged checkpoint at the end of the evaluation stage
@@ -382,7 +382,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/AISHELL-1/ASR/transformer/train_with_wav2vect.py
+++ b/recipes/AISHELL-1/ASR/transformer/train_with_wav2vect.py
@@ -187,7 +187,7 @@ class ASR(sb.core.Brain):
                 stats_meta={"Epoch loaded": self.hparams.epoch_counter.current},
                 test_stats=stage_stats,
             )
-            with open(self.hparams.cer_file, "w") as w:
+            with open(self.hparams.cer_file, "w", encoding="utf-8") as w:
                 self.cer_metric.write_stats(w)
 
             # save the averaged checkpoint at the end of the evaluation stage
@@ -384,7 +384,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/AISHELL-1/Tokenizer/train.py
+++ b/recipes/AISHELL-1/Tokenizer/train.py
@@ -23,7 +23,7 @@ from speechbrain.utils.distributed import run_on_main
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/AISHELL-1/aishell_prepare.py
+++ b/recipes/AISHELL-1/aishell_prepare.py
@@ -150,7 +150,7 @@ def prepare_aishell(
         data_folder, "transcript/aishell_transcript_v0.8.txt"
     )
 
-    with open(path_to_transcript, "r") as f:
+    with open(path_to_transcript, "r", encoding="utf-8") as f:
         lines = f.readlines()
         for line in lines:
             key = line.split()[0]
@@ -180,7 +180,7 @@ def prepare_aishell(
         total_line = 0
         total_duration = 0
         id = 0
-        with open(tmp_csv, mode="w", encoding="utf-8") as csv_f:
+        with open(tmp_csv, mode="w", newline="", encoding="utf-8") as csv_f:
             csv_writer = csv.writer(
                 csv_f, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL
             )

--- a/recipes/AMI/Diarization/experiment.py
+++ b/recipes/AMI/Diarization/experiment.py
@@ -154,7 +154,7 @@ def prepare_subset_json(full_meta_data, rec_id, out_meta_file):
         if k.startswith(rec_id):
             subset[key] = full_meta_data[key]
 
-    with open(out_meta_file, mode="w") as json_f:
+    with open(out_meta_file, mode="w", encoding="utf-8") as json_f:
         json.dump(subset, json_f, indent=2)
 
 
@@ -302,11 +302,11 @@ def diarize_dataset(full_meta, split_type, n_lambdas, pval, n_neighbors=10):
     # This is not needed but just staying with the standards.
     concate_rttm_file = out_rttm_dir + "/sys_output.rttm"
     logger.debug("Concatenating individual RTTM files...")
-    with open(concate_rttm_file, "w") as cat_file:
+    with open(concate_rttm_file, "w", encoding="utf-8") as cat_file:
         for f in glob.glob(out_rttm_dir + "/*.rttm"):
             if f == concate_rttm_file:
                 continue
-            with open(f, "r") as indi_rttm_file:
+            with open(f, "r", encoding="utf-8") as indi_rttm_file:
                 shutil.copyfileobj(indi_rttm_file, cat_file)
 
     msg = "The system generated RTTM file for %s set : %s" % (
@@ -507,7 +507,7 @@ if __name__ == "__main__":  # noqa: C901
     # Load hyperparameters file with command-line overrides.
     params_file, run_opts, overrides = sb.core.parse_arguments(sys.argv[1:])
 
-    with open(params_file) as fin:
+    with open(params_file, encoding="utf-8") as fin:
         params = load_hyperpyyaml(fin, overrides)
 
     # Dataset prep (preparing metadata files)
@@ -558,7 +558,7 @@ if __name__ == "__main__":  # noqa: C901
     # AMI Dev Set: Tune hyperparams on dev set.
     # Read the meta-data file for dev set generated during data_prep
     dev_meta_file = params["dev_meta_file"]
-    with open(dev_meta_file, "r") as f:
+    with open(dev_meta_file, "r", encoding="utf-8") as f:
         meta_dev = json.load(f)
 
     full_meta = meta_dev
@@ -600,7 +600,7 @@ if __name__ == "__main__":  # noqa: C901
     # Load 'dev' and 'eval' metadata files.
     full_meta_dev = full_meta  # current full_meta is for 'dev'
     eval_meta_file = params["eval_meta_file"]
-    with open(eval_meta_file, "r") as f:
+    with open(eval_meta_file, "r", encoding="utf-8") as f:
         full_meta_eval = json.load(f)
 
     # Tag to be appended to final output DER files. Writing DER for individual files.

--- a/recipes/AMI/ami_prepare.py
+++ b/recipes/AMI/ami_prepare.py
@@ -294,7 +294,7 @@ def prepare_segs_for_RTTM(
             RTTM = RTTM + rttm_per_rec
 
     # Write one RTTM as groundtruth. For example, "fullref_eval.rttm"
-    with open(out_rttm_file, "w") as f:
+    with open(out_rttm_file, "w", encoding="utf-8") as f:
         for item in RTTM:
             f.write("%s\n" % item)
 
@@ -406,7 +406,7 @@ def prepare_metadata(
 
     # Read RTTM
     RTTM = []
-    with open(rttm_file, "r") as f:
+    with open(rttm_file, "r", encoding="utf-8") as f:
         for line in f:
             entry = line[:-1]
             RTTM.append(entry)
@@ -438,12 +438,12 @@ def prepare_metadata(
     segs_file = save_dir + "/" + filename + ".segments.rttm"
     subsegment_file = save_dir + "/" + filename + ".subsegments.rttm"
 
-    with open(segs_file, "w") as f:
+    with open(segs_file, "w", encoding="utf-8") as f:
         for row in MERGED_SEGMENTS:
             line_str = " ".join(row)
             f.write("%s\n" % line_str)
 
-    with open(subsegment_file, "w") as f:
+    with open(subsegment_file, "w", encoding="utf-8") as f:
         for row in SUBSEGMENTS:
             line_str = " ".join(row)
             f.write("%s\n" % line_str)
@@ -510,7 +510,7 @@ def prepare_metadata(
             }
 
     out_json_file = save_dir + "/" + filename + "." + mic_type + ".subsegs.json"
-    with open(out_json_file, mode="w") as json_f:
+    with open(out_json_file, mode="w", encoding="utf-8") as json_f:
         json.dump(json_dict, json_f, indent=2)
 
     msg = "%s JSON prepared" % (out_json_file)

--- a/recipes/Aishell1Mix/prepare_data.py
+++ b/recipes/Aishell1Mix/prepare_data.py
@@ -227,7 +227,10 @@ def create_aishell1mix2_csv(
         ]
 
         with open(
-            savepath + "/aishell1mix2_" + set_type + ".csv", "w"
+            savepath + "/aishell1mix2_" + set_type + ".csv",
+            "w",
+            newline="",
+            encoding="utf-8",
         ) as csvfile:
             writer = csv.DictWriter(csvfile, fieldnames=csv_columns)
             writer.writeheader()
@@ -304,7 +307,10 @@ def create_aishell1mix3_csv(
         ]
 
         with open(
-            savepath + "/aishell1mix3_" + set_type + ".csv", "w"
+            savepath + "/aishell1mix3_" + set_type + ".csv",
+            "w",
+            newline="",
+            encoding="utf-8",
         ) as csvfile:
             writer = csv.DictWriter(csvfile, fieldnames=csv_columns)
             writer.writeheader()

--- a/recipes/Aishell1Mix/separation/scripts/create_aishell1_metadata.py
+++ b/recipes/Aishell1Mix/separation/scripts/create_aishell1_metadata.py
@@ -38,6 +38,7 @@ def create_aishell1_metadata(aishell1_dir, md_dir):
     with open(
         os.path.join(aishell1_dir, "transcript/aishell_transcript_v0.8.txt"),
         "r",
+        encoding="utf-8",
     ) as f:
         lines = f.readlines()
         for line in lines:

--- a/recipes/Aishell1Mix/separation/train.py
+++ b/recipes/Aishell1Mix/separation/train.py
@@ -356,7 +356,7 @@ class Separation(sb.Brain):
             test_data, **self.hparams.dataloader_opts
         )
 
-        with open(save_file, "w") as results_csv:
+        with open(save_file, "w", newline="", encoding="utf-8") as results_csv:
             writer = csv.DictWriter(results_csv, fieldnames=csv_columns)
             writer.writeheader()
 
@@ -561,7 +561,7 @@ def dataio_prep(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Initialize ddp (useful only for multi-GPU DDP training)

--- a/recipes/AudioMNIST/audiomnist_prepare.py
+++ b/recipes/AudioMNIST/audiomnist_prepare.py
@@ -278,7 +278,7 @@ def read_file_list(file_name):
     result: lists
         the file list
     """
-    with open(file_name) as list_file:
+    with open(file_name, encoding="utf-8") as list_file:
         return [line.strip() for line in list_file]
 
 
@@ -381,7 +381,7 @@ def read_meta(file_name):
     result: dict
         raw metadata
     """
-    with open(file_name) as meta_file:
+    with open(file_name, encoding="utf-8") as meta_file:
         return json.load(meta_file)
 
 
@@ -652,7 +652,7 @@ def convert_split(
         metadata[item_id].update(process_meta)
 
     logger.info(f"Saving metadata to {metadata_file_path}")
-    with open(metadata_file_path, "w") as metadata_file:
+    with open(metadata_file_path, "w", encoding="utf-8") as metadata_file:
         json.dump(metadata, metadata_file, indent=2)
 
 
@@ -805,7 +805,7 @@ def read_digit_lookup(file_name):
         }
 
     """
-    with open(file_name) as lookup_file:
+    with open(file_name, encoding="utf-8") as lookup_file:
         reader = csv.DictReader(lookup_file)
         lookup = {row["digit"]: row for row in reader}
         for value in lookup.values():

--- a/recipes/AudioMNIST/diffusion/train.py
+++ b/recipes/AudioMNIST/diffusion/train.py
@@ -1598,7 +1598,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides.
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Check whether Tensorboard is available and enabled

--- a/recipes/BinauralWSJ0Mix/prepare_data.py
+++ b/recipes/BinauralWSJ0Mix/prepare_data.py
@@ -100,7 +100,10 @@ def create_binaural_wsj0mix2_csv(
         ]
 
         with open(
-            os.path.join(savepath, savename + set_type + ".csv"), "w"
+            os.path.join(savepath, savename + set_type + ".csv"),
+            "w",
+            newline="",
+            encoding="utf-8",
         ) as csvfile:
             writer = csv.DictWriter(csvfile, fieldnames=csv_columns)
             writer.writeheader()
@@ -184,7 +187,10 @@ def create_binaural_wsj0mix3_csv(
         ]
 
         with open(
-            os.path.join(savepath, savename + set_type + ".csv"), "w"
+            os.path.join(savepath, savename + set_type + ".csv"),
+            "w",
+            newline="",
+            encoding="utf-8",
         ) as csvfile:
             writer = csv.DictWriter(csvfile, fieldnames=csv_columns)
             writer.writeheader()
@@ -279,7 +285,10 @@ def create_binaural_wsj0mix2_noise_csv(
         ]
 
         with open(
-            os.path.join(savepath, savename + set_type + ".csv"), "w"
+            os.path.join(savepath, savename + set_type + ".csv"),
+            "w",
+            newline="",
+            encoding="utf-8",
         ) as csvfile:
             writer = csv.DictWriter(csvfile, fieldnames=csv_columns)
             writer.writeheader()
@@ -359,7 +368,10 @@ def create_binaural_wsj0mix2_reverb_csv(
         ]
 
         with open(
-            os.path.join(savepath, savename + set_type + ".csv"), "w"
+            os.path.join(savepath, savename + set_type + ".csv"),
+            "w",
+            newline="",
+            encoding="utf-8",
         ) as csvfile:
             writer = csv.DictWriter(csvfile, fieldnames=csv_columns)
             writer.writeheader()

--- a/recipes/BinauralWSJ0Mix/separation/train.py
+++ b/recipes/BinauralWSJ0Mix/separation/train.py
@@ -490,7 +490,7 @@ class Separation(sb.Brain):
             test_data, **self.hparams.dataloader_opts
         )
 
-        with open(save_file, "w") as results_csv:
+        with open(save_file, "w", newline="", encoding="utf-8") as results_csv:
             writer = csv.DictWriter(results_csv, fieldnames=csv_columns)
             writer.writeheader()
 
@@ -680,7 +680,7 @@ def dataio_prep(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Initialize ddp (useful only for multi-GPU DDP training)

--- a/recipes/CVSS/S2ST/extract_code.py
+++ b/recipes/CVSS/S2ST/extract_code.py
@@ -214,7 +214,7 @@ def extract_cvss(
     for split in splits:
         dataset_path = data_folder / f"{split}.json"
         logger.info(f"Reading dataset from {dataset_path} ...")
-        meta_json = json.load(open(dataset_path))
+        meta_json = json.load(open(dataset_path, encoding="utf-8"))
         for key in tqdm(meta_json.keys()):
             item = meta_json[key]
             wav = item["tgt_audio"]

--- a/recipes/CVSS/S2ST/train.py
+++ b/recipes/CVSS/S2ST/train.py
@@ -410,7 +410,7 @@ class S2UT(sb.core.Brain):
             )
 
             sample_path = save_folder / f"{utt_id}.txt"
-            with open(sample_path, "w") as file:
+            with open(sample_path, "w", encoding="utf-8") as file:
                 file.write(f"pred: {transcript}\n")
                 file.write(f"ref: {tgt_transcript}\n")
 
@@ -421,7 +421,7 @@ class S2UT(sb.core.Brain):
         )
 
         bleu_path = save_folder / "bleu.txt"
-        with open(bleu_path, "w") as file:
+        with open(bleu_path, "w", encoding="utf-8") as file:
             file.write(
                 f"BLEU score: {round(self.bleu_metric.summarize('BLEU'), 2)}\n"
             )
@@ -553,7 +553,7 @@ if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # If distributed_launch=True then

--- a/recipes/CVSS/cvss_prepare.py
+++ b/recipes/CVSS/cvss_prepare.py
@@ -216,7 +216,11 @@ def prepare_json(
 
     json_dict = {}
     tgt_meta = list(
-        csv.reader(open(tgt_split), delimiter="\t", quoting=csv.QUOTE_NONE)
+        csv.reader(
+            open(tgt_split, newline="", encoding="utf-8"),
+            delimiter="\t",
+            quoting=csv.QUOTE_NONE,
+        )
     )
 
     limit_to_n_sample = (
@@ -247,7 +251,7 @@ def prepare_json(
         }
 
     # Writing the dictionary to the json file
-    with open(json_file, mode="w") as json_f:
+    with open(json_file, mode="w", encoding="utf-8") as json_f:
         json.dump(json_dict, json_f, indent=2)
 
     logger.info(f"{json_file} successfully created!")

--- a/recipes/CommonLanguage/lang_id/train.py
+++ b/recipes/CommonLanguage/lang_id/train.py
@@ -259,7 +259,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides.
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/CommonVoice/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/CommonVoice/ASR/CTC/train_with_wav2vec.py
@@ -150,7 +150,9 @@ class ASR(sb.core.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
     def init_optimizers(self):
@@ -319,7 +321,7 @@ def dataio_prepare(hparams, tokenizer):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/CommonVoice/ASR/seq2seq/train.py
+++ b/recipes/CommonVoice/ASR/seq2seq/train.py
@@ -177,7 +177,9 @@ class ASR(sb.core.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
 
@@ -282,7 +284,7 @@ def dataio_prepare(hparams, tokenizer):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/CommonVoice/ASR/seq2seq/train_with_wav2vec.py
+++ b/recipes/CommonVoice/ASR/seq2seq/train_with_wav2vec.py
@@ -179,7 +179,9 @@ class ASR(sb.core.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
     def init_optimizers(self):
@@ -317,7 +319,7 @@ def dataio_prepare(hparams, tokenizer):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/CommonVoice/ASR/transducer/train.py
+++ b/recipes/CommonVoice/ASR/transducer/train.py
@@ -250,7 +250,9 @@ class ASR(sb.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
             # save the averaged checkpoint at the end of the evaluation stage
@@ -392,7 +394,7 @@ def dataio_prepare(hparams, tokenizer):
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/CommonVoice/ASR/transformer/train.py
+++ b/recipes/CommonVoice/ASR/transformer/train.py
@@ -220,7 +220,9 @@ class ASR(sb.core.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
 
@@ -357,7 +359,7 @@ def dataio_prepare(hparams, tokenizer):
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/CommonVoice/ASR/transformer/train_with_whisper.py
+++ b/recipes/CommonVoice/ASR/transformer/train_with_whisper.py
@@ -151,7 +151,9 @@ class ASR(sb.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
 
@@ -257,7 +259,7 @@ if __name__ == "__main__":
     # create ddp_group with the right communication protocol
     sb.utils.distributed.ddp_init_group(run_opts)
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/CommonVoice/LM/train.py
+++ b/recipes/CommonVoice/LM/train.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
     cmd = f'lmplz -o {hparams["ngram"]} <"{hparams["text_file"]}" > "{tmp_ngram_file}"'
     os.system(cmd)
     with open(tmp_ngram_file, "r", encoding="utf-8") as read_file, open(
-        hparams["ngram_file"], "w"
+        hparams["ngram_file"], "w", encoding="utf-8"
     ) as write_file:
         has_added_eos = False
         for line in read_file:

--- a/recipes/CommonVoice/LM/train.py
+++ b/recipes/CommonVoice/LM/train.py
@@ -23,10 +23,12 @@ logger = get_logger(__name__)
 
 def csv2text():
     """Read CSV file and convert specific data entries into text file."""
-    annotation_file = open(hparams["train_csv"], "r")
+    annotation_file = open(
+        hparams["train_csv"], "r", newline="", encoding="utf-8"
+    )
     reader = csv.reader(annotation_file)
     headers = next(reader, None)
-    text_file = open(hparams["text_file"], "w+")
+    text_file = open(hparams["text_file"], "w+", encoding="utf-8")
     index_label = headers.index("wrd")
     row_idx = 0
     for row in reader:
@@ -42,7 +44,7 @@ if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory
@@ -74,7 +76,7 @@ if __name__ == "__main__":
     tmp_ngram_file = "ngram.arpa"
     cmd = f'lmplz -o {hparams["ngram"]} <"{hparams["text_file"]}" > "{tmp_ngram_file}"'
     os.system(cmd)
-    with open(tmp_ngram_file, "r") as read_file, open(
+    with open(tmp_ngram_file, "r", encoding="utf-8") as read_file, open(
         hparams["ngram_file"], "w"
     ) as write_file:
         has_added_eos = False

--- a/recipes/CommonVoice/common_voice_prepare.py
+++ b/recipes/CommonVoice/common_voice_prepare.py
@@ -326,7 +326,7 @@ def create_csv(
         raise FileNotFoundError(msg)
 
     # We load and skip the header
-    csv_lines = open(orig_tsv_file, "r").readlines()
+    csv_lines = open(orig_tsv_file, "r", encoding="utf-8").readlines()
     header_line = csv_lines[0]
     csv_data_lines = csv_lines[1:]
     nb_samples = len(csv_data_lines)
@@ -358,7 +358,7 @@ def create_csv(
     # Stream into a .tmp file, and rename it to the real path at the end.
     csv_file_tmp = csv_file + ".tmp"
 
-    with open(csv_file_tmp, mode="w", encoding="utf-8") as csv_f:
+    with open(csv_file_tmp, mode="w", newline="", encoding="utf-8") as csv_f:
         csv_writer = csv.writer(
             csv_f, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL
         )

--- a/recipes/CommonVoice/self-supervised-learning/wav2vec2/train_hf_wav2vec2.py
+++ b/recipes/CommonVoice/self-supervised-learning/wav2vec2/train_hf_wav2vec2.py
@@ -241,7 +241,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/DNS/create_wds_shards.py
+++ b/recipes/DNS/create_wds_shards.py
@@ -109,7 +109,7 @@ def write_shards(
         "num_data_samples": len(data_tuples),
     }
 
-    with (shards_path / "meta.json").open("w") as f:
+    with (shards_path / "meta.json").open("w", encoding="utf-8") as f:
         json.dump(meta_dict, f, indent=4)
 
     # shuffle the tuples so that each shard has a large variety in languages

--- a/recipes/DNS/dns_download.py
+++ b/recipes/DNS/dns_download.py
@@ -328,7 +328,7 @@ def download_file(
     mode = "ab" if resume_byte_pos else "wb"
     initial_pos = resume_byte_pos if resume_byte_pos else 0
 
-    with open(download_path, mode) as f:
+    with open(download_path, mode, encoding="utf-8") as f:
         with tqdm(
             total=file_size,
             unit="B",

--- a/recipes/DNS/enhancement/train.py
+++ b/recipes/DNS/enhancement/train.py
@@ -440,7 +440,7 @@ class Enhancement(sb.Brain):
             valid_data, **self.hparams.dataloader_opts_test
         )
 
-        with open(save_file, "w") as results_csv:
+        with open(save_file, "w", newline="", encoding="utf-8") as results_csv:
             writer = csv.DictWriter(results_csv, fieldnames=csv_columns)
             writer.writeheader()
 
@@ -741,7 +741,7 @@ def dataio_prep(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Initialize ddp (useful only for multi-GPU DDP training)

--- a/recipes/DNS/noisyspeech_synthesizer/noisyspeech_synthesizer_singleprocess.py
+++ b/recipes/DNS/noisyspeech_synthesizer/noisyspeech_synthesizer_singleprocess.py
@@ -383,10 +383,10 @@ def main_gen(params):
         "num_data_samples": len(valid_data_tuples),
     }
 
-    with (train_shards_path / "meta.json").open("w") as f:
+    with (train_shards_path / "meta.json").open("w", encoding="utf-8") as f:
         json.dump(train_meta_dict, f, indent=4)
 
-    with (valid_shards_path / "meta.json").open("w") as f:
+    with (valid_shards_path / "meta.json").open("w", encoding="utf-8") as f:
         json.dump(valid_meta_dict, f, indent=4)
 
     return (
@@ -406,7 +406,7 @@ def main_body():  # noqa
 
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Data Directories and Settings

--- a/recipes/DNS/noisyspeech_synthesizer/utils.py
+++ b/recipes/DNS/noisyspeech_synthesizer/utils.py
@@ -29,7 +29,10 @@ def write_log_file(log_dir, log_filename, data):
     """Helper function to write log file"""
     # data = zip(*data)
     with open(
-        os.path.join(log_dir, log_filename), mode="w", newline=""
+        os.path.join(log_dir, log_filename),
+        mode="w",
+        newline="",
+        encoding="utf-8",
     ) as csvfile:
         csvwriter = csv.writer(
             csvfile, delimiter=" ", quotechar="|", quoting=csv.QUOTE_MINIMAL

--- a/recipes/DVoice/ASR/CTC/train_with_wav2vec2.py
+++ b/recipes/DVoice/ASR/CTC/train_with_wav2vec2.py
@@ -141,7 +141,9 @@ class ASR(sb.core.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
     def init_optimizers(self):
@@ -280,7 +282,7 @@ def dataio_prepare(hparams, tokenizer):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/DVoice/dvoice_prepare.py
+++ b/recipes/DVoice/dvoice_prepare.py
@@ -163,15 +163,15 @@ def prepare_dvoice(
 def alffa_public_prepare(language, data_folder):
     if language == "amharic":
         wavs = glob.glob(f"{data_folder}/*/*/*.wav")
-        f_train = open(f"{data_folder}/train/text", "r")
-        f_test = open(f"{data_folder}/test/text", "r")
+        f_train = open(f"{data_folder}/train/text", "r", encoding="utf-8")
+        f_test = open(f"{data_folder}/test/text", "r", encoding="utf-8")
         text = f_train.readlines() + f_test.readlines()
         random.shuffle(text)
 
     if language == "fongbe":
         wavs = glob.glob(f"{data_folder}/*/wav/*/*.wav")
-        f_train = open(f"{data_folder}/train/text", "r")
-        f_test = open(f"{data_folder}/test/text", "r")
+        f_train = open(f"{data_folder}/train/text", "r", encoding="utf-8")
+        f_test = open(f"{data_folder}/test/text", "r", encoding="utf-8")
         text = f_train.readlines() + f_test.readlines()
         random.shuffle(text)
 
@@ -180,9 +180,9 @@ def alffa_public_prepare(language, data_folder):
         wavs_dev = glob.glob(f"{data_folder}/dev/wav/*/*.wav")
         wavs_test = glob.glob(f"{data_folder}/test/wav/*/*.wav")
         wavs = wavs_train + wavs_dev + wavs_test
-        f_train = open(f"{data_folder}/train/text", "r")
-        f_test = open(f"{data_folder}/test/text", "r")
-        f_dev = open(f"{data_folder}/dev/text", "r")
+        f_train = open(f"{data_folder}/train/text", "r", encoding="utf-8")
+        f_test = open(f"{data_folder}/test/text", "r", encoding="utf-8")
+        f_dev = open(f"{data_folder}/dev/text", "r", encoding="utf-8")
         text = f_train.readlines() + f_dev.readlines() + f_test.readlines()
         random.shuffle(text)
 
@@ -351,7 +351,7 @@ def create_csv(
         raise FileNotFoundError(msg)
 
     # We load and skip the header
-    loaded_csv = open(orig_csv_file, "r").readlines()[1:]
+    loaded_csv = open(orig_csv_file, "r", encoding="utf-8").readlines()[1:]
     nb_samples = str(len(loaded_csv))
     msg = "Preparing CSV files for %s samples ..." % (str(nb_samples))
     logger.info(msg)

--- a/recipes/DVoice/dvoice_prepare.py
+++ b/recipes/DVoice/dvoice_prepare.py
@@ -232,10 +232,14 @@ def swahili_prepare(data_folder):
     )
 
     f_train_alffa = open(
-        f"{data_folder}/ALFFA_PUBLIC/ASR/SWAHILI/data/train/text", "r"
+        f"{data_folder}/ALFFA_PUBLIC/ASR/SWAHILI/data/train/text",
+        "r",
+        encoding="utf-8",
     )
     f_test_alffa = open(
-        f"{data_folder}/ALFFA_PUBLIC/ASR/SWAHILI/data/test/text", "r"
+        f"{data_folder}/ALFFA_PUBLIC/ASR/SWAHILI/data/test/text",
+        "r",
+        encoding="utf-8",
     )
     train_alffa = f_train_alffa.readlines()
     test_alffa = f_test_alffa.readlines()

--- a/recipes/ESC50/classification/train.py
+++ b/recipes/ESC50/classification/train.py
@@ -385,7 +385,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/ESC50/esc50_prepare.py
+++ b/recipes/ESC50/esc50_prepare.py
@@ -266,7 +266,7 @@ def create_json(metadata, audio_data_folder, folds_list, json_file):
     if not os.path.exists(parent_dir):
         os.mkdir(parent_dir)
 
-    with open(json_file, mode="w") as json_f:
+    with open(json_file, mode="w", encoding="utf-8") as json_f:
         json.dump(json_dict, json_f, indent=2)
 
     logger.info(f"{json_file} successfully created!")

--- a/recipes/ESC50/interpret/eval.py
+++ b/recipes/ESC50/interpret/eval.py
@@ -143,7 +143,7 @@ class ESCContaminated(torch.utils.data.Dataset):
 if __name__ == "__main__":
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     if hparams["add_wham_noise"]:

--- a/recipes/ESC50/interpret/interpret_amt.py
+++ b/recipes/ESC50/interpret/interpret_amt.py
@@ -660,7 +660,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # classifier is fixed here

--- a/recipes/ESC50/interpret/train_l2i.py
+++ b/recipes/ESC50/interpret/train_l2i.py
@@ -345,7 +345,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     print("Eval only hparams:")

--- a/recipes/ESC50/interpret/train_lmac.py
+++ b/recipes/ESC50/interpret/train_lmac.py
@@ -307,7 +307,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     print("Eval only hparams:")

--- a/recipes/ESC50/interpret/train_nmf.py
+++ b/recipes/ESC50/interpret/train_nmf.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     assert hparams["signal_length_s"] == 5, "Fix wham sig length!"

--- a/recipes/ESC50/interpret/train_piq.py
+++ b/recipes/ESC50/interpret/train_piq.py
@@ -201,7 +201,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     print("Inherited hparams:")

--- a/recipes/Fisher-Callhome-Spanish/ST/transformer/train.py
+++ b/recipes/Fisher-Callhome-Spanish/ST/transformer/train.py
@@ -580,7 +580,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/Fisher-Callhome-Spanish/Tokenizer/train.py
+++ b/recipes/Fisher-Callhome-Spanish/Tokenizer/train.py
@@ -23,7 +23,7 @@ import speechbrain as sb
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/Fisher-Callhome-Spanish/fisher_callhome_prepare.py
+++ b/recipes/Fisher-Callhome-Spanish/fisher_callhome_prepare.py
@@ -278,7 +278,7 @@ def extract_transcription(transcription_path: str) -> List[TDF]:
     """Extract transcriptions from given file"""
     extracted_transcriptions = []
 
-    with open(transcription_path) as transcription_file:
+    with open(transcription_path, encoding="utf-8") as transcription_file:
         # get rid of the first three useless headers
         transcriptions = transcription_file.readlines()[3:]
 

--- a/recipes/GigaSpeech/ASR/CTC/train_with_wavlm.py
+++ b/recipes/GigaSpeech/ASR/CTC/train_with_wavlm.py
@@ -155,7 +155,9 @@ class ASR(sb.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
     def on_fit_batch_end(self, batch, outputs, loss, should_step):
@@ -329,7 +331,7 @@ if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/GigaSpeech/ASR/transducer/train.py
+++ b/recipes/GigaSpeech/ASR/transducer/train.py
@@ -260,7 +260,9 @@ class ASR(sb.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
             # save the averaged checkpoint at the end of the evaluation stage
@@ -419,7 +421,7 @@ if __name__ == "__main__":
     # create ddp_group with the right communication protocol
     sb.utils.distributed.ddp_init_group(run_opts)
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/GigaSpeech/dataset.py
+++ b/recipes/GigaSpeech/dataset.py
@@ -400,7 +400,7 @@ class Gigaspeech(datasets.GeneratorBasedBuilder):
             zip(meta_paths, audio_archives_iterators)
         ):
             meta_dict = dict()
-            with open(meta_path) as csvfile:
+            with open(meta_path, encoding="utf-8") as csvfile:
                 meta_csv = csv.DictReader(csvfile)
                 for line in meta_csv:
                     meta_dict[line["sid"]] = line

--- a/recipes/GigaSpeech/gigaspeech_prepare.py
+++ b/recipes/GigaSpeech/gigaspeech_prepare.py
@@ -243,7 +243,7 @@ def prepare_gigaspeech(
         check_gigaspeech_folders(data_folder, json_file)
 
         logger.info(f"Starting reading {json_file}.")
-        with open(json_file, "r") as f:
+        with open(json_file, "r", encoding="utf-8") as f:
             info = json.load(f)
         logger.info(f"Reading {json_file} done.")
 

--- a/recipes/Google-speech-commands/train.py
+++ b/recipes/Google-speech-commands/train.py
@@ -200,7 +200,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/IEMOCAP/emotion_recognition/iemocap_prepare.py
+++ b/recipes/IEMOCAP/emotion_recognition/iemocap_prepare.py
@@ -133,7 +133,7 @@ def create_json(wav_list, json_file):
         }
 
     # Writing the dictionary to the json file
-    with open(json_file, mode="w") as json_f:
+    with open(json_file, mode="w", encoding="utf-8") as json_f:
         json.dump(json_dict, json_f, indent=2)
 
     logger.info(f"{json_file} successfully created!")
@@ -292,7 +292,7 @@ def load_utterInfo(inputFile):
         r"[\[]*[0-9]*[.][0-9]*[ -]*[0-9]*[.][0-9]*[\]][\t][a-z0-9_]*[\t][a-z]{3}[\t][\[][0-9]*[.][0-9]*[, ]+[0-9]*[.][0-9]*[, ]+[0-9]*[.][0-9]*[\]]",
         re.IGNORECASE,
     )  # noqa
-    with open(inputFile, "r") as myfile:
+    with open(inputFile, "r", encoding="utf-8") as myfile:
         data = myfile.read().replace("\n", " ")
     result = pattern.findall(data)
     out = []

--- a/recipes/IEMOCAP/emotion_recognition/train.py
+++ b/recipes/IEMOCAP/emotion_recognition/train.py
@@ -166,7 +166,7 @@ class EmoIdBrain(sb.Brain):
             save_file = os.path.join(
                 self.hparams.output_folder, "predictions.csv"
             )
-            with open(save_file, "w", newline="") as csvfile:
+            with open(save_file, "w", newline="", encoding="utf-8") as csvfile:
                 outwriter = csv.writer(csvfile, delimiter=",")
                 outwriter.writerow(["id", "prediction", "true_value"])
 
@@ -185,7 +185,9 @@ class EmoIdBrain(sb.Brain):
                     torch.argmax(output, dim=-1).squeeze(dim=1).tolist()
                 )
 
-                with open(save_file, "a", newline="") as csvfile:
+                with open(
+                    save_file, "a", newline="", encoding="utf-8"
+                ) as csvfile:
                     outwriter = csv.writer(csvfile, delimiter=",")
                     for emo_id, prediction, true_val in zip(
                         emo_ids, predictions, true_vals
@@ -285,7 +287,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides.
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/IEMOCAP/emotion_recognition/train_with_wav2vec2.py
+++ b/recipes/IEMOCAP/emotion_recognition/train_with_wav2vec2.py
@@ -219,7 +219,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides.
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/IEMOCAP/iemocap_prepare.py
+++ b/recipes/IEMOCAP/iemocap_prepare.py
@@ -133,7 +133,7 @@ def create_json(wav_list, json_file):
         }
 
     # Writing the dictionary to the json file
-    with open(json_file, mode="w") as json_f:
+    with open(json_file, mode="w", encoding="utf-8") as json_f:
         json.dump(json_dict, json_f, indent=2)
 
     logger.info(f"{json_file} successfully created!")
@@ -292,7 +292,7 @@ def load_utterInfo(inputFile):
         r"[\[]*[0-9]*[.][0-9]*[ -]*[0-9]*[.][0-9]*[\]][\t][a-z0-9_]*[\t][a-z]{3}[\t][\[][0-9]*[.][0-9]*[, ]+[0-9]*[.][0-9]*[, ]+[0-9]*[.][0-9]*[\]]",
         re.IGNORECASE,
     )  # noqa
-    with open(inputFile, "r") as myfile:
+    with open(inputFile, "r", encoding="utf-8") as myfile:
         data = myfile.read().replace("\n", " ")
     result = pattern.findall(data)
     out = []

--- a/recipes/IWSLT22_lowresource/AST/transformer/train.py
+++ b/recipes/IWSLT22_lowresource/AST/transformer/train.py
@@ -358,7 +358,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # creates a logger

--- a/recipes/IWSLT22_lowresource/AST/transformer/train_samu.py
+++ b/recipes/IWSLT22_lowresource/AST/transformer/train_samu.py
@@ -289,7 +289,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/IWSLT22_lowresource/AST/transformer/train_with_samu_mbart.py
+++ b/recipes/IWSLT22_lowresource/AST/transformer/train_with_samu_mbart.py
@@ -222,7 +222,7 @@ class ST(sb.core.Brain):
                 test_stats=stage_stats,
             )
 
-            with open(self.hparams.bleu_file, "w") as w:
+            with open(self.hparams.bleu_file, "w", encoding="utf-8") as w:
                 self.bleu_metric.write_stats(w)
 
 
@@ -389,7 +389,7 @@ def dataio_prepare(hparams, tokenizer):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/IWSLT22_lowresource/AST/transformer/train_with_w2v_mbart.py
+++ b/recipes/IWSLT22_lowresource/AST/transformer/train_with_w2v_mbart.py
@@ -222,7 +222,7 @@ class ST(sb.core.Brain):
                 test_stats=stage_stats,
             )
 
-            with open(self.hparams.bleu_file, "w") as w:
+            with open(self.hparams.bleu_file, "w", encoding="utf-8") as w:
                 self.bleu_metric.write_stats(w)
 
 
@@ -389,7 +389,7 @@ def dataio_prepare(hparams, tokenizer):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/IWSLT22_lowresource/prepare_iwslt22.py
+++ b/recipes/IWSLT22_lowresource/prepare_iwslt22.py
@@ -45,7 +45,7 @@ def generate_json(folder_path, split):
 
 
 def read_file(f_path):
-    return [line for line in open(f_path)]
+    return [line for line in open(f_path, encoding="utf-8")]
 
 
 def data_proc(dataset_folder, output_folder):

--- a/recipes/KsponSpeech/ASR/transformer/train.py
+++ b/recipes/KsponSpeech/ASR/transformer/train.py
@@ -209,7 +209,9 @@ class ASR(sb.core.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
                     self.cer_metric.write_stats(w)
 
@@ -377,7 +379,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/KsponSpeech/LM/train.py
+++ b/recipes/KsponSpeech/LM/train.py
@@ -157,7 +157,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/KsponSpeech/Tokenizer/train.py
+++ b/recipes/KsponSpeech/Tokenizer/train.py
@@ -26,7 +26,7 @@ from speechbrain.utils.distributed import run_on_main
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/KsponSpeech/ksponspeech_prepare.py
+++ b/recipes/KsponSpeech/ksponspeech_prepare.py
@@ -185,7 +185,7 @@ def create_csv(save_folder, wav_lst, text_dict, split, select_n_sentences):
             break
 
     # Writing the csv_lines
-    with open(csv_file, mode="w") as csv_f:
+    with open(csv_file, mode="w", newline="", encoding="utf-8") as csv_f:
         csv_writer = csv.writer(
             csv_f, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL
         )
@@ -258,7 +258,7 @@ def text_to_dict(trnpath):
     # Initialization of the text dictionary
     text_dict = {}
     # Reading all the transcription files is text_lst
-    with open(trnpath, "r") as f:
+    with open(trnpath, "r", encoding="utf-8") as f:
         # Reading all line of the transcription file
         for line in f:
             filename, raw_script = line.split(" :: ")

--- a/recipes/LJSpeech/TTS/fastspeech2/train.py
+++ b/recipes/LJSpeech/TTS/fastspeech2/train.py
@@ -570,7 +570,7 @@ def dataio_prepare(hparams):
 
 def main():
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
     sb.utils.distributed.ddp_init_group(run_opts)
 

--- a/recipes/LJSpeech/TTS/fastspeech2/train_internal_alignment.py
+++ b/recipes/LJSpeech/TTS/fastspeech2/train_internal_alignment.py
@@ -362,7 +362,7 @@ def dataio_prepare(hparams):
 
 def main():
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
     sb.utils.distributed.ddp_init_group(run_opts)
 

--- a/recipes/LJSpeech/TTS/tacotron2/train.py
+++ b/recipes/LJSpeech/TTS/tacotron2/train.py
@@ -337,7 +337,7 @@ if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/LJSpeech/TTS/vocoder/diffwave/train.py
+++ b/recipes/LJSpeech/TTS/vocoder/diffwave/train.py
@@ -300,7 +300,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides.
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Check whether Tensorboard is available and enabled

--- a/recipes/LJSpeech/TTS/vocoder/hifigan/train.py
+++ b/recipes/LJSpeech/TTS/vocoder/hifigan/train.py
@@ -344,7 +344,7 @@ if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/LJSpeech/TTS/vocoder/hifigan_discrete/extract_code.py
+++ b/recipes/LJSpeech/TTS/vocoder/hifigan_discrete/extract_code.py
@@ -227,7 +227,7 @@ def extract_ljspeech(
     for split in splits:
         dataset_path = data_folder / f"{split}.json"
         logger.info(f"Reading dataset from {dataset_path} ...")
-        meta_json = json.load(open(dataset_path))
+        meta_json = json.load(open(dataset_path, encoding="utf-8"))
         for key in tqdm(meta_json.keys()):
             item = meta_json[key]
             wav = item["wav"]

--- a/recipes/LJSpeech/TTS/vocoder/hifigan_discrete/train.py
+++ b/recipes/LJSpeech/TTS/vocoder/hifigan_discrete/train.py
@@ -476,7 +476,7 @@ if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # If --distributed_launch then

--- a/recipes/LJSpeech/ljspeech_prepare.py
+++ b/recipes/LJSpeech/ljspeech_prepare.py
@@ -292,7 +292,9 @@ def split_sets(data_folder, splits, split_ratio):
     """
     meta_csv = os.path.join(data_folder, METADATA_CSV)
     csv_reader = csv.reader(
-        open(meta_csv), delimiter="|", quoting=csv.QUOTE_NONE
+        open(meta_csv, newline="", encoding="utf-8"),
+        delimiter="|",
+        quoting=csv.QUOTE_NONE,
     )
 
     meta_csv = list(csv_reader)
@@ -543,7 +545,7 @@ def prepare_json(
             json_dict[id].update({"pitch": pitch_file})
 
     # Writing the dictionary to the json file
-    with open(json_file, mode="w") as json_f:
+    with open(json_file, mode="w", encoding="utf-8") as json_f:
         json.dump(json_dict, json_f, indent=2)
 
     logger.info(f"{json_file} successfully created!")

--- a/recipes/LJSpeech/quantization/train.py
+++ b/recipes/LJSpeech/quantization/train.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/LibriMix/prepare_data.py
+++ b/recipes/LibriMix/prepare_data.py
@@ -96,7 +96,12 @@ def create_libri2mix_csv(
             "noise_wav_opts",
         ]
 
-        with open(savepath + "/libri2mix_" + set_type + ".csv", "w") as csvfile:
+        with open(
+            savepath + "/libri2mix_" + set_type + ".csv",
+            "w",
+            newline="",
+            encoding="utf-8",
+        ) as csvfile:
             writer = csv.DictWriter(csvfile, fieldnames=csv_columns)
             writer.writeheader()
             for i, (mix_path, s1_path, s2_path, noise_path) in enumerate(
@@ -171,7 +176,12 @@ def create_libri3mix_csv(
             "noise_wav_opts",
         ]
 
-        with open(savepath + "/libri3mix_" + set_type + ".csv", "w") as csvfile:
+        with open(
+            savepath + "/libri3mix_" + set_type + ".csv",
+            "w",
+            newline="",
+            encoding="utf-8",
+        ) as csvfile:
             writer = csv.DictWriter(csvfile, fieldnames=csv_columns)
             writer.writeheader()
             for (

--- a/recipes/LibriMix/separation/train.py
+++ b/recipes/LibriMix/separation/train.py
@@ -356,7 +356,7 @@ class Separation(sb.Brain):
             test_data, **self.hparams.dataloader_opts
         )
 
-        with open(save_file, "w") as results_csv:
+        with open(save_file, "w", newline="", encoding="utf-8") as results_csv:
             writer = csv.DictWriter(results_csv, fieldnames=csv_columns)
             writer.writeheader()
 
@@ -560,7 +560,7 @@ def dataio_prep(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Initialize ddp (useful only for multi-GPU DDP training)

--- a/recipes/LibriParty/VAD/commonlanguage_prepare.py
+++ b/recipes/LibriParty/VAD/commonlanguage_prepare.py
@@ -50,7 +50,7 @@ def _prepare_csv(folder, filelist, csv_file, max_length=None):
     """
     try:
         if sb.utils.distributed.if_main_process():
-            with open(csv_file, "w") as w:
+            with open(csv_file, "w", encoding="utf-8") as w:
                 w.write("ID,duration,wav,wav_format,wav_opts\n\n")
                 for line in filelist:
                     # Read file for duration/channel info

--- a/recipes/LibriParty/VAD/libriparty_prepare.py
+++ b/recipes/LibriParty/VAD/libriparty_prepare.py
@@ -27,7 +27,7 @@ valid_json_dataset = {}
 
 
 def load_data_json(path):
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         json_file = json.load(f)
     return json_file
 
@@ -220,7 +220,7 @@ def create_json_dataset(dic, sample_rate, window_size):
 
 def save_dataset(json_save_path, json_dataset):
     """Saves a JSON file."""
-    with open(json_save_path, "w+") as fp:
+    with open(json_save_path, "w+", encoding="utf-8") as fp:
         json.dump(json_dataset, fp, indent=4)
 
 

--- a/recipes/LibriParty/VAD/musan_prepare.py
+++ b/recipes/LibriParty/VAD/musan_prepare.py
@@ -56,7 +56,7 @@ def _prepare_csv(folder, filelist, csv_file, max_length=None):
     """
     try:
         if sb.utils.distributed.if_main_process():
-            with open(csv_file, "w") as w:
+            with open(csv_file, "w", encoding="utf-8") as w:
                 w.write("ID,duration,wav,wav_format,wav_opts\n\n")
                 for line in filelist:
                     # Read file for duration/channel info

--- a/recipes/LibriParty/VAD/train.py
+++ b/recipes/LibriParty/VAD/train.py
@@ -207,7 +207,7 @@ if __name__ == "__main__":
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Initialize ddp (useful only for multi-GPU DDP training)

--- a/recipes/LibriParty/generate_dataset/create_custom_dataset.py
+++ b/recipes/LibriParty/generate_dataset/create_custom_dataset.py
@@ -118,7 +118,8 @@ for index, split in enumerate(["train", "dev", "eval"]):
 for index, split in enumerate(["train", "dev", "eval"]):
     # load metadata
     with open(
-        os.path.join(params["out_folder"], "metadata", split + ".json")
+        os.path.join(params["out_folder"], "metadata", split + ".json"),
+        encoding="utf-8",
     ) as f:
         c_meta = json.load(f)
     print("Creating {} set".format(split))

--- a/recipes/LibriParty/generate_dataset/create_custom_dataset.py
+++ b/recipes/LibriParty/generate_dataset/create_custom_dataset.py
@@ -23,7 +23,7 @@ from speechbrain.utils.data_utils import get_all_files
 
 # Load hyperparameters file with command-line overrides
 params_file, run_opts, overrides = sb.core.parse_arguments(sys.argv[1:])
-with open(params_file) as fin:
+with open(params_file, encoding="utf-8") as fin:
     params = load_hyperpyyaml(fin, overrides)
 
 # setting seeds for reproducible code.
@@ -55,7 +55,7 @@ def parse_libri_folder(libri_folders):
     # step 2: we then build an hashtable for words for each utterance
     words_dict = {}
     for trans in txt_files:
-        with open(trans, "r") as f:
+        with open(trans, "r", encoding="utf-8") as f:
             for line in f:
                 splitted = line.split(" ")
                 utt_id = splitted[0]

--- a/recipes/LibriParty/generate_dataset/get_dataset_from_metadata.py
+++ b/recipes/LibriParty/generate_dataset/get_dataset_from_metadata.py
@@ -23,7 +23,7 @@ URL_METADATA = (
 
 # Load hyperparameters file with command-line overrides
 params_file, run_opts, overrides = sb.core.parse_arguments(sys.argv[1:])
-with open(params_file) as fin:
+with open(params_file, encoding="utf-8") as fin:
     params = load_hyperpyyaml(fin, overrides)
 
 metadata_folder = params["metadata_folder"]
@@ -39,7 +39,11 @@ download_file(
 )
 
 for data_split in ["train", "dev", "eval"]:
-    with open(os.path.join(metadata_folder, data_split + ".json"), "r") as f:
+    with open(
+        os.path.join(metadata_folder, data_split + ".json"),
+        "r",
+        encoding="utf-8",
+    ) as f:
         metadata = json.load(f)
     print("Creating data for {} set".format(data_split))
     c_folder = os.path.join(params["out_folder"], data_split)

--- a/recipes/LibriParty/generate_dataset/local/create_mixtures_from_metadata.py
+++ b/recipes/LibriParty/generate_dataset/local/create_mixtures_from_metadata.py
@@ -112,7 +112,9 @@ def create_mixture(session_n, output_dir, params, metadata):
             )
 
     with open(
-        os.path.join(output_dir, session_n, "{}.json".format(session_n)), "w"
+        os.path.join(output_dir, session_n, "{}.json".format(session_n)),
+        "w",
+        encoding="utf-8",
     ) as f:
         json.dump(session_meta, f, indent=4)
 

--- a/recipes/LibriParty/generate_dataset/local/create_mixtures_metadata.py
+++ b/recipes/LibriParty/generate_dataset/local/create_mixtures_metadata.py
@@ -200,5 +200,5 @@ def create_metadata(
 
         dataset_metadata["session_{}".format(n_sess)] = activity
 
-    with open(output_filename + ".json", "w") as f:
+    with open(output_filename + ".json", "w", encoding="utf-8") as f:
         json.dump(dataset_metadata, f, indent=4)

--- a/recipes/LibriSpeech/ASR/CTC/train.py
+++ b/recipes/LibriSpeech/ASR/CTC/train.py
@@ -169,7 +169,7 @@ class ASR(sb.core.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.wer_file, "w") as w:
+                with open(self.hparams.wer_file, "w", encoding="utf-8") as w:
                     self.wer_metric.write_stats(w)
 
     def on_fit_batch_end(self, batch, outputs, loss, should_step):
@@ -307,7 +307,7 @@ def dataio_prepare(hparams, tokenizer):
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # If --distributed_launch then

--- a/recipes/LibriSpeech/ASR/CTC/train_with_bestrq.py
+++ b/recipes/LibriSpeech/ASR/CTC/train_with_bestrq.py
@@ -148,7 +148,9 @@ class ASR(sb.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
     def init_optimizers(self):
@@ -282,7 +284,7 @@ if __name__ == "__main__":
     # create ddp_group with the right communication protocol
     sb.utils.distributed.ddp_init_group(run_opts)
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/LibriSpeech/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/LibriSpeech/ASR/CTC/train_with_wav2vec.py
@@ -192,7 +192,9 @@ class ASR(sb.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
     def init_optimizers(self):
@@ -332,7 +334,7 @@ if __name__ == "__main__":
     # create ddp_group with the right communication protocol
     sb.utils.distributed.ddp_init_group(run_opts)
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/LibriSpeech/ASR/CTC/train_with_wav2vec_k2.py
+++ b/recipes/LibriSpeech/ASR/CTC/train_with_wav2vec_k2.py
@@ -204,7 +204,11 @@ class ASR(sb.Brain):
             )
             if if_main_process():
                 for k, stat in self.wer_metrics.items():
-                    with open(self.hparams.wer_file + f"_{k}.txt", "w") as w:
+                    with open(
+                        self.hparams.wer_file + f"_{k}.txt",
+                        "w",
+                        encoding="utf-8",
+                    ) as w:
                         stat.write_stats(w)
 
     def init_optimizers(self):
@@ -326,7 +330,7 @@ if __name__ == "__main__":
     # create ddp_group with the right communication protocol
     sb.utils.distributed.ddp_init_group(run_opts)
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # env_corrupt is not supported with k2 yet

--- a/recipes/LibriSpeech/ASR/CTC/train_with_whisper.py
+++ b/recipes/LibriSpeech/ASR/CTC/train_with_whisper.py
@@ -157,7 +157,9 @@ class ASR(sb.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
     def init_optimizers(self):
@@ -289,7 +291,7 @@ if __name__ == "__main__":
     # create ddp_group with the right communication protocol
     sb.utils.distributed.ddp_init_group(run_opts)
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/LibriSpeech/ASR/seq2seq/train.py
+++ b/recipes/LibriSpeech/ASR/seq2seq/train.py
@@ -175,7 +175,9 @@ class ASR(sb.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
 
@@ -304,7 +306,7 @@ if __name__ == "__main__":
     # create ddp_group with the right communication protocol
     sb.utils.distributed.ddp_init_group(run_opts)
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/LibriSpeech/ASR/transducer/train.py
+++ b/recipes/LibriSpeech/ASR/transducer/train.py
@@ -260,7 +260,9 @@ class ASR(sb.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
             # save the averaged checkpoint at the end of the evaluation stage
@@ -427,7 +429,7 @@ if __name__ == "__main__":
     # create ddp_group with the right communication protocol
     sb.utils.distributed.ddp_init_group(run_opts)
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/LibriSpeech/ASR/transformer/train.py
+++ b/recipes/LibriSpeech/ASR/transformer/train.py
@@ -224,7 +224,9 @@ class ASR(sb.core.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
             # save the averaged checkpoint at the end of the evaluation stage
@@ -378,7 +380,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/LibriSpeech/ASR/transformer/train_bayesspeech.py
+++ b/recipes/LibriSpeech/ASR/transformer/train_bayesspeech.py
@@ -229,7 +229,9 @@ class ASR(sb.core.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
             # save the averaged checkpoint at the end of the evaluation stage
@@ -383,7 +385,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/LibriSpeech/ASR/transformer/train_with_whisper.py
+++ b/recipes/LibriSpeech/ASR/transformer/train_with_whisper.py
@@ -165,7 +165,9 @@ class ASR(sb.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
 
@@ -266,7 +268,7 @@ if __name__ == "__main__":
     # create ddp_group with the right communication protocol
     sb.utils.distributed.ddp_init_group(run_opts)
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/LibriSpeech/G2P/evaluate.py
+++ b/recipes/LibriSpeech/G2P/evaluate.py
@@ -385,7 +385,7 @@ class G2PEvaluator:
             return self.per_metrics.summarize()
 
     def _output_wer_file(self):
-        with open(self.hparams.eval_wer_file, "w") as w:
+        with open(self.hparams.eval_wer_file, "w", encoding="utf-8") as w:
             w.write("\nPER stats:\n")
             self.per_metrics.write_stats(w)
             print(
@@ -402,7 +402,7 @@ if __name__ == "__main__":
         search_hparam_file = sys.argv[0]
         hparams_file, run_opts, overrides = hp_ctx.parse_arguments(sys.argv[1:])
         device = run_opts.get("device", "cpu")
-        with open(hparams_file) as fin:
+        with open(hparams_file, encoding="utf-8") as fin:
             hparams = load_hyperpyyaml(fin, overrides)
 
         # Load dependencies

--- a/recipes/LibriSpeech/G2P/tokenizer_prepare.py
+++ b/recipes/LibriSpeech/G2P/tokenizer_prepare.py
@@ -53,7 +53,7 @@ def prepare_annotation(src, destination_file_name, phonemes):
         }
         for item in src
     }
-    with open(destination_file_name, "w") as dst_file:
+    with open(destination_file_name, "w", encoding="utf-8") as dst_file:
         json.dump(annotation, dst_file, indent=2)
 
 

--- a/recipes/LibriSpeech/G2P/train.py
+++ b/recipes/LibriSpeech/G2P/train.py
@@ -635,7 +635,7 @@ class G2PBrain(sb.Brain):
         file_name: str
             the report file name
         """
-        with open(file_name, "w") as w:
+        with open(file_name, "w", encoding="utf-8") as w:
             w.write("\nseq2seq loss stats:\n")
             self.seq_metrics.write_stats(w)
             w.write("\nPER stats:\n")
@@ -652,7 +652,7 @@ class G2PBrain(sb.Brain):
         file_name: str
             the report file name
         """
-        with open(file_name, "w") as w:
+        with open(file_name, "w", encoding="utf-8") as w:
             self.classification_metrics_homograph.write_stats(w)
 
     def _add_stats_prefix(self, stats):
@@ -1172,7 +1172,7 @@ if __name__ == "__main__":
         hparams_file, run_opts, overrides = hp_ctx.parse_arguments(sys.argv[1:])
 
         # Load hyperparameters file with command-line overrides
-        with open(hparams_file) as fin:
+        with open(hparams_file, encoding="utf-8") as fin:
             hparams = load_hyperpyyaml(fin, overrides)
 
         # Validate hyperparameters

--- a/recipes/LibriSpeech/G2P/train_lm.py
+++ b/recipes/LibriSpeech/G2P/train_lm.py
@@ -164,7 +164,7 @@ if __name__ == "__main__":
     from tokenizer_prepare import prepare_tokenizer  # noqa
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     if hparams.get("phn_tokenize"):

--- a/recipes/LibriSpeech/LM/train.py
+++ b/recipes/LibriSpeech/LM/train.py
@@ -161,7 +161,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/LibriSpeech/LM/train_ngram.py
+++ b/recipes/LibriSpeech/LM/train_ngram.py
@@ -77,13 +77,13 @@ def dataprep_lm_training(
     column_text_key = "wrd"  # defined in librispeech_prepare.py
     lm_corpus = os.path.join(lm_dir, "libri_lm_corpus.txt")
     line_seen = set()
-    with open(lm_corpus, "w") as corpus:
+    with open(lm_corpus, "w", encoding="utf-8") as corpus:
         for file in csv_files:
             for line in get_list_from_csv(file, column_text_key):
                 corpus.write(line + "\n")
                 line_seen.add(line + "\n")
         for file in external_lm_corpus:
-            with open(file) as f:
+            with open(file, encoding="utf-8") as f:
                 for line in f:
                     if line not in line_seen:
                         corpus.write(line)
@@ -100,7 +100,7 @@ if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/LibriSpeech/Tokenizer/train.py
+++ b/recipes/LibriSpeech/Tokenizer/train.py
@@ -25,7 +25,7 @@ from speechbrain.utils.distributed import run_on_main
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/LibriSpeech/librispeech_prepare.py
+++ b/recipes/LibriSpeech/librispeech_prepare.py
@@ -193,7 +193,7 @@ def create_lexicon_and_oov_csv(all_texts, save_folder):
     # Get list of all words in the lexicon
     lexicon_words = []
     lexicon_pronunciations = []
-    with open(lexicon_path, "r") as f:
+    with open(lexicon_path, "r", encoding="utf-8") as f:
         lines = f.readlines()
         for line in lines:
             word = line.split()[0]
@@ -204,7 +204,7 @@ def create_lexicon_and_oov_csv(all_texts, save_folder):
     # Create lexicon.csv
     header = "ID,duration,char,phn\n"
     lexicon_csv_path = os.path.join(save_folder, "lexicon.csv")
-    with open(lexicon_csv_path, "w") as f:
+    with open(lexicon_csv_path, "w", newline="", encoding="utf-8") as f:
         f.write(header)
         for idx in range(len(lexicon_words)):
             separated_graphemes = [c for c in lexicon_words[idx]]
@@ -239,7 +239,7 @@ def split_lexicon(data_folder, split_ratio):
     """
     # Reading lexicon.csv
     lexicon_csv_path = os.path.join(data_folder, "lexicon.csv")
-    with open(lexicon_csv_path, "r") as f:
+    with open(lexicon_csv_path, "r", newline="", encoding="utf-8") as f:
         lexicon_lines = f.readlines()
     # Remove header
     lexicon_lines = lexicon_lines[1:]
@@ -257,11 +257,26 @@ def split_lexicon(data_folder, split_ratio):
     test_lines = [header] + lexicon_lines[tr_snts + valid_snts :]
 
     # Saving files
-    with open(os.path.join(data_folder, "lexicon_tr.csv"), "w") as f:
+    with open(
+        os.path.join(data_folder, "lexicon_tr.csv"),
+        "w",
+        newline="",
+        encoding="utf-8",
+    ) as f:
         f.writelines(train_lines)
-    with open(os.path.join(data_folder, "lexicon_dev.csv"), "w") as f:
+    with open(
+        os.path.join(data_folder, "lexicon_dev.csv"),
+        "w",
+        newline="",
+        encoding="utf-8",
+    ) as f:
         f.writelines(valid_lines)
-    with open(os.path.join(data_folder, "lexicon_test.csv"), "w") as f:
+    with open(
+        os.path.join(data_folder, "lexicon_test.csv"),
+        "w",
+        newline="",
+        encoding="utf-8",
+    ) as f:
         f.writelines(test_lines)
 
 
@@ -349,7 +364,7 @@ def create_csv(save_folder, wav_lst, text_dict, split, select_n_sentences):
             break
 
     # Writing the csv_lines
-    with open(csv_file, mode="w") as csv_f:
+    with open(csv_file, mode="w", newline="", encoding="utf-8") as csv_f:
         csv_writer = csv.writer(
             csv_f, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL
         )
@@ -423,7 +438,7 @@ def text_to_dict(text_lst):
     text_dict = {}
     # Reading all the transcription files is text_lst
     for file in text_lst:
-        with open(file, "r") as f:
+        with open(file, "r", encoding="utf-8") as f:
             # Reading all line of the transcription file
             for line in f:
                 line_lst = line.strip().split(" ")

--- a/recipes/LibriSpeech/self-supervised-learning/BEST-RQ/train.py
+++ b/recipes/LibriSpeech/self-supervised-learning/BEST-RQ/train.py
@@ -290,7 +290,7 @@ def main():
 
     sb.utils.distributed.ddp_init_group(run_opts)
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
     hparams.update(run_opts)
 

--- a/recipes/LibriSpeech/self-supervised-learning/wav2vec2/train_sb_wav2vec2.py
+++ b/recipes/LibriSpeech/self-supervised-learning/wav2vec2/train_sb_wav2vec2.py
@@ -325,7 +325,7 @@ def main():
 
     sb.utils.distributed.ddp_init_group(run_opts)
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
     hparams.update(run_opts)
 

--- a/recipes/LibriTTS/TTS/mstacotron2/compute_speaker_embeddings.py
+++ b/recipes/LibriTTS/TTS/mstacotron2/compute_speaker_embeddings.py
@@ -69,7 +69,7 @@ def compute_speaker_embeddings(
 
         speaker_embeddings = dict()  # Holds speaker embeddings
 
-        json_file = open(input_filepaths[i])
+        json_file = open(input_filepaths[i], encoding="utf-8")
         json_data = json.load(json_file)
 
         # Processes all utterances in the data manifest file

--- a/recipes/LibriTTS/TTS/mstacotron2/train.py
+++ b/recipes/LibriTTS/TTS/mstacotron2/train.py
@@ -306,7 +306,7 @@ class Tacotron2Brain(sb.Brain):
                 str(self.hparams.epoch_counter.current),
                 "train_input_text.txt",
             )
-            with open(train_sample_text, "w") as f:
+            with open(train_sample_text, "w", encoding="utf-8") as f:
                 f.write(labels[0])
 
             train_input_audio = os.path.join(
@@ -452,7 +452,7 @@ class Tacotron2Brain(sb.Brain):
                 str(self.hparams.epoch_counter.current),
                 "inf_input_text.txt",
             )
-            with open(inf_sample_text, "w") as f:
+            with open(inf_sample_text, "w", encoding="utf-8") as f:
                 f.write(labels[0])
 
             inf_input_audio = os.path.join(
@@ -551,7 +551,7 @@ if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # If --distributed_launch then

--- a/recipes/LibriTTS/libritts_prepare.py
+++ b/recipes/LibriTTS/libritts_prepare.py
@@ -216,7 +216,7 @@ def create_json(wav_list, json_file, sample_rate, model_name=None):
             "/", *path_parts[:-1], uttid + ".normalized.txt"
         )
         try:
-            with open(normalized_text_path) as f:
+            with open(normalized_text_path, encoding="utf-8") as f:
                 normalized_text = f.read()
                 if normalized_text.__contains__("{"):
                     normalized_text = normalized_text.replace("{", "")
@@ -254,7 +254,7 @@ def create_json(wav_list, json_file, sample_rate, model_name=None):
             json_dict[uttid].update({"label_phoneme": phonemes})
 
     # Writes the dictionary to the json file
-    with open(json_file, mode="w") as json_f:
+    with open(json_file, mode="w", encoding="utf-8") as json_f:
         json.dump(json_dict, json_f, indent=2)
 
     logger.info(f"{json_file} successfully created!")

--- a/recipes/LibriTTS/vocoder/hifigan/train.py
+++ b/recipes/LibriTTS/vocoder/hifigan/train.py
@@ -364,7 +364,7 @@ if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/LibriTTS/vocoder/hifigan_discrete/extract_code.py
+++ b/recipes/LibriTTS/vocoder/hifigan_discrete/extract_code.py
@@ -225,7 +225,7 @@ def extract_libritts(
     for split in splits:
         dataset_path = data_folder / f"{split}.json"
         logger.info(f"Reading dataset from {dataset_path} ...")
-        meta_json = json.load(open(dataset_path))
+        meta_json = json.load(open(dataset_path, encoding="utf-8"))
         for key in tqdm(meta_json.keys()):
             item = meta_json[key]
             wav = item["wav"]

--- a/recipes/LibriTTS/vocoder/hifigan_discrete/extract_speaker_embeddings.py
+++ b/recipes/LibriTTS/vocoder/hifigan_discrete/extract_speaker_embeddings.py
@@ -178,7 +178,7 @@ def extract_libritts_embeddings(
     for split in splits:
         dataset_path = save_folder / f"{split}.json"
         logger.info(f"Reading dataset from {dataset_path} ...")
-        meta_json = json.load(open(dataset_path))
+        meta_json = json.load(open(dataset_path, encoding="utf-8"))
         for key in tqdm(meta_json.keys()):
             item = meta_json[key]
             wav = item["wav"]

--- a/recipes/LibriTTS/vocoder/hifigan_discrete/train.py
+++ b/recipes/LibriTTS/vocoder/hifigan_discrete/train.py
@@ -476,7 +476,7 @@ if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # If --distributed_launch then

--- a/recipes/LibriTTS/vocoder/hifigan_discrete/train_spk.py
+++ b/recipes/LibriTTS/vocoder/hifigan_discrete/train_spk.py
@@ -485,7 +485,7 @@ if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # If --distributed_launch then

--- a/recipes/MEDIA/ASR/CTC/train_hf_wav2vec.py
+++ b/recipes/MEDIA/ASR/CTC/train_hf_wav2vec.py
@@ -153,9 +153,9 @@ class ASR(sb.core.Brain):
                 stats_meta={"Epoch loaded": self.hparams.epoch_counter.current},
                 test_stats=stage_stats,
             )
-            with open(hparams["cer_file_test"], "w") as w:
+            with open(hparams["cer_file_test"], "w", encoding="utf-8") as w:
                 self.cer_metric.write_stats(w)
-            with open(hparams["ctc_file_test"], "w") as w:
+            with open(hparams["ctc_file_test"], "w", encoding="utf-8") as w:
                 self.ctc_metric.write_stats(w)
 
 
@@ -284,7 +284,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides.
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol.

--- a/recipes/MEDIA/SLU/CTC/train_hf_wav2vec.py
+++ b/recipes/MEDIA/SLU/CTC/train_hf_wav2vec.py
@@ -171,13 +171,13 @@ class SLU(sb.core.Brain):
                 stats_meta={"Epoch loaded": self.hparams.epoch_counter.current},
                 test_stats=stage_stats,
             )
-            with open(hparams["cer_file_test"], "w") as w:
+            with open(hparams["cer_file_test"], "w", encoding="utf-8") as w:
                 self.cer_metric.write_stats(w)
-            with open(hparams["ctc_file_test"], "w") as w:
+            with open(hparams["ctc_file_test"], "w", encoding="utf-8") as w:
                 self.ctc_metric.write_stats(w)
-            with open(hparams["coer_file_test"], "w") as w:
+            with open(hparams["coer_file_test"], "w", encoding="utf-8") as w:
                 self.coer_metric.write_stats(w)
-            with open(hparams["cver_file_test"], "w") as w:
+            with open(hparams["cver_file_test"], "w", encoding="utf-8") as w:
                 self.cver_metric.write_stats(w)
 
 
@@ -306,7 +306,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides.
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol.

--- a/recipes/MEDIA/media_prepare.py
+++ b/recipes/MEDIA/media_prepare.py
@@ -406,7 +406,7 @@ def append_data(save_folder, data, corpus):
     if to_append is not None:
         write_first_row(save_folder, corpus)
         path = save_folder + "/csv/" + corpus + ".csv"
-        SB_file = open(path, "a")
+        SB_file = open(path, "a", encoding="utf-8")
         writer = csv.writer(SB_file, delimiter=",")
         writer.writerows(to_append)
         SB_file.close()
@@ -900,7 +900,12 @@ def write_first_row(save_folder, corpus):
         Either 'train', 'dev', 'test', or 'test2'.
     """
 
-    SB_file = open(save_folder + "/csv/" + corpus + ".csv", "w")
+    SB_file = open(
+        save_folder + "/csv/" + corpus + ".csv",
+        "w",
+        newline="",
+        encoding="utf-8",
+    )
     writer = csv.writer(SB_file, delimiter=",")
     writer.writerow(
         [
@@ -1090,7 +1095,7 @@ def get_channels(path):
 
     channels = []
     filenames = []
-    with open(path) as file:
+    with open(path, encoding="utf-8") as file:
         reader = csv.reader(file, delimiter=",")
         for row in reader:
             channels.append(row[0])
@@ -1137,7 +1142,7 @@ def get_concepts_full_relax(path):
 
     concepts_full = []
     concepts_relax = []
-    with open(path) as file:
+    with open(path, encoding="utf-8") as file:
         reader = csv.reader(file, delimiter=",")
         for row in reader:
             concepts_full.append(row[0])

--- a/recipes/MultiWOZ/response_generation/gpt/train_with_gpt.py
+++ b/recipes/MultiWOZ/response_generation/gpt/train_with_gpt.py
@@ -155,7 +155,9 @@ class ResGenBrain(sb.Brain):
                 min_keys=["PPL"],
             )
             if epoch == hparams["number_of_epochs"] - 1:
-                with open(self.hparams.bleu_4_valid_file, "w") as w:
+                with open(
+                    self.hparams.bleu_4_valid_file, "w", encoding="utf-8"
+                ) as w:
                     self.bleu_4_metric.write_stats(w)
                     for i in range(len(self.hyps)):
                         w.write("target: " + str(self.references[i]) + "\n")
@@ -170,7 +172,9 @@ class ResGenBrain(sb.Brain):
                 stats_meta={"Epoch loaded": self.hparams.epoch_counter.current},
                 test_stats=stage_stats,
             )
-            with open(self.hparams.bleu_4_test_file, "w") as w:
+            with open(
+                self.hparams.bleu_4_test_file, "w", encoding="utf-8"
+            ) as w:
                 self.bleu_4_metric.write_stats(w)
                 for i in range(len(self.hyps)):
                     w.write("target: " + str(self.references[i]) + "\n")
@@ -392,7 +396,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides.
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/MultiWOZ/response_generation/llama2/train_with_llama2.py
+++ b/recipes/MultiWOZ/response_generation/llama2/train_with_llama2.py
@@ -348,7 +348,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides.
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/MultiWOZ/response_generation/multiwoz_prepare.py
+++ b/recipes/MultiWOZ/response_generation/multiwoz_prepare.py
@@ -198,7 +198,9 @@ def get_splits(dataset_folder) -> Tuple[List[str], List[str], List[str]]:
     tr_split: List[str] = []
     with open(os.path.join(dataset_folder, "valListFile.txt")) as f:
         dev_split: List[str] = [key.strip() for key in f]
-    with open(os.path.join(dataset_folder, "testListFile.txt")) as f:
+    with open(
+        os.path.join(dataset_folder, "testListFile.txt"), encoding="utf-8"
+    ) as f:
         te_split: List[str] = [key.strip() for key in f]
 
     for key in dialogues_keys:
@@ -296,7 +298,7 @@ def get_replacements(
         Pairs of elements used to substitute the first element with the second.
     """
     replacements = []
-    with open(replacements_path, "r") as fin:
+    with open(replacements_path, "r", encoding="utf-8") as fin:
         for line in fin.readlines():
             tok_from, tok_to = line.replace("\n", "").split("\t")
             replacements.append((" " + tok_from + " ", " " + tok_to + " "))
@@ -569,7 +571,7 @@ def get_json_object(data_path: str) -> dict:
     loaded_json: dict
         A loaded json object.
     """
-    with open(data_path, "r") as data_file:
+    with open(data_path, "r", encoding="utf-8") as data_file:
         data = json.load(data_file)
 
     return data
@@ -686,5 +688,5 @@ def save_dialogue_dataset(
     save_file: str
         Path to the folder where the original MultiWOZ dataset is stored.
     """
-    with open(save_file, "w") as f:
+    with open(save_file, "w", encoding="utf-8") as f:
         json.dump(dataset, f, indent=4)

--- a/recipes/MultiWOZ/response_generation/multiwoz_prepare.py
+++ b/recipes/MultiWOZ/response_generation/multiwoz_prepare.py
@@ -196,7 +196,9 @@ def get_splits(dataset_folder) -> Tuple[List[str], List[str], List[str]]:
     )
     dialogues_keys: Set[str] = set(mwoz_21_dialogues.keys())
     tr_split: List[str] = []
-    with open(os.path.join(dataset_folder, "valListFile.txt")) as f:
+    with open(
+        os.path.join(dataset_folder, "valListFile.txt"), encoding="utf-8"
+    ) as f:
         dev_split: List[str] = [key.strip() for key in f]
     with open(
         os.path.join(dataset_folder, "testListFile.txt"), encoding="utf-8"

--- a/recipes/REAL-M/sisnr-estimation/train.py
+++ b/recipes/REAL-M/sisnr-estimation/train.py
@@ -406,7 +406,7 @@ class Separation(sb.Brain):
             test_data, **self.hparams.dataloader_opts
         )
 
-        with open(save_file, "w") as results_csv:
+        with open(save_file, "w", newline="", encoding="utf-8") as results_csv:
             writer = csv.DictWriter(results_csv, fieldnames=csv_columns)
             writer.writeheader()
 
@@ -572,7 +572,7 @@ def dataio_prep(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Initialize ddp (useful only for multi-GPU DDP training)

--- a/recipes/RescueSpeech/ASR/noise-robust/train.py
+++ b/recipes/RescueSpeech/ASR/noise-robust/train.py
@@ -348,7 +348,7 @@ class ASR(sb.core.Brain):
                 stats_meta={"Epoch loaded": self.hparams.epoch_counter.current},
                 test_stats=stage_stats,
             )
-            with open(self.hparams.test_wer_file, "w") as w:
+            with open(self.hparams.test_wer_file, "w", encoding="utf-8") as w:
                 self.wer_metric.write_stats(w)
 
     def add_speed_perturb(self, clean, targ_lens):
@@ -511,7 +511,7 @@ class ASR(sb.core.Brain):
 
         test_loader = sb.dataio.dataloader.make_dataloader(test_data)
 
-        with open(save_file, "w") as results_csv:
+        with open(save_file, "w", newline="", encoding="utf-8") as results_csv:
             writer = csv.DictWriter(results_csv, fieldnames=csv_columns)
             writer.writeheader()
 
@@ -780,7 +780,7 @@ if __name__ == "__main__":
     # create ddp_group with the right communication protocol
     sb.utils.distributed.ddp_init_group(run_opts)
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/RescueSpeech/rescuespeech_prepare.py
+++ b/recipes/RescueSpeech/rescuespeech_prepare.py
@@ -195,7 +195,7 @@ def create_asr_csv(
         raise FileNotFoundError(msg)
 
     # We load and skip the header
-    loaded_csv = open(orig_tsv_file, "r").readlines()[1:]
+    loaded_csv = open(orig_tsv_file, "r", encoding="utf-8").readlines()[1:]
     nb_samples = str(len(loaded_csv))
 
     msg = "Preparing CSV files for %s samples ..." % (str(nb_samples))
@@ -461,7 +461,7 @@ def write2csv(
     # that all files have the same duration in MS-DNS dataset.
 
     total_duration = 0
-    with open(csv_file, "w") as csvfile:
+    with open(csv_file, "w", encoding="utf-8") as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=csv_columns)
         writer.writeheader()
 

--- a/recipes/SLURP/NLU/train.py
+++ b/recipes/SLURP/NLU/train.py
@@ -160,7 +160,9 @@ class SLU(sb.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
 
@@ -270,7 +272,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     show_results_every = 100  # plots results every N iterations

--- a/recipes/SLURP/Tokenizer/train.py
+++ b/recipes/SLURP/Tokenizer/train.py
@@ -23,7 +23,7 @@ from speechbrain.utils.distributed import run_on_main
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/SLURP/direct/train.py
+++ b/recipes/SLURP/direct/train.py
@@ -188,7 +188,9 @@ class SLU(sb.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
 
@@ -279,7 +281,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     show_results_every = 100  # plots results every N iterations

--- a/recipes/SLURP/direct/train_with_wav2vec2.py
+++ b/recipes/SLURP/direct/train_with_wav2vec2.py
@@ -187,7 +187,9 @@ class SLU(sb.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
     def init_optimizers(self):
@@ -296,7 +298,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     show_results_every = 100  # plots results every N iterations

--- a/recipes/Switchboard/ASR/CTC/train_with_wav2vec.py
+++ b/recipes/Switchboard/ASR/CTC/train_with_wav2vec.py
@@ -174,7 +174,9 @@ class ASR(sb.core.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
     def init_optimizers(self):
@@ -340,7 +342,7 @@ def dataio_prepare(hparams, tokenizer):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/Switchboard/ASR/normalize_util.py
+++ b/recipes/Switchboard/ASR/normalize_util.py
@@ -21,7 +21,9 @@ def read_glm_csv(save_folder):
     """Load the ARPA Hub4-E and Hub5-E alternate spellings and contractions map"""
 
     alternatives_dict = defaultdict(list)
-    with open(os.path.join(save_folder, "glm.csv")) as csv_file:
+    with open(
+        os.path.join(save_folder, "glm.csv"), encoding="utf-8"
+    ) as csv_file:
         csv_reader = csv.reader(csv_file, delimiter=",")
         for row in csv_reader:
             alternatives = row[1].split("|")

--- a/recipes/Switchboard/ASR/seq2seq/train.py
+++ b/recipes/Switchboard/ASR/seq2seq/train.py
@@ -206,7 +206,9 @@ class ASR(sb.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
 
@@ -360,7 +362,7 @@ if __name__ == "__main__":
     # create ddp_group with the right communication protocol
     sb.utils.distributed.ddp_init_group(run_opts)
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/Switchboard/ASR/transformer/train.py
+++ b/recipes/Switchboard/ASR/transformer/train.py
@@ -243,7 +243,9 @@ class ASR(sb.core.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
             # save the averaged checkpoint at the end of the evaluation stage
@@ -439,7 +441,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/Switchboard/LM/train.py
+++ b/recipes/Switchboard/LM/train.py
@@ -139,7 +139,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/Switchboard/Tokenizer/train.py
+++ b/recipes/Switchboard/Tokenizer/train.py
@@ -25,7 +25,7 @@ from speechbrain.utils.distributed import run_on_main
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/Switchboard/switchboard_prepare.py
+++ b/recipes/Switchboard/switchboard_prepare.py
@@ -1106,7 +1106,9 @@ def parse_glm_file(glm_dir, save_folder):
         Directory to store the parsed GLM file
     """
     results = defaultdict(list)
-    with open(os.path.join(glm_dir, "en20000405_hub5.glm")) as file:
+    with open(
+        os.path.join(glm_dir, "en20000405_hub5.glm"), encoding="utf-8"
+    ) as file:
         is_contraction = False
         for line in file:
             # Skip comments

--- a/recipes/Switchboard/switchboard_prepare.py
+++ b/recipes/Switchboard/switchboard_prepare.py
@@ -165,7 +165,7 @@ def write_csv(csv_file, csv_lines, utt_id_idx=0, max_utt=300):
     # Keep track of the number of times each utterance appears
     utt2count = defaultdict(int)
 
-    with open(csv_file, mode="w") as csv_f:
+    with open(csv_file, mode="w", newline="", encoding="utf-8") as csv_f:
         csv_writer = csv.writer(
             csv_f, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL
         )
@@ -518,8 +518,8 @@ def prepare_lexicon(lexicon_file, output_file):
 
     """
     lexicon = []
-    lex_out = open(output_file, "w")
-    with open(lexicon_file) as lf:
+    lex_out = open(output_file, "w", encoding="utf-8")
+    with open(lexicon_file, encoding="utf-8") as lf:
         # Skip first row
         next(lf)
         for line in lf:
@@ -597,7 +597,7 @@ def make_acronym_map(save_folder, lexicon_file, acronym_map_file):
     logger.info(
         f"Prepared Swbd1 + MSU single letter lexicon with {len(fin_lex)} entries"
     )
-    fout_map = open(acronym_map_file, "w")
+    fout_map = open(acronym_map_file, "w", encoding="utf-8")
 
     # Initialise single letter dictionary
     dict_letter = {}
@@ -705,7 +705,7 @@ def make_acronym_map(save_folder, lexicon_file, acronym_map_file):
     fout_map.close()
 
     # Load acronym map for further processing
-    fin_map = open(acronym_map_file, "r")
+    fin_map = open(acronym_map_file, "r", encoding="utf-8")
     dict_acronym = {}
     dict_acronym_noi = {}  # Mapping of acronyms without I, i
     for pair in fin_map:
@@ -792,7 +792,7 @@ def make_name_to_disk_dict(mapping_table: str):
         A dictionary that maps from sph filename (key) to disk-id (value)
     """
     name2disk = {}
-    with open(mapping_table) as mt:
+    with open(mapping_table, encoding="utf-8") as mt:
         for line in mt:
             split = line.split()
             name = split[1].strip()
@@ -905,7 +905,7 @@ def swbd1_data_prep(
         ]
         # Open each transcription file and extract information
         for filename in transcript_files_split:
-            with open(filename) as file:
+            with open(filename, encoding="utf-8") as file:
                 for line in file:
                     str_split = line.split()
                     id = str_split[0].strip()
@@ -998,7 +998,7 @@ def eval2000_data_prep(data_folder: str, save_folder: str):
         ["ID", "duration", "start", "stop", "channel", "wav", "words", "spk_id"]
     ]
 
-    with open(transcription_file) as file:
+    with open(transcription_file, encoding="utf-8") as file:
         utt_count = 0
         for line in file:
             # Skip header
@@ -1069,7 +1069,7 @@ def eval2000_data_prep(data_folder: str, save_folder: str):
         csv_file = os.path.join(save_folder, filename)
         logger.info(f"Creating csv file {csv_file}")
 
-        with open(csv_file, mode="w") as csv_f:
+        with open(csv_file, mode="w", newline="", encoding="utf-8") as csv_f:
             csv_writer = csv.writer(
                 csv_f, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL
             )
@@ -1147,7 +1147,7 @@ def parse_glm_file(glm_dir, save_folder):
     csv_file = os.path.join(save_folder, "glm.csv")
     logger.info("Writing GLM csv file")
 
-    with open(csv_file, mode="w") as csv_f:
+    with open(csv_file, mode="w", newline="", encoding="utf-8") as csv_f:
         csv_writer = csv.writer(
             csv_f, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL
         )
@@ -1200,7 +1200,7 @@ def fisher_data_prep(data_folder, save_folder):
         transcript_files = get_all_files(joined_path, match_and=[".txt"])
 
         for transcript_files in transcript_files:
-            with open(transcript_files) as file:
+            with open(transcript_files, encoding="utf-8") as file:
                 for line in file:
                     # skip header and empty lines
                     if line.startswith("#") or len(line.strip()) < 1:
@@ -1236,7 +1236,7 @@ def fisher_data_prep(data_folder, save_folder):
     csv_file = os.path.join(save_folder, "fisher.csv")
     logger.info(f"Creating csv file {csv_file}")
 
-    with open(csv_file, mode="w") as csv_f:
+    with open(csv_file, mode="w", newline="", encoding="utf-8") as csv_f:
         csv_writer = csv.writer(
             csv_f, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL
         )

--- a/recipes/TIMIT/ASR/CTC/train.py
+++ b/recipes/TIMIT/ASR/CTC/train.py
@@ -106,7 +106,9 @@ class ASR_Brain(sb.Brain):
                 test_stats={"loss": stage_loss, "PER": per},
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     w.write("CTC loss stats:\n")
                     self.ctc_metrics.write_stats(w)
                     w.write("\nPER stats:\n")
@@ -207,7 +209,7 @@ if __name__ == "__main__":
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Dataset prep (parsing TIMIT and annotation into csv files)

--- a/recipes/TIMIT/ASR/seq2seq/train.py
+++ b/recipes/TIMIT/ASR/seq2seq/train.py
@@ -142,7 +142,9 @@ class ASR(sb.Brain):
                 test_stats={"loss": stage_loss, "PER": per},
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     w.write("CTC loss stats:\n")
                     self.ctc_metrics.write_stats(w)
                     w.write("\nseq2seq loss stats:\n")
@@ -282,7 +284,7 @@ if __name__ == "__main__":
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Dataset prep (parsing TIMIT and annotation into csv files)

--- a/recipes/TIMIT/ASR/seq2seq/train_with_wav2vec2.py
+++ b/recipes/TIMIT/ASR/seq2seq/train_with_wav2vec2.py
@@ -144,7 +144,9 @@ class ASR(sb.Brain):
                 test_stats={"loss": stage_loss, "PER": per},
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     w.write("CTC loss stats:\n")
                     self.ctc_metrics.write_stats(w)
                     w.write("\nseq2seq loss stats:\n")
@@ -289,7 +291,7 @@ if __name__ == "__main__":
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Dataset prep (parsing TIMIT and annotation into csv files)

--- a/recipes/TIMIT/ASR/transducer/train.py
+++ b/recipes/TIMIT/ASR/transducer/train.py
@@ -146,7 +146,7 @@ class ASR_Brain(sb.Brain):
 
 
 def save_metrics_to_file(wer_file, transducer_metrics, per_metrics):
-    with open(wer_file, "w") as w:
+    with open(wer_file, "w", encoding="utf-8") as w:
         w.write("Transducer loss stats:\n")
         transducer_metrics.write_stats(w)
         w.write("\nPER stats:\n")
@@ -249,7 +249,7 @@ if __name__ == "__main__":
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Dataset prep (parsing TIMIT and annotation into csv files)

--- a/recipes/TIMIT/ASR/transducer/train_wav2vec.py
+++ b/recipes/TIMIT/ASR/transducer/train_wav2vec.py
@@ -143,7 +143,9 @@ class ASR_Brain(sb.Brain):
                 test_stats={"loss": stage_loss, "PER": per},
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     w.write("Transducer loss stats:\n")
                     self.transducer_metrics.write_stats(w)
                     w.write("\nPER stats:\n")
@@ -266,7 +268,7 @@ if __name__ == "__main__":
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Dataset prep (parsing TIMIT and annotation into csv files)

--- a/recipes/TIMIT/Alignment/train.py
+++ b/recipes/TIMIT/Alignment/train.py
@@ -242,7 +242,7 @@ if __name__ == "__main__":
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Dataset prep (parsing TIMIT and annotation into csv files)

--- a/recipes/TIMIT/timit_prepare.py
+++ b/recipes/TIMIT/timit_prepare.py
@@ -452,7 +452,7 @@ def get_phoneme_lists(phn_file, phn_set):
     phonemes = []
     ends = []
 
-    for line in open(phn_file):
+    for line in open(phn_file, encoding="utf-8"):
         end, phoneme = line.rstrip("\n").replace("h#", "sil").split(" ")[1:]
 
         # Getting dictionaries for phoneme conversion

--- a/recipes/TIMIT/timit_prepare.py
+++ b/recipes/TIMIT/timit_prepare.py
@@ -409,7 +409,10 @@ def create_json(wav_lst, json_file, uppercase, phn_set):
             err_msg = "the wrd file %s does not exists!" % (wrd_file)
             raise FileNotFoundError(err_msg)
 
-        words = [line.rstrip("\n").split(" ")[2] for line in open(wrd_file)]
+        words = [
+            line.rstrip("\n").split(" ")[2]
+            for line in open(wrd_file, encoding="utf-8")
+        ]
         words = " ".join(words)
 
         # Retrieving phonemes
@@ -435,7 +438,7 @@ def create_json(wav_lst, json_file, uppercase, phn_set):
         }
 
     # Writing the dictionary to the json file
-    with open(json_file, mode="w") as json_f:
+    with open(json_file, mode="w", encoding="utf-8") as json_f:
         json.dump(json_dict, json_f, indent=2)
 
     logger.info(f"{json_file} successfully created!")

--- a/recipes/Tedlium2/ASR/transformer/tedlium2_prepare.py
+++ b/recipes/Tedlium2/ASR/transformer/tedlium2_prepare.py
@@ -44,7 +44,7 @@ def make_splits(sph_file, stm_file, utt_save_folder, avoid_if_shorter_than):
         return
 
     # load the annotation of the entire speech recording
-    annotation_file = open(stm_file, "r")
+    annotation_file = open(stm_file, "r", encoding="utf-8")
     annotations = annotation_file.readlines()
 
     # load the original speech recording

--- a/recipes/Tedlium2/ASR/transformer/train.py
+++ b/recipes/Tedlium2/ASR/transformer/train.py
@@ -219,7 +219,9 @@ class ASR(sb.core.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
             # save the averaged checkpoint at the end of the evaluation stage
@@ -365,7 +367,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # If --distributed_launch then

--- a/recipes/Tedlium2/Tokenizer/train.py
+++ b/recipes/Tedlium2/Tokenizer/train.py
@@ -25,7 +25,7 @@ from speechbrain.utils.distributed import run_on_main
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/Tedlium2/tedlium2_prepare.py
+++ b/recipes/Tedlium2/tedlium2_prepare.py
@@ -44,7 +44,7 @@ def make_splits(sph_file, stm_file, utt_save_folder, avoid_if_shorter_than):
         return
 
     # load the annotation of the entire speech recording
-    annotation_file = open(stm_file, "r")
+    annotation_file = open(stm_file, "r", encoding="utf-8")
     annotations = annotation_file.readlines()
 
     # load the original speech recording

--- a/recipes/UrbanSound8k/SoundClassification/train.py
+++ b/recipes/UrbanSound8k/SoundClassification/train.py
@@ -361,7 +361,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/UrbanSound8k/urbansound8k_prepare.py
+++ b/recipes/UrbanSound8k/urbansound8k_prepare.py
@@ -258,7 +258,7 @@ def create_json(metadata, audio_data_folder, folds_list, json_file):
     if not os.path.exists(parent_dir):
         os.mkdir(parent_dir)
 
-    with open(json_file, mode="w") as json_f:
+    with open(json_file, mode="w", encoding="utf-8") as json_f:
         json.dump(json_dict, json_f, indent=2)
 
     logger.info(f"{json_file} successfully created!")

--- a/recipes/Voicebank/ASR/CTC/train.py
+++ b/recipes/Voicebank/ASR/CTC/train.py
@@ -95,7 +95,7 @@ class ASR_Brain(sb.Brain):
                 stats_meta={"Epoch loaded": self.hparams.epoch_counter.current},
                 test_stats={"loss": stage_loss, "PER": per},
             )
-            with open(self.hparams.per_file, "w") as w:
+            with open(self.hparams.per_file, "w", encoding="utf-8") as w:
                 w.write("CTC loss stats:\n")
                 self.ctc_metrics.write_stats(w)
                 w.write("\nPER stats:\n")
@@ -168,7 +168,7 @@ def dataio_prep(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Initialize ddp (useful only for multi-GPU DDP training)

--- a/recipes/Voicebank/MTL/ASR_enhance/train.py
+++ b/recipes/Voicebank/MTL/ASR_enhance/train.py
@@ -384,7 +384,9 @@ class MTLbrain(sb.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.stats_file + ".txt", "w") as w:
+                with open(
+                    self.hparams.stats_file + ".txt", "w", encoding="utf-8"
+                ) as w:
                     if self.hparams.enhance_weight > 0:
                         w.write("\nstoi stats:\n")
                         self.stoi_metrics.write_stats(w)
@@ -490,7 +492,7 @@ def dataio_prep(hparams, token_encoder):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/Voicebank/dereverb/MetricGAN-U/train.py
+++ b/recipes/Voicebank/dereverb/MetricGAN-U/train.py
@@ -732,7 +732,7 @@ def create_folder(folder):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Initialize ddp (useful only for multi-GPU DDP training)

--- a/recipes/Voicebank/dereverb/MetricGAN-U/voicebank_revb_prepare.py
+++ b/recipes/Voicebank/dereverb/MetricGAN-U/voicebank_revb_prepare.py
@@ -308,7 +308,7 @@ def create_json(wav_lst, json_file, clean_folder):
         }
 
     # Writing the json lines
-    with open(json_file, mode="w") as json_f:
+    with open(json_file, mode="w", encoding="utf-8") as json_f:
         json.dump(json_dict, json_f, indent=2)
 
     logger.info(f"{json_file} successfully created!")

--- a/recipes/Voicebank/dereverb/spectral_mask/train.py
+++ b/recipes/Voicebank/dereverb/spectral_mask/train.py
@@ -208,7 +208,7 @@ def create_folder(folder):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Initialize ddp (useful only for multi-GPU DDP training)

--- a/recipes/Voicebank/dereverb/spectral_mask/voicebank_revb_prepare.py
+++ b/recipes/Voicebank/dereverb/spectral_mask/voicebank_revb_prepare.py
@@ -307,7 +307,7 @@ def create_json(wav_lst, json_file, clean_folder):
         }
 
     # Writing the json lines
-    with open(json_file, mode="w") as json_f:
+    with open(json_file, mode="w", encoding="utf-8") as json_f:
         json.dump(json_dict, json_f, indent=2)
 
     logger.info(f"{json_file} successfully created!")

--- a/recipes/Voicebank/enhance/MetricGAN-U/train.py
+++ b/recipes/Voicebank/enhance/MetricGAN-U/train.py
@@ -723,7 +723,7 @@ def create_folder(folder):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Initialize ddp (useful only for multi-GPU DDP training)

--- a/recipes/Voicebank/enhance/MetricGAN-U/voicebank_prepare.py
+++ b/recipes/Voicebank/enhance/MetricGAN-U/voicebank_prepare.py
@@ -302,7 +302,7 @@ def create_lexicon(lexicon_save_filepath):
     # each word to our lexicon dictionary
     lexicon = MISSING_LEXICON
     delayed_words = {}
-    for line in open(lexicon_save_filepath):
+    for line in open(lexicon_save_filepath, encoding="utf-8"):
         line = line.split()
         phns = " ".join(p.strip("012") for p in line[1:])
 
@@ -377,7 +377,7 @@ def create_json(wav_lst, json_file, clean_folder, txt_folder, lexicon):
         }
 
     # Writing the json lines
-    with open(json_file, mode="w") as json_f:
+    with open(json_file, mode="w", encoding="utf-8") as json_f:
         json.dump(json_dict, json_f, indent=2)
 
     logger.info(f"{json_file} successfully created!")

--- a/recipes/Voicebank/enhance/MetricGAN-U/voicebank_prepare.py
+++ b/recipes/Voicebank/enhance/MetricGAN-U/voicebank_prepare.py
@@ -357,7 +357,9 @@ def create_json(wav_lst, json_file, clean_folder, txt_folder, lexicon):
 
         # Read text
         snt_id = filename.replace(".wav", "")
-        with open(os.path.join(txt_folder, snt_id + ".txt")) as f:
+        with open(
+            os.path.join(txt_folder, snt_id + ".txt"), encoding="utf-8"
+        ) as f:
             word_string = f.read()
         word_string = remove_punctuation(word_string).strip().upper()
         phones = [

--- a/recipes/Voicebank/enhance/MetricGAN/train.py
+++ b/recipes/Voicebank/enhance/MetricGAN/train.py
@@ -567,7 +567,7 @@ def create_folder(folder):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Initialize ddp (useful only for multi-GPU DDP training)

--- a/recipes/Voicebank/enhance/SEGAN/train.py
+++ b/recipes/Voicebank/enhance/SEGAN/train.py
@@ -458,7 +458,7 @@ def create_folder(folder):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Initialize ddp (useful only for multi-GPU DDP training)

--- a/recipes/Voicebank/enhance/spectral_mask/train.py
+++ b/recipes/Voicebank/enhance/spectral_mask/train.py
@@ -201,7 +201,7 @@ def create_folder(folder):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Initialize ddp (useful only for multi-GPU DDP training)

--- a/recipes/Voicebank/enhance/waveform_map/train.py
+++ b/recipes/Voicebank/enhance/waveform_map/train.py
@@ -178,7 +178,7 @@ def create_folder(folder):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Initialize ddp (useful only for multi-GPU DDP training)

--- a/recipes/Voicebank/voicebank_prepare.py
+++ b/recipes/Voicebank/voicebank_prepare.py
@@ -298,7 +298,7 @@ def create_lexicon(lexicon_save_filepath):
     # each word to our lexicon dictionary
     lexicon = MISSING_LEXICON
     delayed_words = {}
-    for line in open(lexicon_save_filepath):
+    for line in open(lexicon_save_filepath, encoding="utf-8"):
         line = line.split()
         phns = " ".join(p.strip("012") for p in line[1:])
 
@@ -373,7 +373,7 @@ def create_json(wav_lst, json_file, clean_folder, txt_folder, lexicon):
         }
 
     # Writing the json lines
-    with open(json_file, mode="w") as json_f:
+    with open(json_file, mode="w", encoding="utf-8") as json_f:
         json.dump(json_dict, json_f, indent=2)
 
     logger.info(f"{json_file} successfully created!")

--- a/recipes/Voicebank/voicebank_prepare.py
+++ b/recipes/Voicebank/voicebank_prepare.py
@@ -353,7 +353,9 @@ def create_json(wav_lst, json_file, clean_folder, txt_folder, lexicon):
 
         # Read text
         snt_id = filename.replace(".wav", "")
-        with open(os.path.join(txt_folder, snt_id + ".txt")) as f:
+        with open(
+            os.path.join(txt_folder, snt_id + ".txt"), encoding="utf-8"
+        ) as f:
             word_string = f.read()
         word_string = remove_punctuation(word_string).strip().upper()
         phones = [

--- a/recipes/VoxCeleb/SpeakerRec/extract_speaker_embeddings.py
+++ b/recipes/VoxCeleb/SpeakerRec/extract_speaker_embeddings.py
@@ -81,7 +81,7 @@ def compute_embeddings(params, wav_scp, outdir):
         numpy manner.
     """
     with torch.no_grad():
-        with open(wav_scp, "r") as wavscp:
+        with open(wav_scp, "r", encoding="utf-8") as wavscp:
             for line in wavscp:
                 utt, wav_path = line.split()
                 out_file = "{}/{}.npy".format(outdir, utt)
@@ -120,7 +120,7 @@ if __name__ == "__main__":
         # Ensure to put the saved model in the output folder
         overrides += f"\noutput_folder: {out_dir}"
 
-    with open(params_file) as fin:
+    with open(params_file, encoding="utf-8") as fin:
         params = load_hyperpyyaml(fin, overrides)
     run_on_main(params["pretrainer"].collect_files)
     params["pretrainer"].load_collected(run_opts["device"])

--- a/recipes/VoxCeleb/SpeakerRec/speaker_verification_cosine.py
+++ b/recipes/VoxCeleb/SpeakerRec/speaker_verification_cosine.py
@@ -86,7 +86,7 @@ def get_verification_scores(veri_test):
     negative_scores = []
 
     save_file = os.path.join(params["output_folder"], "scores.txt")
-    s_file = open(save_file, "w")
+    s_file = open(save_file, "w", encoding="utf-8")
 
     # Cosine similarity initialization
     similarity = torch.nn.CosineSimilarity(dim=-1, eps=1e-6)
@@ -225,7 +225,7 @@ if __name__ == "__main__":
 
     # Load hyperparameters file with command-line overrides
     params_file, run_opts, overrides = sb.core.parse_arguments(sys.argv[1:])
-    with open(params_file) as fin:
+    with open(params_file, encoding="utf-8") as fin:
         params = load_hyperpyyaml(fin, overrides)
 
     # Download verification list (to exclude verification sentences from train)
@@ -280,7 +280,7 @@ if __name__ == "__main__":
     # Compute the EER
     logger.info("Computing EER..")
     # Reading standard verification split
-    with open(veri_file_path) as f:
+    with open(veri_file_path, encoding="utf-8") as f:
         veri_test = [line.rstrip() for line in f]
 
     positive_scores, negative_scores = get_verification_scores(veri_test)

--- a/recipes/VoxCeleb/SpeakerRec/speaker_verification_plda.py
+++ b/recipes/VoxCeleb/SpeakerRec/speaker_verification_plda.py
@@ -227,7 +227,7 @@ if __name__ == "__main__":
 
     # Load hyperparameters file with command-line overrides
     params_file, run_opts, overrides = sb.core.parse_arguments(sys.argv[1:])
-    with open(params_file) as fin:
+    with open(params_file, encoding="utf-8") as fin:
         params = load_hyperpyyaml(fin, overrides)
 
     # Download verification list (to exclude verification sentences from train)

--- a/recipes/VoxCeleb/SpeakerRec/speaker_verification_plda.py
+++ b/recipes/VoxCeleb/SpeakerRec/speaker_verification_plda.py
@@ -119,7 +119,7 @@ def verification_performance(scores_plda):
     labels = []
     positive_scores = []
     negative_scores = []
-    for line in open(veri_file_path):
+    for line in open(veri_file_path, encoding="utf-8"):
         lab = int(line.split(" ")[0].rstrip().split(".")[0].strip())
         enrol_id = line.split(" ")[1].rstrip().split(".")[0].strip()
         test_id = line.split(" ")[2].rstrip().split(".")[0].strip()

--- a/recipes/VoxCeleb/SpeakerRec/train_speaker_embeddings.py
+++ b/recipes/VoxCeleb/SpeakerRec/train_speaker_embeddings.py
@@ -188,7 +188,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Download verification list (to exclude verification sentences from train)

--- a/recipes/VoxCeleb/voxceleb_prepare.py
+++ b/recipes/VoxCeleb/voxceleb_prepare.py
@@ -413,7 +413,7 @@ def prepare_csv(seg_dur, wav_lst, csv_file, random_segment=False, amp_th=0):
     csv_output = csv_output + entry
 
     # Writing the csv lines
-    with open(csv_file, mode="w") as csv_f:
+    with open(csv_file, mode="w", newline="", encoding="utf-8") as csv_f:
         csv_writer = csv.writer(
             csv_f, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL
         )
@@ -490,7 +490,7 @@ def prepare_csv_enrol_test(data_folders, save_folder, verification_pairs_file):
         csv_file = os.path.join(save_folder, ENROL_CSV)
 
         # Writing the csv lines
-        with open(csv_file, mode="w") as csv_f:
+        with open(csv_file, mode="w", newline="", encoding="utf-8") as csv_f:
             csv_writer = csv.writer(
                 csv_f, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL
             )
@@ -526,7 +526,7 @@ def prepare_csv_enrol_test(data_folders, save_folder, verification_pairs_file):
         csv_file = os.path.join(save_folder, TEST_CSV)
 
         # Writing the csv lines
-        with open(csv_file, mode="w") as csv_f:
+        with open(csv_file, mode="w", newline="", encoding="utf-8") as csv_f:
             csv_writer = csv.writer(
                 csv_f, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL
             )

--- a/recipes/VoxCeleb/voxceleb_prepare.py
+++ b/recipes/VoxCeleb/voxceleb_prepare.py
@@ -269,7 +269,7 @@ def _get_utt_split_lists(
     for data_folder in data_folders:
         test_lst = [
             line.rstrip("\n").split(" ")[1]
-            for line in open(verification_pairs_file)
+            for line in open(verification_pairs_file, encoding="utf-8")
         ]
         test_lst = set(sorted(test_lst))
 
@@ -452,7 +452,7 @@ def prepare_csv_enrol_test(data_folders, save_folder, verification_pairs_file):
         enrol_ids, test_ids = [], []
 
         # Get unique ids (enrol and test utterances)
-        for line in open(test_lst_file):
+        for line in open(test_lst_file, encoding="utf-8"):
             e_id = line.split(" ")[1].rstrip().split(".")[0].strip()
             t_id = line.split(" ")[2].rstrip().split(".")[0].strip()
             enrol_ids.append(e_id)

--- a/recipes/VoxLingua107/lang_id/create_wds_shards.py
+++ b/recipes/VoxLingua107/lang_id/create_wds_shards.py
@@ -100,7 +100,7 @@ def write_shards(
         "num_data_samples": len(data_tuples),
     }
 
-    with (shards_path / "meta.json").open("w") as f:
+    with (shards_path / "meta.json").open("w", encoding="utf-8") as f:
         json.dump(meta_dict, f)
 
     # shuffle the tuples so that each shard has a large variety in languages

--- a/recipes/VoxLingua107/lang_id/train.py
+++ b/recipes/VoxLingua107/lang_id/train.py
@@ -207,7 +207,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Data preparation for augmentation

--- a/recipes/VoxPopuli/ASR/transducer/train.py
+++ b/recipes/VoxPopuli/ASR/transducer/train.py
@@ -241,7 +241,9 @@ class ASR(sb.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
             # save the averaged checkpoint at the end of the evaluation stage
@@ -394,7 +396,7 @@ if __name__ == "__main__":
     # create ddp_group with the right communication protocol
     sb.utils.distributed.ddp_init_group(run_opts)
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/VoxPopuli/Tokenizer/train.py
+++ b/recipes/VoxPopuli/Tokenizer/train.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
 
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/VoxPopuli/voxpopuli_prepare.py
+++ b/recipes/VoxPopuli/voxpopuli_prepare.py
@@ -254,7 +254,7 @@ def create_csv(
         raise FileNotFoundError(msg)
 
     # We load and skip the header
-    loaded_csv = open(orig_tsv_file, "r").readlines()[1:]
+    loaded_csv = open(orig_tsv_file, "r", encoding="utf-8").readlines()[1:]
     nb_samples = len(loaded_csv)
 
     msg = "Preparing CSV files for %s samples ..." % (str(nb_samples))

--- a/recipes/WHAMandWHAMR/enhancement/train.py
+++ b/recipes/WHAMandWHAMR/enhancement/train.py
@@ -424,7 +424,7 @@ class Separation(sb.Brain):
             test_data, **self.hparams.dataloader_opts
         )
 
-        with open(save_file, "w") as results_csv:
+        with open(save_file, "w", newline="", encoding="utf-8") as results_csv:
             writer = csv.DictWriter(results_csv, fieldnames=csv_columns)
             writer.writeheader()
 
@@ -614,7 +614,7 @@ def dataio_prep(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Initialize ddp (useful only for multi-GPU DDP training)

--- a/recipes/WHAMandWHAMR/prepare_data.py
+++ b/recipes/WHAMandWHAMR/prepare_data.py
@@ -185,7 +185,9 @@ def create_whamr_rir_csv(datapath, savepath):
     files = os.listdir(datapath)
     all_paths = [os.path.join(datapath, fl) for fl in files]
 
-    with open(savepath + "/whamr_rirs.csv", "w") as csvfile:
+    with open(
+        savepath + "/whamr_rirs.csv", "w", newline="", encoding="utf-8"
+    ) as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=csv_columns)
         writer.writeheader()
         for i, wav_path in enumerate(all_paths):

--- a/recipes/WHAMandWHAMR/prepare_data.py
+++ b/recipes/WHAMandWHAMR/prepare_data.py
@@ -136,7 +136,9 @@ def create_wham_whamr_csv(
         ]
 
         with open(
-            os.path.join(savepath, savename + set_type + ".csv"), "w"
+            os.path.join(savepath, savename + set_type + ".csv"),
+            "w",
+            encoding="utf-8",
         ) as csvfile:
             writer = csv.DictWriter(csvfile, fieldnames=csv_columns)
             writer.writeheader()

--- a/recipes/WHAMandWHAMR/separation/train.py
+++ b/recipes/WHAMandWHAMR/separation/train.py
@@ -356,7 +356,7 @@ class Separation(sb.Brain):
             test_data, **self.hparams.dataloader_opts
         )
 
-        with open(save_file, "w") as results_csv:
+        with open(save_file, "w", newline="", encoding="utf-8") as results_csv:
             writer = csv.DictWriter(results_csv, fieldnames=csv_columns)
             writer.writeheader()
 
@@ -533,7 +533,7 @@ def dataio_prep(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Initialize ddp (useful only for multi-GPU DDP training)

--- a/recipes/WSJ0Mix/prepare_data.py
+++ b/recipes/WSJ0Mix/prepare_data.py
@@ -95,7 +95,9 @@ def create_custom_dataset(
         ]
 
         with open(
-            os.path.join(savepath, dataset_name + "_" + set_type + ".csv"), "w"
+            os.path.join(savepath, dataset_name + "_" + set_type + ".csv"),
+            "w",
+            encoding="utf-8",
         ) as csvfile:
             writer = csv.DictWriter(csvfile, fieldnames=csv_columns)
             writer.writeheader()

--- a/recipes/WSJ0Mix/prepare_data.py
+++ b/recipes/WSJ0Mix/prepare_data.py
@@ -151,7 +151,12 @@ def create_wsj_csv(datapath, savepath):
             "s2_wav_opts",
         ]
 
-        with open(savepath + "/wsj_" + set_type + ".csv", "w") as csvfile:
+        with open(
+            savepath + "/wsj_" + set_type + ".csv",
+            "w",
+            newline="",
+            encoding="utf-8",
+        ) as csvfile:
             writer = csv.DictWriter(csvfile, fieldnames=csv_columns)
             writer.writeheader()
             for i, (mix_path, s1_path, s2_path) in enumerate(
@@ -211,7 +216,12 @@ def create_wsj_csv_3spks(datapath, savepath):
             "s3_wav_opts",
         ]
 
-        with open(savepath + "/wsj_" + set_type + ".csv", "w") as csvfile:
+        with open(
+            savepath + "/wsj_" + set_type + ".csv",
+            "w",
+            newline="",
+            encoding="utf-8",
+        ) as csvfile:
             writer = csv.DictWriter(csvfile, fieldnames=csv_columns)
             writer.writeheader()
             for i, (mix_path, s1_path, s2_path, s3_path) in enumerate(

--- a/recipes/WSJ0Mix/separation/train.py
+++ b/recipes/WSJ0Mix/separation/train.py
@@ -336,7 +336,7 @@ class Separation(sb.Brain):
             test_data, **self.hparams.dataloader_opts
         )
 
-        with open(save_file, "w") as results_csv:
+        with open(save_file, "w", newline="", encoding="utf-8") as results_csv:
             writer = csv.DictWriter(results_csv, fieldnames=csv_columns)
             writer.writeheader()
 
@@ -517,7 +517,7 @@ def dataio_prep(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Initialize ddp (useful only for multi-GPU DDP training)

--- a/recipes/ZaionEmotionDataset/emotion_diarization/datasets/prepare_EMOVDB.py
+++ b/recipes/ZaionEmotionDataset/emotion_diarization/datasets/prepare_EMOVDB.py
@@ -306,7 +306,7 @@ def concat_wavs(data_folder, save_json):
 
                 emotion_wavs = emotion_wavs[1:]
 
-    with open(save_json, "w") as outfile:
+    with open(save_json, "w", encoding="utf-8") as outfile:
         json.dump(data_json, outfile)
     return data_json
 

--- a/recipes/ZaionEmotionDataset/emotion_diarization/datasets/prepare_ESD.py
+++ b/recipes/ZaionEmotionDataset/emotion_diarization/datasets/prepare_ESD.py
@@ -301,7 +301,7 @@ def concat_wavs(data_folder, save_json):
 
                 emotion_wavs = emotion_wavs[1:]
 
-    with open(save_json, "w") as outfile:
+    with open(save_json, "w", encoding="utf-8") as outfile:
         json.dump(data_json, outfile)
     return data_json
 

--- a/recipes/ZaionEmotionDataset/emotion_diarization/datasets/prepare_IEMOCAP.py
+++ b/recipes/ZaionEmotionDataset/emotion_diarization/datasets/prepare_IEMOCAP.py
@@ -121,7 +121,7 @@ def load_utterInfo(inputFile):
         r"[\[]*[0-9]*[.][0-9]*[ -]*[0-9]*[.][0-9]*[\]][\t][a-z0-9_]*[\t][a-z]{3}[\t][\[][0-9]*[.][0-9]*[, ]+[0-9]*[.][0-9]*[, ]+[0-9]*[.][0-9]*[\]]",
         re.IGNORECASE,
     )  # noqa
-    with open(inputFile, "r") as myfile:
+    with open(inputFile, "r", encoding="utf-8") as myfile:
         data = myfile.read().replace("\n", " ")
     result = pattern.findall(data)
     out = []
@@ -359,7 +359,7 @@ def concat_wavs(data_folder, save_json, emo_wavs, neu_wavs, annotations):
 
                 emotion_wavs = emotion_wavs[1:]
 
-    with open(save_json, "w") as outfile:
+    with open(save_json, "w", encoding="utf-8") as outfile:
         json.dump(data_json, outfile)
     return data_json
 

--- a/recipes/ZaionEmotionDataset/emotion_diarization/datasets/prepare_JLCORPUS.py
+++ b/recipes/ZaionEmotionDataset/emotion_diarization/datasets/prepare_JLCORPUS.py
@@ -284,7 +284,7 @@ def concat_wavs(data_folder, save_json):
 
                 emotion_wavs = emotion_wavs[1:]
 
-    with open(save_json, "w") as outfile:
+    with open(save_json, "w", encoding="utf-8") as outfile:
         json.dump(data_json, outfile)
     return data_json
 

--- a/recipes/ZaionEmotionDataset/emotion_diarization/datasets/prepare_RAVDESS.py
+++ b/recipes/ZaionEmotionDataset/emotion_diarization/datasets/prepare_RAVDESS.py
@@ -295,7 +295,7 @@ def concat_wavs(data_folder, save_json):
 
                 emotion_wavs = emotion_wavs[1:]
 
-    with open(save_json, "w") as outfile:
+    with open(save_json, "w", encoding="utf-8") as outfile:
         json.dump(data_json, outfile)
     return data_json
 

--- a/recipes/ZaionEmotionDataset/emotion_diarization/train.py
+++ b/recipes/ZaionEmotionDataset/emotion_diarization/train.py
@@ -48,7 +48,7 @@ class EmoDiaBrain(sb.Brain):
             preds_decoded = label_encoder.decode_ndim(preds)
 
             self.load_ZED()
-            with open(self.hparams.eder_file, "a") as w:
+            with open(self.hparams.eder_file, "a", encoding="utf-8") as w:
                 for i in range(len(batch.id)):
                     if len(preds_decoded[i]) < len(emoid_decoded[i]):
                         preds_decoded[i].append(preds_decoded[i][-1])
@@ -164,11 +164,11 @@ class EmoDiaBrain(sb.Brain):
                     "EDER": sum(self.eder) / len(self.eder),
                 },
             )
-            # with open(self.hparams.cer_file, "a") as w:
+            # with open(self.hparams.cer_file, "a", encoding="utf-8") as w:
             #     self.error_metrics.write_stats(w)
 
     def load_ZED(self):
-        with open(self.hparams.test_annotation, "r") as f:
+        with open(self.hparams.test_annotation, "r", encoding="utf-8") as f:
             ZED_data = json.load(f)
         self.ZED = ZED_data
 
@@ -274,7 +274,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides.
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/recipes/ZaionEmotionDataset/emotion_diarization/zed_prepare.py
+++ b/recipes/ZaionEmotionDataset/emotion_diarization/zed_prepare.py
@@ -219,7 +219,7 @@ def prepare_test(ZED_folder, save_json_test, win_len, stride):
 
     try:
         zed_json_path = os.path.join(ZED_folder, "ZED.json")
-        with open(zed_json_path, "r") as f:
+        with open(zed_json_path, "r", encoding="utf-8") as f:
             all_dict = json.load(f)
     except OSError:
         logger.info(f"ZED.json can't be found under {ZED_folder}")
@@ -296,7 +296,7 @@ def create_json(data, json_file):
         The path of the output json file
     """
     # Writing the dictionary to the json file
-    with open(json_file, mode="w") as json_f:
+    with open(json_file, mode="w", encoding="utf-8") as json_f:
         json.dump(data, json_f, indent=2)
     logger.info(f"{json_file} successfully created!")
 
@@ -325,7 +325,7 @@ def check_and_prepare_dataset(
             logger.info(
                 f"{json_path} exists, skipping f{data_name} preparation."
             )
-            with open(json_path, "r") as f:
+            with open(json_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
         dictionary.update(data.items())
     else:

--- a/recipes/fluent-speech-commands/Tokenizer/train.py
+++ b/recipes/fluent-speech-commands/Tokenizer/train.py
@@ -23,7 +23,7 @@ from speechbrain.utils.distributed import run_on_main
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/fluent-speech-commands/direct/train.py
+++ b/recipes/fluent-speech-commands/direct/train.py
@@ -150,7 +150,9 @@ class SLU(sb.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
 
@@ -241,7 +243,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     show_results_every = 100  # plots results every N iterations

--- a/recipes/timers-and-such/LM/train.py
+++ b/recipes/timers-and-such/LM/train.py
@@ -149,7 +149,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     show_results_every = 100  # plots results every N iterations

--- a/recipes/timers-and-such/Tokenizer/train.py
+++ b/recipes/timers-and-such/Tokenizer/train.py
@@ -23,7 +23,7 @@ from speechbrain.utils.distributed import run_on_main
 if __name__ == "__main__":
     # CLI:
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # create ddp_group with the right communication protocol

--- a/recipes/timers-and-such/decoupled/train.py
+++ b/recipes/timers-and-such/decoupled/train.py
@@ -155,7 +155,9 @@ class SLU(sb.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
 
@@ -285,7 +287,7 @@ def data_io_prepare(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     show_results_every = 100  # plots results every N iterations

--- a/recipes/timers-and-such/direct/train.py
+++ b/recipes/timers-and-such/direct/train.py
@@ -150,7 +150,9 @@ class SLU(sb.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
 
@@ -272,7 +274,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     show_results_every = 100  # plots results every N iterations

--- a/recipes/timers-and-such/direct/train_with_wav2vec2.py
+++ b/recipes/timers-and-such/direct/train_with_wav2vec2.py
@@ -160,7 +160,9 @@ class SLU(sb.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
     def init_optimizers(self):
@@ -300,7 +302,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     show_results_every = 100  # plots results every N iterations

--- a/recipes/timers-and-such/multistage/train.py
+++ b/recipes/timers-and-such/multistage/train.py
@@ -164,7 +164,9 @@ class SLU(sb.Brain):
                 test_stats=stage_stats,
             )
             if if_main_process():
-                with open(self.hparams.test_wer_file, "w") as w:
+                with open(
+                    self.hparams.test_wer_file, "w", encoding="utf-8"
+                ) as w:
                     self.wer_metric.write_stats(w)
 
 
@@ -286,7 +288,7 @@ def dataio_prepare(hparams):
 if __name__ == "__main__":
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     show_results_every = 100  # plots results every N iterations

--- a/speechbrain/__init__.py
+++ b/speechbrain/__init__.py
@@ -6,7 +6,9 @@ import os
 from .core import Brain, Stage, create_experiment_directory, parse_arguments
 from .utils.importutils import deprecated_redirect, lazy_export_all
 
-with open(os.path.join(os.path.dirname(__file__), "version.txt")) as f:
+with open(
+    os.path.join(os.path.dirname(__file__), "version.txt"), encoding="utf-8"
+) as f:
     version = f.read().strip()
 
 __all__ = [

--- a/speechbrain/alignment/aligner.py
+++ b/speechbrain/alignment/aligner.py
@@ -101,7 +101,7 @@ class HMMAligner(torch.nn.Module):
         self.lexicon_path = lexicon_path
 
         if self.lexicon_path is not None:
-            with open(self.lexicon_path, "r") as f:
+            with open(self.lexicon_path, "r", encoding="utf-8") as f:
                 lines = f.readlines()
 
             for i, line in enumerate(lines):

--- a/speechbrain/augment/preparation.py
+++ b/speechbrain/augment/preparation.py
@@ -89,7 +89,7 @@ def write_csv(filelist, csv_file, max_length=None):
         The maximum recording length in seconds.
         Recordings longer than this will be automatically cut into pieces.
     """
-    with open(csv_file, "w") as w:
+    with open(csv_file, "w", encoding="utf-8") as w:
         w.write("ID,duration,wav,wav_format,wav_opts\n")
         for i, filename in enumerate(filelist):
             _write_csv_row(w, filename, i, max_length)

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -169,9 +169,9 @@ def create_experiment_directory(
                 hyperparams_filename = os.path.join(
                     experiment_directory, "hyperparams.yaml"
                 )
-                with open(hyperparams_to_save) as f:
+                with open(hyperparams_to_save, encoding="utf-8") as f:
                     resolved_yaml = resolve_references(f, overrides)
-                with open(hyperparams_filename, "w") as w:
+                with open(hyperparams_filename, "w", encoding="utf-8") as w:
                     print("# Generated %s from:" % date.today(), file=w)
                     print("# %s" % os.path.abspath(hyperparams_to_save), file=w)
                     print("# yamllint disable", file=w)
@@ -204,7 +204,9 @@ def create_experiment_directory(
             if save_env_desc:
                 description_str = sb.utils.logger.get_environment_description()
                 with open(
-                    os.path.join(experiment_directory, "env.log"), "w"
+                    os.path.join(experiment_directory, "env.log"),
+                    "w",
+                    encoding="utf-8",
                 ) as fo:
                     fo.write(description_str)
     finally:
@@ -1870,13 +1872,13 @@ class Brain:
             "avg_train_loss": self.avg_train_loss,
             "optimizer_step": self.optimizer_step,
         }
-        with open(path, "w") as w:
+        with open(path, "w", encoding="utf-8") as w:
             w.write(yaml.dump(save_dict))
 
     @sb.utils.checkpoints.mark_as_loader
     def _recover(self, path, end_of_epoch):
         del end_of_epoch
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             save_dict = yaml.safe_load(f)
         self.step = save_dict["step"]
         self.avg_train_loss = save_dict["avg_train_loss"]

--- a/speechbrain/dataio/dataio.py
+++ b/speechbrain/dataio/dataio.py
@@ -55,7 +55,7 @@ def load_data_json(json_path, replacements={}):
     ... }
     ... '''
     >>> tmpfile = getfixture('tmpdir') / "test.json"
-    >>> with open(tmpfile, "w") as fo:
+    >>> with open(tmpfile, "w", encoding="utf-8") as fo:
     ...     _ = fo.write(json_spec)
     >>> data = load_data_json(tmpfile, {"ROOT": "/home"})
     >>> data["ex1"]["files"][0]
@@ -64,7 +64,7 @@ def load_data_json(json_path, replacements={}):
     '/home/ex2.wav'
 
     """
-    with open(json_path, "r") as f:
+    with open(json_path, "r", encoding="utf-8") as f:
         out_json = json.load(f)
     _recursive_format(out_json, replacements)
     return out_json
@@ -122,14 +122,14 @@ def load_data_csv(csv_path, replacements={}):
     ... utt2,2.0,$data_folder/utt2.wav
     ... '''
     >>> tmpfile = getfixture("tmpdir") / "test.csv"
-    >>> with open(tmpfile, "w") as fo:
+    >>> with open(tmpfile, "w", encoding="utf-8") as fo:
     ...     _ = fo.write(csv_spec)
     >>> data = load_data_csv(tmpfile, {"data_folder": "/home"})
     >>> data["utt1"]["wav_path"]
     '/home/utt1.wav'
     """
 
-    with open(csv_path, newline="") as csvfile:
+    with open(csv_path, newline="", encoding="utf-8") as csvfile:
         result = {}
         reader = csv.DictReader(csvfile, skipinitialspace=True)
         variable_finder = re.compile(r"\$([\w.]+)")
@@ -708,7 +708,7 @@ def write_txt_file(data, filename, sampling_rate=None):
     del sampling_rate  # Not used.
     # Check if the path of filename exists
     os.makedirs(os.path.dirname(filename), exist_ok=True)
-    with open(filename, "w") as fout:
+    with open(filename, "w", encoding="utf-8") as fout:
         if isinstance(data, torch.Tensor):
             data = data.tolist()
         if isinstance(data, np.ndarray):
@@ -954,7 +954,7 @@ def load_pkl(file):
             break
 
     try:
-        open(file + ".lock", "w").close()
+        open(file + ".lock", "w", encoding="utf-8").close()
         with open(file, "rb") as f:
             return pickle.load(f)
     finally:
@@ -1081,11 +1081,15 @@ def merge_csvs(data_folder, csv_lst, merged_csv):
     write_path = os.path.join(data_folder, merged_csv)
     if os.path.isfile(write_path):
         logger.info("Skipping merging. Completed in previous run.")
-    with open(os.path.join(data_folder, csv_lst[0])) as f:
+    with open(
+        os.path.join(data_folder, csv_lst[0]), newline="", encoding="utf-8"
+    ) as f:
         header = f.readline()
     lines = []
     for csv_file in csv_lst:
-        with open(os.path.join(data_folder, csv_file)) as f:
+        with open(
+            os.path.join(data_folder, csv_file), newline="", encoding="utf-8"
+        ) as f:
             for i, line in enumerate(f):
                 if i == 0:
                     # Checking header
@@ -1095,7 +1099,7 @@ def merge_csvs(data_folder, csv_lst, merged_csv):
                         )
                     continue
                 lines.append(line)
-    with open(write_path, "w") as f:
+    with open(write_path, "w", encoding="utf-8") as f:
         f.write(header)
         for line in lines:
             f.write(line)

--- a/speechbrain/dataio/dataloader.py
+++ b/speechbrain/dataio/dataloader.py
@@ -315,7 +315,7 @@ class SaveableDataLoader(DataLoader):
             to_save = None
         else:
             to_save = self._speechbrain_iterator._num_yielded
-        with open(path, "w") as fo:
+        with open(path, "w", encoding="utf-8") as fo:
             fo.write(str(to_save))
 
     @mark_as_loader
@@ -333,7 +333,7 @@ class SaveableDataLoader(DataLoader):
             # Don't load at end of epoch, as we actually want to start a fresh
             # epoch iteration next.
             return
-        with open(path) as fi:
+        with open(path, encoding="utf-8") as fi:
             saved = fi.read()
             if saved == str(None):
                 # Saved at a point where e.g. an iterator did not yet exist.
@@ -398,7 +398,7 @@ class LoopedLoader:
     @mark_as_saver
     def save(self, path):
         """Saves the needed information."""
-        with open(path, "w") as fo:
+        with open(path, "w", encoding="utf-8") as fo:
             print(self.step, file=fo)
             print(self.total_steps, file=fo)
             print(self.total_samples, file=fo)
@@ -406,7 +406,7 @@ class LoopedLoader:
     @mark_as_loader
     def load(self, path, end_of_epoch=True):
         """Loads the needed information."""
-        with open(path) as fi:
+        with open(path, encoding="utf-8") as fi:
             self.step = int(fi.readline().strip())
             self.total_steps = int(fi.readline().strip())
             self.total_samples = int(fi.readline().strip())

--- a/speechbrain/dataio/encoder.py
+++ b/speechbrain/dataio/encoder.py
@@ -766,7 +766,7 @@ class CategoricalEncoder:
     @staticmethod
     def _save_literal(path, lab2ind, extras):
         """Save which is compatible with _load_literal"""
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             for label, ind in lab2ind.items():
                 f.write(
                     repr(label)
@@ -793,7 +793,7 @@ class CategoricalEncoder:
         lab2ind = {}
         ind2lab = {}
         extras = {}
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             # Load the label to index mapping (until EXTRAS_SEPARATOR)
             for line in f:
                 if line == CategoricalEncoder.EXTRAS_SEPARATOR:

--- a/speechbrain/dataio/legacy.py
+++ b/speechbrain/dataio/legacy.py
@@ -148,7 +148,7 @@ def load_sb_extended_csv(csv_path, replacements={}):
         List of DynamicItems to add in DynamicItemDataset.
 
     """
-    with open(csv_path, newline="") as csvfile:
+    with open(csv_path, newline="", encoding="utf-8") as csvfile:
         result = {}
         reader = csv.DictReader(csvfile, skipinitialspace=True)
         variable_finder = re.compile(r"\$([\w.]+)")

--- a/speechbrain/decoders/language_model.py
+++ b/speechbrain/decoders/language_model.py
@@ -44,7 +44,7 @@ def load_unigram_set_from_arpa(arpa_path: str) -> Set[str]:
         Set of unigrams.
     """
     unigrams = set()
-    with open(arpa_path) as f:
+    with open(arpa_path, encoding="utf-8") as f:
         start_1_gram = False
         for line in f:
             line = line.strip()

--- a/speechbrain/decoders/seq2seq.py
+++ b/speechbrain/decoders/seq2seq.py
@@ -663,6 +663,7 @@ class S2SBeamSearcher(S2SBaseSearcher):
     eos_threshold : float
         The threshold coefficient for eos token. Default: 1.5.
         See 3.1.2 in reference: https://arxiv.org/abs/1904.02619
+        TODO https://arxiv.org/pdf/2005.09265 ?
     length_normalization : bool
         Whether to divide the scores by the length. Default: True.
     using_max_attn_shift: bool

--- a/speechbrain/decoders/seq2seq.py
+++ b/speechbrain/decoders/seq2seq.py
@@ -663,7 +663,6 @@ class S2SBeamSearcher(S2SBaseSearcher):
     eos_threshold : float
         The threshold coefficient for eos token. Default: 1.5.
         See 3.1.2 in reference: https://arxiv.org/abs/1904.02619
-        TODO https://arxiv.org/pdf/2005.09265 ?
     length_normalization : bool
         Whether to divide the scores by the length. Default: True.
     using_max_attn_shift: bool

--- a/speechbrain/inference/interfaces.py
+++ b/speechbrain/inference/interfaces.py
@@ -131,7 +131,7 @@ def foreign_class(
     sys.path.append(str(pymodule_local_path.parent))
 
     # Load the modules:
-    with open(hparams_local_path) as fin:
+    with open(hparams_local_path, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides, overrides_must_match)
 
     hparams["savedir"] = savedir
@@ -504,7 +504,7 @@ class Pretrained(torch.nn.Module):
                 raise
 
         # Load the modules:
-        with open(hparams_local_path) as fin:
+        with open(hparams_local_path, encoding="utf-8") as fin:
             hparams = load_hyperpyyaml(
                 fin, overrides, overrides_must_match=overrides_must_match
             )

--- a/speechbrain/k2_integration/lexicon.py
+++ b/speechbrain/k2_integration/lexicon.py
@@ -471,7 +471,7 @@ def prepare_char_lexicon(
     ...    [1, 1, 1, 1, "hello world"],
     ...    [2, 0.5, 1, 1, "hello"]
     ... ]
-    >>> with open(csv_file, "w", newline="") as f:
+    >>> with open(csv_file, "w", newline="", encoding="utf-8")  as f:
     ...    writer = csv.writer(f)
     ...    writer.writerows(data)
     >>> extra_csv_files = [csv_file]
@@ -483,7 +483,7 @@ def prepare_char_lexicon(
     lexicon = dict()
     if len(extra_csv_files) != 0:
         for file in extra_csv_files:
-            with open(file, "r") as f:
+            with open(file, "r", encoding="utf-8") as f:
                 csv_reader = csv.DictReader(f)
                 for row in csv_reader:
                     # Split the transcription into words
@@ -496,7 +496,7 @@ def prepare_char_lexicon(
                                 lexicon[word] = list(word)
 
     for file in vocab_files:
-        with open(file) as f:
+        with open(file, encoding="utf-8") as f:
             for line in f:
                 # Split the line
                 word = line.strip().split()[0]
@@ -508,7 +508,9 @@ def prepare_char_lexicon(
                         lexicon[word] = list(word)
     # Write the lexicon to lang_dir/lexicon.txt
     os.makedirs(lang_dir, exist_ok=True)
-    with open(os.path.join(lang_dir, "lexicon.txt"), "w") as f:
+    with open(
+        os.path.join(lang_dir, "lexicon.txt"), "w", encoding="utf-8"
+    ) as f:
         fc = f"{UNK} {UNK_t}\n"
         for word in lexicon:
             fc += word + " " + " ".join(lexicon[word]) + "\n"

--- a/speechbrain/k2_integration/utils.py
+++ b/speechbrain/k2_integration/utils.py
@@ -130,7 +130,7 @@ def load_G(path: Union[str, Path], cache: bool = True) -> k2.Fsa:
         raise FileNotFoundError(
             f"File {path} not found. " "You need to run arpa_to_fst to get it."
         )
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         G = k2.Fsa.from_openfst(f.read(), acceptor=False)
         torch.save(G.as_dict(), path[:-8] + ".pt")
     return G

--- a/speechbrain/lm/arpa.py
+++ b/speechbrain/lm/arpa.py
@@ -348,5 +348,5 @@ def arpa_to_fst(
         )
         raise e
     logger.info(f"Writing {out_fst}")
-    with open(out_fst, "w") as f:
+    with open(out_fst, "w", encoding="utf-8") as f:
         f.write(s)

--- a/speechbrain/processing/diarization.py
+++ b/speechbrain/processing/diarization.py
@@ -63,7 +63,7 @@ def read_rttm(rttm_file_path):
         List containing rows of RTTM file.
     """
     rttm = []
-    with open(rttm_file_path, "r") as f:
+    with open(rttm_file_path, "r", encoding="utf-8") as f:
         for line in f:
             entry = line[:-1]
             rttm.append(entry)
@@ -88,7 +88,7 @@ def write_ders_file(ref_rttm, DER, out_der_file):
     rec_id_list = []
     count = 0
 
-    with open(out_der_file, "w") as f:
+    with open(out_der_file, "w", encoding="utf-8") as f:
         for row in spkr_info:
             a = row.split(" ")
             rec_id = a[1]
@@ -123,7 +123,7 @@ def prepare_subset_csv(full_diary_csv, rec_id, out_csv_file):
 
     out_csv = out_csv_head + entry
 
-    with open(out_csv_file, mode="w") as csv_file:
+    with open(out_csv_file, mode="w", newline="", encoding="utf-8") as csv_file:
         csv_writer = csv.writer(
             csv_file, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL
         )
@@ -318,7 +318,7 @@ def write_rttm(segs_list, out_rttm_file):
         ]
         rttm.append(new_row)
 
-    with open(out_rttm_file, "w") as f:
+    with open(out_rttm_file, "w", encoding="utf-8") as f:
         for row in rttm:
             line_str = " ".join(row)
             f.write("%s\n" % line_str)

--- a/speechbrain/tokenizers/SentencePiece.py
+++ b/speechbrain/tokenizers/SentencePiece.py
@@ -215,7 +215,7 @@ class SentencePiece:
             + " sequences from:"
             + self.annotation_train
         )
-        annotation_file = open(self.annotation_train, "r")
+        annotation_file = open(self.annotation_train, "r", encoding="utf-8")
         reader = csv.reader(annotation_file)
         headers = next(reader, None)
         if self.annotation_read not in headers:
@@ -223,7 +223,7 @@ class SentencePiece:
                 self.annotation_read + " must exist in:" + self.annotation_train
             )
         index_label = headers.index(self.annotation_read)
-        text_file = open(self.text_file, "w+")
+        text_file = open(self.text_file, "w+", encoding="utf-8")
         row_idx = 0
         for row in reader:
             if self.num_sequences is not None and row_idx > self.num_sequences:
@@ -257,11 +257,11 @@ class SentencePiece:
         )
 
         # Read JSON
-        with open(self.annotation_train, "r") as f:
+        with open(self.annotation_train, "r", encoding="utf-8") as f:
             out_json = json.load(f)
 
         # Save text file
-        text_file = open(self.text_file, "w+")
+        text_file = open(self.text_file, "w+", encoding="utf-8")
         row_idx = 0
 
         for snt_id in out_json.keys():
@@ -347,7 +347,9 @@ class SentencePiece:
                 )
                 # csv reading
                 if self.annotation_format == "csv":
-                    fannotation_file = open(annotation_file, "r")
+                    fannotation_file = open(
+                        annotation_file, "r", encoding="utf-8"
+                    )
                     reader = csv.reader(fannotation_file)
                     headers = next(reader, None)
                     if self.annotation_read not in headers:
@@ -359,7 +361,9 @@ class SentencePiece:
                     index_label = headers.index(self.annotation_read)
                 # json reading
                 else:
-                    with open(self.annotation_train, "r") as f:
+                    with open(
+                        self.annotation_train, "r", encoding="utf-8"
+                    ) as f:
                         reader = json.load(f)
                         index_label = self.annotation_read
 

--- a/speechbrain/utils/checkpoints.py
+++ b/speechbrain/utils/checkpoints.py
@@ -424,13 +424,13 @@ def register_checkpoint_hooks(cls, save_on_main_only=True):
     ...
     ...     @mark_as_saver
     ...     def save(self, path):
-    ...         with open(path, "w") as fo:
+    ...         with open(path, "w", encoding="utf-8") as fo:
     ...             fo.write(str(self.param))
     ...
     ...     @mark_as_loader
     ...     def load(self, path, end_of_epoch):
     ...         del end_of_epoch  # Unused here
-    ...         with open(path) as fi:
+    ...         with open(path, encoding="utf-8") as fi:
     ...             self.param = int(fi.read())
     """
     global DEFAULT_LOAD_HOOKS
@@ -1194,7 +1194,7 @@ class Checkpointer:
         # directory paths (as produced by _list_checkpoint_dirs)
         checkpoints = []
         for ckpt_dir in checkpoint_dirs:
-            with open(ckpt_dir / METAFNAME) as fi:
+            with open(ckpt_dir / METAFNAME, encoding="utf-8") as fi:
                 meta = yaml.load(fi, Loader=yaml.Loader)
             paramfiles = {}
             for ckptfile in ckpt_dir.iterdir():
@@ -1238,7 +1238,7 @@ class Checkpointer:
         # This internal method saves the meta information in the given path
         meta = {"unixtime": time.time(), "end-of-epoch": end_of_epoch}
         meta.update(meta_to_include)
-        with open(fpath, "w") as fo:
+        with open(fpath, "w", encoding="utf-8") as fo:
             fo.write("# yamllint disable\n")
             fo.write(yaml.dump(meta))
         return meta

--- a/speechbrain/utils/data_utils.py
+++ b/speechbrain/utils/data_utils.py
@@ -188,7 +188,7 @@ def get_list_from_csv(csvfile, field, delimiter=",", skipinitialspace=True):
     The list of files in the given field of a csv
     """
     lst = []
-    with open(csvfile, newline="") as csvf:
+    with open(csvfile, newline="", encoding="utf-8") as csvf:
         reader = csv.DictReader(
             csvf, delimiter=delimiter, skipinitialspace=skipinitialspace
         )

--- a/speechbrain/utils/epoch_loop.py
+++ b/speechbrain/utils/epoch_loop.py
@@ -61,7 +61,7 @@ class EpochCounter:
 
     @mark_as_saver
     def _save(self, path):
-        with open(path, "w") as fo:
+        with open(path, "w", encoding="utf-8") as fo:
             fo.write(str(self.current))
 
     @mark_as_loader
@@ -70,7 +70,7 @@ class EpochCounter:
         #  loaded in parameter transfer, this starts a new epoch.
         #  However, parameter transfer to EpochCounter should
         #  probably never be used really.
-        with open(path) as fi:
+        with open(path, encoding="utf-8") as fi:
             saved_value = int(fi.read())
             if end_of_epoch:
                 self.current = saved_value
@@ -171,7 +171,7 @@ class EpochCounterWithStopper(EpochCounter):
 
     @mark_as_saver
     def _save(self, path):
-        with open(path, "w") as fo:
+        with open(path, "w", encoding="utf-8") as fo:
             yaml.dump(
                 {
                     "current_epoch": self.current,
@@ -185,7 +185,7 @@ class EpochCounterWithStopper(EpochCounter):
     @mark_as_loader
     def _recover(self, path, end_of_epoch=True, device=None):
         del device  # Not used.
-        with open(path) as fi:
+        with open(path, encoding="utf-8") as fi:
             saved_dict = yaml.safe_load(fi)
             if end_of_epoch:
                 self.current = saved_dict["current_epoch"]

--- a/speechbrain/utils/hpopt.py
+++ b/speechbrain/utils/hpopt.py
@@ -387,7 +387,7 @@ class HyperparameterOptimizationContext:
                 hpopt_mode, *self.reporter_args, **self.reporter_kwargs
             )
             if isinstance(hpopt, str) and os.path.exists(hpopt):
-                with open(hpopt) as hpopt_file:
+                with open(hpopt, encoding="utf-8") as hpopt_file:
                     trial_id = get_trial_id()
                     hpopt_overrides = load_hyperpyyaml(
                         hpopt_file,

--- a/speechbrain/utils/logger.py
+++ b/speechbrain/utils/logger.py
@@ -194,7 +194,7 @@ def setup_logging(
         The level to use if the config file is not found.
     """
     if os.path.exists(config_path):
-        with open(config_path, "rt") as f:
+        with open(config_path, "rt", encoding="utf-8") as f:
             config = yaml.safe_load(f)
         recursive_update(config, overrides)
         logging.config.dictConfig(config)

--- a/speechbrain/utils/train_logger.py
+++ b/speechbrain/utils/train_logger.py
@@ -97,7 +97,7 @@ class FileTrainLogger(TrainLogger):
             if stats is not None:
                 string_summary += " - " + self._stats_to_string(stats, dataset)
 
-        with open(self.save_file, "a") as fout:
+        with open(self.save_file, "a", encoding="utf-8") as fout:
             print(string_summary, file=fout)
         if verbose:
             logger.info(string_summary)

--- a/templates/enhancement/mini_librispeech_prepare.py
+++ b/templates/enhancement/mini_librispeech_prepare.py
@@ -102,7 +102,7 @@ def create_json(wav_list, json_file):
         json_dict[uttid] = {"wav": relative_path, "length": duration}
 
     # Writing the dictionary to the json file
-    with open(json_file, mode="w") as json_f:
+    with open(json_file, mode="w", encoding="utf-8") as json_f:
         json.dump(json_dict, json_f, indent=2)
 
     logger.info(f"{json_file} successfully created!")

--- a/templates/enhancement/train.py
+++ b/templates/enhancement/train.py
@@ -268,7 +268,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/templates/hyperparameter_optimization_speaker_id/train.py
+++ b/templates/hyperparameter_optimization_speaker_id/train.py
@@ -296,7 +296,7 @@ if __name__ == "__main__":
         sb.utils.distributed.ddp_init_group(run_opts)
 
         # Load hyperparameters file with command-line overrides.
-        with open(hparams_file) as fin:
+        with open(hparams_file, encoding="utf-8") as fin:
             hparams = load_hyperpyyaml(fin, overrides)
 
         # Create experiment directory

--- a/templates/speaker_id/mini_librispeech_prepare.py
+++ b/templates/speaker_id/mini_librispeech_prepare.py
@@ -120,7 +120,7 @@ def create_json(wav_list, json_file):
         }
 
     # Writing the dictionary to the json file
-    with open(json_file, mode="w") as json_f:
+    with open(json_file, mode="w", encoding="utf-8") as json_f:
         json.dump(json_dict, json_f, indent=2)
 
     logger.info(f"{json_file} successfully created!")

--- a/templates/speaker_id/train.py
+++ b/templates/speaker_id/train.py
@@ -281,7 +281,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides.
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/templates/speech_recognition/ASR/train.py
+++ b/templates/speech_recognition/ASR/train.py
@@ -321,7 +321,7 @@ class ASR(sb.Brain):
                 stats_meta={"Epoch loaded": self.hparams.epoch_counter.current},
                 test_stats=stage_stats,
             )
-            with open(self.hparams.test_wer_file, "w") as w:
+            with open(self.hparams.test_wer_file, "w", encoding="utf-8") as w:
                 self.wer_metric.write_stats(w)
 
 
@@ -439,7 +439,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/templates/speech_recognition/LM/train.py
+++ b/templates/speech_recognition/LM/train.py
@@ -211,7 +211,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/templates/speech_recognition/Tokenizer/train.py
+++ b/templates/speech_recognition/Tokenizer/train.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
 
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Create experiment directory

--- a/templates/speech_recognition/mini_librispeech_prepare.py
+++ b/templates/speech_recognition/mini_librispeech_prepare.py
@@ -101,7 +101,7 @@ def get_transcription(trans_list):
     trans_dict = {}
     for trans_file in trans_list:
         # Reading the text file
-        with open(trans_file) as f:
+        with open(trans_file, encoding="utf-8") as f:
             for line in f:
                 uttid = line.split(" ")[0]
                 text = line.rstrip().split(" ")[1:]
@@ -146,7 +146,7 @@ def create_json(wav_list, trans_dict, json_file):
         }
 
     # Writing the dictionary to the json file
-    with open(json_file, mode="w") as json_f:
+    with open(json_file, mode="w", encoding="utf-8") as json_f:
         json.dump(json_dict, json_f, indent=2)
 
     logger.info(f"{json_file} successfully created!")

--- a/tests/consistency/test_HF_repo.py
+++ b/tests/consistency/test_HF_repo.py
@@ -69,7 +69,9 @@ def repo_list(recipe_folder="tests/recipes", field="HF_repo"):
     # Loop over all recipe CSVs
     for recipe_csvfile in os.listdir(recipe_folder):
         with open(
-            os.path.join(recipe_folder, recipe_csvfile), newline=""
+            os.path.join(recipe_folder, recipe_csvfile),
+            newline="",
+            encoding="utf-8",
         ) as csvf:
             reader = csv.DictReader(csvf, delimiter=",", skipinitialspace=True)
             for row in reader:
@@ -104,7 +106,7 @@ def check_repo(HF_repo):
     code_snippets = []
     code = []
     flag = False
-    with open(dest_file, "r") as f:
+    with open(dest_file, "r", encoding="utf-8") as f:
         for line in f:
             if "```python" in line:
                 flag = True

--- a/tests/consistency/test_recipe.py
+++ b/tests/consistency/test_recipe.py
@@ -140,7 +140,9 @@ def test_mandatory_files(
         if recipe_csvfile in __skip_list:
             continue
         with open(
-            os.path.join(recipe_folder, recipe_csvfile), newline=""
+            os.path.join(recipe_folder, recipe_csvfile),
+            newline="",
+            encoding="utf-8",
         ) as csvf:
             reader = csv.DictReader(csvf, delimiter=",", skipinitialspace=True)
             for row_id, row in enumerate(reader):
@@ -177,7 +179,9 @@ def test_README_links(
         if recipe_csvfile in __skip_list:
             continue
         with open(
-            os.path.join(recipe_folder, recipe_csvfile), newline=""
+            os.path.join(recipe_folder, recipe_csvfile),
+            newline="",
+            encoding="utf-8",
         ) as csvf:
             reader = csv.DictReader(csvf, delimiter=",", skipinitialspace=True)
             for row in reader:

--- a/tests/consistency/test_recipe.py
+++ b/tests/consistency/test_recipe.py
@@ -185,7 +185,9 @@ def test_README_links(
         ) as csvf:
             reader = csv.DictReader(csvf, delimiter=",", skipinitialspace=True)
             for row in reader:
-                with open(row[readme_field].strip()) as readmefile:
+                with open(
+                    row[readme_field].strip(), encoding="utf-8"
+                ) as readmefile:
                     content = readmefile.read()
                     for field in must_link:
                         links = row[field].strip().split(" ")

--- a/tests/consistency/test_yaml.py
+++ b/tests/consistency/test_yaml.py
@@ -30,7 +30,9 @@ def test_yaml_script_consistency(recipe_folder="tests/recipes"):
         if recipe_csvfile in __skip_list:
             continue
         with open(
-            os.path.join(recipe_folder, recipe_csvfile), newline=""
+            os.path.join(recipe_folder, recipe_csvfile),
+            newline="",
+            encoding="utf-8",
         ) as csvfile:
             reader = csv.DictReader(
                 csvfile, delimiter=",", skipinitialspace=True

--- a/tests/integration/ASR_CTC/example_asr_ctc_experiment.py
+++ b/tests/integration/ASR_CTC/example_asr_ctc_experiment.py
@@ -114,7 +114,7 @@ def main(device="cpu"):
     data_folder = (experiment_dir / data_folder).resolve()
 
     # Load model hyper parameters:
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin)
 
     # Dataset creation

--- a/tests/integration/ASR_CTC/example_asr_ctc_experiment_complex_net.py
+++ b/tests/integration/ASR_CTC/example_asr_ctc_experiment_complex_net.py
@@ -114,7 +114,7 @@ def main(device="cpu"):
     data_folder = (experiment_dir / data_folder).resolve()
 
     # Load model hyper parameters:
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin)
 
     # Dataset creation

--- a/tests/integration/ASR_CTC/example_asr_ctc_experiment_quaternion_net.py
+++ b/tests/integration/ASR_CTC/example_asr_ctc_experiment_quaternion_net.py
@@ -114,7 +114,7 @@ def main(device="cpu"):
     data_folder = (experiment_dir / data_folder).resolve()
 
     # Load model hyper parameters:
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin)
 
     # Dataset creation

--- a/tests/integration/ASR_ConformerTransducer_streaming/example_asr_conformertransducer_streaming_experiment.py
+++ b/tests/integration/ASR_ConformerTransducer_streaming/example_asr_conformertransducer_streaming_experiment.py
@@ -244,7 +244,7 @@ def main(device="cpu"):
     data_folder = (experiment_dir / data_folder).resolve()
 
     # Load model hyper parameters:
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin)
 
     # Dataset creation

--- a/tests/integration/ASR_Transducer/example_asr_transducer_experiment.py
+++ b/tests/integration/ASR_Transducer/example_asr_transducer_experiment.py
@@ -141,7 +141,7 @@ def main(device="cpu"):
     data_folder = (experiment_dir / data_folder).resolve()
 
     # Load model hyper parameters:
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin)
 
     # Dataset creation

--- a/tests/integration/ASR_alignment_forward/example_asr_alignment_forward_experiment.py
+++ b/tests/integration/ASR_alignment_forward/example_asr_alignment_forward_experiment.py
@@ -107,7 +107,7 @@ def main(device="cpu"):
     data_folder = (experiment_dir / data_folder).resolve()
 
     # Load model hyper parameters:
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin)
 
     # Dataset creation

--- a/tests/integration/ASR_alignment_viterbi/example_asr_alignment_viterbi_experiment.py
+++ b/tests/integration/ASR_alignment_viterbi/example_asr_alignment_viterbi_experiment.py
@@ -113,7 +113,7 @@ def main(device="cpu"):
     data_folder = (experiment_dir / data_folder).resolve()
 
     # Load model hyper parameters:
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin)
 
     # Dataset creation

--- a/tests/integration/ASR_seq2seq/example_asr_seq2seq_experiment.py
+++ b/tests/integration/ASR_seq2seq/example_asr_seq2seq_experiment.py
@@ -126,7 +126,7 @@ def main(device="cpu"):
     data_folder = (experiment_dir / data_folder).resolve()
 
     # Load model hyper parameters:
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin)
 
     # Dataset creation

--- a/tests/integration/G2P/example_g2p.py
+++ b/tests/integration/G2P/example_g2p.py
@@ -134,7 +134,7 @@ def main(device="cpu"):
     data_folder = (experiment_dir / data_folder).resolve()
 
     # Load model hyper parameters:
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin)
 
     # Dataset creation

--- a/tests/integration/LM_RNN/example_lm_rnn_experiment.py
+++ b/tests/integration/LM_RNN/example_lm_rnn_experiment.py
@@ -93,7 +93,7 @@ def main(device="cpu"):
     data_folder = (experiment_dir / data_folder).resolve()
 
     # Load model hyper parameters:
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin)
 
     # Dataset creation

--- a/tests/integration/VAD/example_vad.py
+++ b/tests/integration/VAD/example_vad.py
@@ -118,7 +118,7 @@ def main(device="cpu"):
     hparams_file = os.path.join(experiment_dir, "hyperparams.yaml")
     data_folder = "/../../samples/VAD"
     data_folder = os.path.abspath(experiment_dir + data_folder)
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin)
 
     # Data IO creation

--- a/tests/integration/augmentation/example_add_noise.py
+++ b/tests/integration/augmentation/example_add_noise.py
@@ -19,7 +19,7 @@ def main():
         "output_folder": output_folder,
         "data_folder": os.path.join(experiment_dir, "..", "..", "samples"),
     }
-    with open(hyperparams_file) as fin:
+    with open(hyperparams_file, encoding="utf-8") as fin:
         hyperparams = load_hyperpyyaml(fin, overrides)
 
     sb.create_experiment_directory(

--- a/tests/integration/augmentation/example_add_reverb.py
+++ b/tests/integration/augmentation/example_add_reverb.py
@@ -19,7 +19,7 @@ def main():
         "output_folder": output_folder,
         "data_folder": os.path.join(experiment_dir, "..", "..", "samples"),
     }
-    with open(hyperparams_file) as fin:
+    with open(hyperparams_file, encoding="utf-8") as fin:
         hyperparams = load_hyperpyyaml(fin, overrides)
 
     sb.create_experiment_directory(

--- a/tests/integration/augmentation/example_do_clip.py
+++ b/tests/integration/augmentation/example_do_clip.py
@@ -19,7 +19,7 @@ def main():
         "output_folder": output_folder,
         "data_folder": os.path.join(experiment_dir, "..", "..", "samples"),
     }
-    with open(hyperparams_file) as fin:
+    with open(hyperparams_file, encoding="utf-8") as fin:
         hyperparams = load_hyperpyyaml(fin, overrides)
 
     sb.create_experiment_directory(

--- a/tests/integration/augmentation/example_drop_chunk.py
+++ b/tests/integration/augmentation/example_drop_chunk.py
@@ -19,7 +19,7 @@ def main():
         "output_folder": output_folder,
         "data_folder": os.path.join(experiment_dir, "..", "..", "samples"),
     }
-    with open(hyperparams_file) as fin:
+    with open(hyperparams_file, encoding="utf-8") as fin:
         hyperparams = load_hyperpyyaml(fin, overrides)
 
     sb.create_experiment_directory(

--- a/tests/integration/augmentation/example_drop_freq.py
+++ b/tests/integration/augmentation/example_drop_freq.py
@@ -19,7 +19,7 @@ def main():
         "output_folder": output_folder,
         "data_folder": os.path.join(experiment_dir, "..", "..", "samples"),
     }
-    with open(hyperparams_file) as fin:
+    with open(hyperparams_file, encoding="utf-8") as fin:
         hyperparams = load_hyperpyyaml(fin, overrides)
 
     sb.create_experiment_directory(

--- a/tests/integration/augmentation/example_speed_perturb.py
+++ b/tests/integration/augmentation/example_speed_perturb.py
@@ -19,7 +19,7 @@ def main():
         "output_folder": output_folder,
         "data_folder": os.path.join(experiment_dir, "..", "..", "samples"),
     }
-    with open(hyperparams_file) as fin:
+    with open(hyperparams_file, encoding="utf-8") as fin:
         hyperparams = load_hyperpyyaml(fin, overrides)
 
     sb.create_experiment_directory(

--- a/tests/integration/autoencoder/example_auto_experiment.py
+++ b/tests/integration/autoencoder/example_auto_experiment.py
@@ -103,7 +103,7 @@ def main(device="cpu"):
     data_folder = (experiment_dir / data_folder).resolve()
 
     # Load model hyper parameters:
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin)
 
     # Dataset creation

--- a/tests/integration/enhance_GAN/example_enhance_gan_experiment.py
+++ b/tests/integration/enhance_GAN/example_enhance_gan_experiment.py
@@ -140,7 +140,7 @@ def main(device="cpu"):
     data_folder = (experiment_dir / data_folder).resolve()
 
     # Load model hyper parameters:
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin)
 
     # Dataset creation

--- a/tests/integration/sampling/example_sorting.py
+++ b/tests/integration/sampling/example_sorting.py
@@ -142,7 +142,7 @@ def recipe(device="cpu", yaml_file="hyperparams.yaml", run_opts=None):
     hparams_file = os.path.join(experiment_dir, yaml_file)
     data_folder = "../../samples/"
     data_folder = (experiment_dir / data_folder).resolve()
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin)
 
     # usually here: sb.utils.distributed.ddp_init_group(run_opts)

--- a/tests/integration/separation/example_conv_tasnet.py
+++ b/tests/integration/separation/example_conv_tasnet.py
@@ -131,7 +131,7 @@ def main(device="cpu"):
     data_folder = (experiment_dir / data_folder).resolve()
 
     # Load model hyper parameters:
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin)
 
     # Dataset creation

--- a/tests/integration/speaker_id/example_xvector_experiment.py
+++ b/tests/integration/speaker_id/example_xvector_experiment.py
@@ -105,7 +105,7 @@ def main(device="cpu"):
     data_folder = (experiment_dir / data_folder).resolve()
 
     # Load model hyper parameters:
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin)
 
     # Dataset creation

--- a/tests/templates/fetching_ddp_dynbatch_finetuning/finetune.py
+++ b/tests/templates/fetching_ddp_dynbatch_finetuning/finetune.py
@@ -173,7 +173,7 @@ if __name__ == "__main__":
     # DDP init
     sb.utils.distributed.ddp_init_group(run_opts)
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Kept aside for later

--- a/tests/templates/fetching_ddp_dynbatch_finetuning/finetune_fetch_once.py
+++ b/tests/templates/fetching_ddp_dynbatch_finetuning/finetune_fetch_once.py
@@ -173,7 +173,7 @@ if __name__ == "__main__":
     # DDP init
     sb.utils.distributed.ddp_init_group(run_opts)
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     # Kept aside for later

--- a/tests/templates/fetching_ddp_dynbatch_finetuning/multisource_mini_recipe.py
+++ b/tests/templates/fetching_ddp_dynbatch_finetuning/multisource_mini_recipe.py
@@ -152,7 +152,7 @@ class SLU(sb.Brain):
                 stats_meta={"Epoch loaded": self.hparams.epoch_counter.current},
                 test_stats=stage_stats,
             )
-            with open(self.hparams.test_wer_file, "w") as w:
+            with open(self.hparams.test_wer_file, "w", encoding="utf-8") as w:
                 self.wer_metric.write_stats(w)
 
 
@@ -284,7 +284,7 @@ if __name__ == "__main__":
 
     # Load hyperparameters file with command-line overrides
     hparams_file, run_opts, overrides = sb.parse_arguments(sys.argv[1:])
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides)
 
     show_results_every = 100  # plots results every N iterations

--- a/tests/unittests/test_augment.py
+++ b/tests/unittests/test_augment.py
@@ -35,7 +35,7 @@ def test_add_noise(tmpdir, device):
     write_audio(noisefile, test_noise.transpose(0, 1).cpu(), 16000)
 
     csv = os.path.join(tmpdir, "noise.csv")
-    with open(csv, "w") as w:
+    with open(csv, "w", encoding="utf-8") as w:
         w.write("ID, duration, wav, wav_format, wav_opts\n")
         w.write(f"1, 1.0, {noisefile}, wav,\n")
 
@@ -77,7 +77,7 @@ def test_add_reverb(tmpdir, device):
 
     # write ir csv file
     csv = os.path.join(tmpdir, "ir.csv")
-    with open(csv, "w") as w:
+    with open(csv, "w", encoding="utf-8") as w:
         w.write("ID, duration, wav, wav_format, wav_opts\n")
         w.write(f"1, 0.5, {ir1}, wav,\n")
         w.write(f"2, 0.5, {ir2}, wav,\n")

--- a/tests/unittests/test_checkpoints.py
+++ b/tests/unittests/test_checkpoints.py
@@ -116,13 +116,13 @@ def test_recovery_custom_io(tmpdir):
 
         @mark_as_saver
         def save(self, path):
-            with open(path, "w") as fo:
+            with open(path, "w", encoding="utf-8") as fo:
                 fo.write(str(self.param))
 
         @mark_as_loader
         def load(self, path, end_of_epoch):
             del end_of_epoch  # Unused
-            with open(path) as fi:
+            with open(path, encoding="utf-8") as fi:
                 self.param = int(fi.read())
 
     custom_recoverable = CustomRecoverable(0)
@@ -335,13 +335,13 @@ def test_checkpoint_hook_register(tmpdir):
 
         @mark_as_saver
         def save(self, path):
-            with open(path, "w") as fo:
+            with open(path, "w", encoding="utf-8") as fo:
                 fo.write(str(self.param))
 
         @mark_as_loader
         def load(self, path, end_of_epoch):
             del end_of_epoch  # Unused
-            with open(path) as fi:
+            with open(path, encoding="utf-8") as fi:
                 self.param = int(fi.read())
 
     recoverable = CustomRecoverable(1.0)
@@ -359,12 +359,12 @@ def test_checkpoint_hook_register(tmpdir):
                 self.param = int(param)
 
             def save(self, path):
-                with open(path, "w") as fo:
+                with open(path, "w", encoding="utf-8") as fo:
                     fo.write(str(self.param))
 
             @mark_as_loader
             def load(self, path):  # MISSING end_of_epoch
-                with open(path) as fi:
+                with open(path, encoding="utf-8") as fi:
                     self.param = int(fi.read())
 
     with pytest.raises(TypeError):
@@ -375,12 +375,12 @@ def test_checkpoint_hook_register(tmpdir):
 
             @mark_as_saver
             def save(self, path, extra_arg):  # Extra argument
-                with open(path, "w") as fo:
+                with open(path, "w", encoding="utf-8") as fo:
                     fo.write(str(self.param))
 
             def load(self, path, end_of_epoch):
                 del end_of_epoch  # Unused
-                with open(path) as fi:
+                with open(path, encoding="utf-8") as fi:
                     self.param = int(fi.read())
 
 

--- a/tests/unittests/test_k2.py
+++ b/tests/unittests/test_k2.py
@@ -16,7 +16,7 @@ logger = get_logger(__name__)
 @pytest.fixture
 def tmp_csv_file(tmp_path):
     csv_file = tmp_path / "train.csv"
-    with open(csv_file, "w") as f:
+    with open(csv_file, "w", encoding="utf-8") as f:
         f.write("ID,duration,wav,spk_id,wrd\n")
         f.write("1,1,1,1,hello world\n")
         f.write("2,0.5,1,1,hello\n")
@@ -37,7 +37,7 @@ def test_get_lexicon(tmp_path, tmp_csv_file):
     )
 
     # Read the output and assert its content
-    with open(lang_dir / "lexicon.txt", "r") as f:
+    with open(lang_dir / "lexicon.txt", "r", encoding="utf-8") as f:
         assert f.read() == "<UNK> <unk>\nhello h e l l o\nworld w o r l d\n"
 
 
@@ -55,7 +55,7 @@ def test_get_lexicon_with_boundary(tmp_path, tmp_csv_file):
     )
 
     # Read the output and assert its content
-    with open(lang_dir / "lexicon.txt", "r") as f:
+    with open(lang_dir / "lexicon.txt", "r", encoding="utf-8") as f:
         assert (
             f.read()
             == "<UNK> <unk>\nhello h e l l o <eow>\nworld w o r l d <eow>\n"
@@ -66,7 +66,7 @@ def test_get_lexicon_with_boundary(tmp_path, tmp_csv_file):
 def mock_lexicon_file(tmp_path):
     lexicon_content = "hello h e l l o\nworld w o r l d\n"
     lexicon_file = tmp_path / "mock_lexicon.txt"
-    with open(lexicon_file, "w") as f:
+    with open(lexicon_file, "w", encoding="utf-8") as f:
         f.write(lexicon_content)
     return lexicon_file
 
@@ -102,7 +102,7 @@ def test_write_lexicon(tmp_path):
     expected_content = "hello h e l l o\nworld w o r l d\n"
 
     # Read back the content of the file and assert its correctness.
-    with open(lexicon_file, "r") as f:
+    with open(lexicon_file, "r", encoding="utf-8") as f:
         assert f.read() == expected_content
 
 
@@ -285,7 +285,9 @@ def test_prepare_lang():
     hello h e l l o
     world w o r l d
     """
-    with open(os.path.join(temp_dir, "lexicon.txt"), "w") as f:
+    with open(
+        os.path.join(temp_dir, "lexicon.txt"), "w", encoding="utf-8"
+    ) as f:
         f.write(lexicon_content.strip())
 
     # Step 2: Run prepare_lang
@@ -317,7 +319,7 @@ def test_lexicon_loading_and_conversion():
 hello h e l l o
 world w o r l d"""
         lexicon_file = tmpdir_path.joinpath("lexicon.txt")
-        with open(lexicon_file, "w") as f:
+        with open(lexicon_file, "w", encoding="utf-8") as f:
             f.write(lexicon_sample)
 
         # Create a lang directory with the lexicon and L.pt, L_inv.pt, L_disambig.pt using prepare_lang
@@ -381,7 +383,7 @@ def test_ctc_k2_loss():
 hello h e l l o
 world w o r l d"""
         lexicon_file_path = f"{tmpdir}/lexicon.txt"
-        with open(lexicon_file_path, "w") as f:
+        with open(lexicon_file_path, "w", encoding="utf-8") as f:
             f.write(lexicon_sample)
 
         # Create a lang directory with the lexicon and L.pt, L_inv.pt, L_disambig.pt

--- a/tests/utils/check_HF_repo.py
+++ b/tests/utils/check_HF_repo.py
@@ -73,7 +73,9 @@ def repo_list(recipe_folder="tests/recipes", field="HF_repo"):
             continue
 
         with open(
-            os.path.join(recipe_folder, recipe_csvfile), newline=""
+            os.path.join(recipe_folder, recipe_csvfile),
+            newline="",
+            encoding="utf-8",
         ) as csvf:
             reader = csv.DictReader(csvf, delimiter=",", skipinitialspace=True)
             for row in reader:
@@ -113,7 +115,7 @@ def check_repo(HF_repo):
     code = []
     flag = False
     check = True
-    with open(dest_file, "r") as f:
+    with open(dest_file, "r", encoding="utf-8") as f:
         for line in f:
             if "```python" in line:
                 flag = True

--- a/tests/utils/check_docstrings.py
+++ b/tests/utils/check_docstrings.py
@@ -72,7 +72,7 @@ def check_docstrings(
         check_line = True
         is_class = False
         first_line = True
-        with open(libpath) as f:
+        with open(libpath, encoding="utf-8") as f:
             for line in f:
 
                 # Remove spaces or tabs

--- a/tests/utils/check_url.py
+++ b/tests/utils/check_url.py
@@ -49,7 +49,7 @@ def find_urls_in_file(path, line_exclude_regex):
         return False
 
     # Read the file
-    with open(path, "r") as file:
+    with open(path, "r", encoding="utf-8") as file:
         text = file.read()
 
     lines = text.split("\n")

--- a/tests/utils/check_yaml.py
+++ b/tests/utils/check_yaml.py
@@ -27,7 +27,7 @@ def get_yaml_var(hparam_file):
         included).
     """
     var_lst = []
-    with open(hparam_file) as f:
+    with open(hparam_file, encoding="utf-8") as f:
         for line in f:
             # Avoid empty lists or comments - skip pretrainer definitions
             if (
@@ -90,7 +90,7 @@ def detect_script_vars(script_file, var_lst):
         'hparams.get("',
     ]
     detected_var = []
-    with open(script_file) as f:
+    with open(script_file, encoding="utf-8") as f:
         for line in f:
             for var in var_lst:
                 # The pattern can be ["key"] or ".key"
@@ -266,7 +266,7 @@ def check_module_vars(
 
     # Extract Modules variables from the hparam file
     module_vars_hparams = []
-    with open(hparam_file) as f:
+    with open(hparam_file, encoding="utf-8") as f:
         for line in f:
             if module_key in line:
                 module_block = True
@@ -279,7 +279,7 @@ def check_module_vars(
                 module_vars_hparams.append(var)
 
     # Extract Modules variables from the script file
-    with open(script_file) as file:
+    with open(script_file, encoding="utf-8") as file:
         lines = file.readlines()
         lines = [line.rstrip() for line in lines]
 

--- a/tests/utils/recipe_tests.py
+++ b/tests/utils/recipe_tests.py
@@ -139,7 +139,9 @@ def prepare_test(
         logger.info(f"Loading recipes from: {recipe_csvfile}")
         # Detect needed information for the recipe tests
         with open(
-            os.path.join(recipe_folder, recipe_csvfile), newline=""
+            os.path.join(recipe_folder, recipe_csvfile),
+            newline="",
+            encoding="utf-8",
         ) as csvf:
             reader = csv.DictReader(csvf, delimiter=",", skipinitialspace=True)
             for row_id, row in enumerate(reader):
@@ -256,7 +258,7 @@ def check_performance(
         return False
 
     # Real all the lines of the performance file
-    with open(filename) as file:
+    with open(filename, encoding="utf-8") as file:
         lines = file.readlines()
 
     # Filter the lines
@@ -407,8 +409,8 @@ def run_test_cmd(cmd, stdout_file, stderr_file):
         The return code obtained after running the command. If 0, the test is
         run without errors. If >0 the execution failed.
     """
-    f_stdout = open(stdout_file, "w")
-    f_stderr = open(stderr_file, "w")
+    f_stdout = open(stdout_file, "w", encoding="utf-8")
+    f_stderr = open(stderr_file, "w", encoding="utf-8")
     child = sp.Popen([cmd], stdout=f_stdout, stderr=f_stderr, shell=True)
     child.communicate()[0]
     rc = child.returncode
@@ -671,11 +673,11 @@ def download_only_test(
         cmd = (
             "python -c 'import sys;from hyperpyyaml import load_hyperpyyaml;import speechbrain;"
             "hparams_file, run_opts, overrides = speechbrain.parse_arguments(sys.argv[1:]);"
-            "fin=open(hparams_file);hparams = load_hyperpyyaml(fin, overrides);fin.close();"
+            "fin=open(hparams_file, encoding='utf-8');hparams = load_hyperpyyaml(fin, overrides);fin.close();"
             # 'speechbrain.create_experiment_directory(experiment_directory=hparams["output_folder"],'
             # 'hyperparams_to_save=hparams_file,overrides=overrides,);'
         )
-        with open(test_hparam[recipe_id]) as hparam_file:
+        with open(test_hparam[recipe_id], encoding="utf-8") as hparam_file:
             for line in hparam_file:
                 if "pretrainer" in line:
                     cmd += 'hparams["pretrainer"].collect_files();hparams["pretrainer"].load_collected(device="cpu");'
@@ -820,7 +822,7 @@ def load_yaml_test(
 
         tag_custom_model = None
         # Append additional overrides when needed
-        with open(hparam_file) as f:
+        with open(hparam_file, encoding="utf-8") as f:
             for line in f:
                 # os.chdir(run_folder) is not changing sys.module, and pydoc.locate (in load_hyperpyyaml) fails
                 if "new:custom_model" in line:
@@ -851,7 +853,7 @@ def load_yaml_test(
                     if pattern in line and line.find(pattern) == 0:
                         overrides.update({key: value})
 
-        with open(hparam_file) as fin:
+        with open(hparam_file, encoding="utf-8") as fin:
             try:
                 _ = load_hyperpyyaml(fin, overrides)
             except Exception as e:

--- a/tests/utils/refactoring_checks.py
+++ b/tests/utils/refactoring_checks.py
@@ -222,7 +222,7 @@ def gather_expected_results(
     """
     # load results, if existing -or- new from scratch
     if os.path.exists(yaml_path):
-        with open(yaml_path) as yaml_in:
+        with open(yaml_path, encoding="utf-8") as yaml_in:
             results = yaml.safe_load(yaml_in)
     else:
         results = {}
@@ -236,7 +236,9 @@ def gather_expected_results(
         # skip if results are there
         if repo not in results.keys():
             # get values
-            with open(f"{updates_dir}/{repo}/test.yaml") as yaml_test:
+            with open(
+                f"{updates_dir}/{repo}/test.yaml", encoding="utf-8"
+            ) as yaml_test:
                 values = load_hyperpyyaml(yaml_test)
 
             print(f"Collecting results for: {repo} w/ values={values}")
@@ -244,7 +246,7 @@ def gather_expected_results(
 
             # extend the results
             results[repo] = {"before": prediction}
-            with open(yaml_path, "w") as yaml_out:
+            with open(yaml_path, "w", encoding="utf-8") as yaml_out:
                 yaml.dump(results, yaml_out, default_flow_style=None)
 
 
@@ -273,7 +275,7 @@ def gather_refactoring_results(
     """
     # expected results need to exist
     if os.path.exists(yaml_path):
-        with open(yaml_path) as yaml_in:
+        with open(yaml_path, encoding="utf-8") as yaml_in:
             results = yaml.safe_load(yaml_in)
 
     # go through each repo
@@ -285,7 +287,9 @@ def gather_refactoring_results(
         # skip if results are there
         if "after" not in results[repo].keys():
             # get values
-            with open(f"{updates_dir}/{repo}/test.yaml") as yaml_test:
+            with open(
+                f"{updates_dir}/{repo}/test.yaml", encoding="utf-8"
+            ) as yaml_test:
                 values = load_hyperpyyaml(yaml_test)
 
             print(
@@ -299,7 +303,7 @@ def gather_refactoring_results(
             )
 
             # update
-            with open(yaml_path, "w") as yaml_out:
+            with open(yaml_path, "w", encoding="utf-8") as yaml_out:
                 yaml.dump(results, yaml_out, default_flow_style=None)
 
             print(f"\tsame: {results[repo]['same']}")
@@ -343,7 +347,7 @@ def test_performance(
     )  # noqa
 
     # Dataio preparation; we need the test sets only
-    with open(values["recipe_yaml"]) as fin:
+    with open(values["recipe_yaml"], encoding="utf-8") as fin:
         recipe_hparams = load_hyperpyyaml(
             fin, values["overrides"] | recipe_overrides
         )
@@ -418,7 +422,7 @@ if __name__ == "__main__":
         sys.argv[1:]
     )
 
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         dataset_overrides = load_hyperpyyaml(fin, overrides)
 
     # go through each repo
@@ -431,7 +435,7 @@ if __name__ == "__main__":
     # load results, if existing -or- new from scratch
     yaml_path = f'{dataset_overrides["new_interfaces_local_dir"]}.yaml'
     if os.path.exists(yaml_path):
-        with open(yaml_path) as yaml_in:
+        with open(yaml_path, encoding="utf-8") as yaml_in:
             results = yaml.safe_load(yaml_in)
     else:
         results = {}
@@ -442,7 +446,9 @@ if __name__ == "__main__":
     )
     for repo in repos:
         # get values
-        with open(f"{updates_dir}/{repo}/test.yaml") as yaml_test:
+        with open(
+            f"{updates_dir}/{repo}/test.yaml", encoding="utf-8"
+        ) as yaml_test:
             values = load_hyperpyyaml(yaml_test)
 
         # for this testing, some fields need to exist; skip otherwise
@@ -481,7 +487,7 @@ if __name__ == "__main__":
             )
 
             # update
-            with open(yaml_path, "w") as yaml_out:
+            with open(yaml_path, "w", encoding="utf-8") as yaml_out:
                 yaml.dump(results, yaml_out, default_flow_style=None)
 
         # After refactoring
@@ -505,9 +511,9 @@ if __name__ == "__main__":
             print(f'\t  same: {results[repo]["same"]}')
 
             # update
-            with open(yaml_path, "w") as yaml_out:
+            with open(yaml_path, "w", encoding="utf-8") as yaml_out:
                 yaml.dump(results, yaml_out, default_flow_style=None)
 
     # update
-    with open(yaml_path, "w") as yaml_out:
+    with open(yaml_path, "w", encoding="utf-8") as yaml_out:
         yaml.dump(results, yaml_out, default_flow_style=None)

--- a/tools/compute_wer.py
+++ b/tools/compute_wer.py
@@ -43,7 +43,7 @@ import speechbrain.utils.edit_distance as edit_distance
 # These internal utilities read Kaldi-style text/utt2spk files:
 def _plain_text_reader(path):
     # yields key, token_list
-    with open(path, "r") as fi:
+    with open(path, "r", encoding="utf-8") as fi:
         for line in fi:
             key, *tokens = line.strip().split()
             yield key, tokens
@@ -58,7 +58,7 @@ def _plain_text_keydict(path):
 
 def _utt2spk_keydict(path):
     utt2spk = {}
-    with open(path, "r") as fi:
+    with open(path, "r", encoding="utf-8") as fi:
         for line in fi:
             utt, spk = line.strip().split()
             utt2spk[utt] = spk

--- a/tools/g2p.py
+++ b/tools/g2p.py
@@ -109,13 +109,13 @@ def transcribe_file(g2p, text_file_name, output_file_name=None, batch_size=64):
 
     """
     line_count = get_line_count(text_file_name)
-    with open(text_file_name) as text_file:
+    with open(text_file_name, encoding="utf-8") as text_file:
         if output_file_name is None:
             transcribe_stream(
                 g2p, text_file, sys.stdout, batch_size, total=line_count
             )
         else:
-            with open(output_file_name, "w") as output_file:
+            with open(output_file_name, "w", encoding="utf-8") as output_file:
                 transcribe_stream(
                     g2p, text_file, output_file, batch_size, total=line_count
                 )
@@ -135,7 +135,7 @@ def get_line_count(text_file_name):
     line_count: int
         the number of lines in the file
     """
-    with open(text_file_name) as text_file:
+    with open(text_file_name, encoding="utf-8") as text_file:
         return sum(1 for _ in text_file)
 
 
@@ -306,7 +306,7 @@ def load_g2p_checkpoint(
     g2p: speechbrain.inference.text.GraphemeToPhoneme
         a pretrained G2P model, initialized from a checkpoint
     """
-    with open(hparams_file_name) as hparams_file:
+    with open(hparams_file_name, encoding="utf-8") as hparams_file:
         hparams = load_hyperpyyaml(hparams_file, overrides)
     checkpointer = hparams.get("checkpointer")
     if checkpointer is None:

--- a/tools/profiling/profile.py
+++ b/tools/profiling/profile.py
@@ -338,7 +338,7 @@ def profile_pretrained(
 
     # Store tables
     print("\n\tReal-time factor")
-    with open("benchmark_realtime_factors.md", "w") as f:
+    with open("benchmark_realtime_factors.md", "w", encoding="utf-8") as f:
         f.write(
             benchmark_to_markdown(
                 benchmark=realtime_factor,
@@ -348,7 +348,7 @@ def profile_pretrained(
         )
 
     print("\n\tPeak memory")
-    with open("benchmark_memory_peaks.md", "w") as f:
+    with open("benchmark_memory_peaks.md", "w", encoding="utf-8") as f:
         f.write(
             benchmark_to_markdown(
                 benchmark=memory_peaks,
@@ -366,7 +366,7 @@ if __name__ == "__main__":
     sb.utils.distributed.ddp_init_group(run_opts)
 
     # Load hyperparameters file with command-line overrides
-    with open(hparams_file) as fin:
+    with open(hparams_file, encoding="utf-8") as fin:
         hparams = load_hyperpyyaml(fin, overrides, overrides_must_match=False)
 
     # Ensure profiling dimensions are set

--- a/tools/readme_builder.py
+++ b/tools/readme_builder.py
@@ -36,7 +36,7 @@ def create_table(fid_w, csv_file):
         None
     """
     # Read CSV file into a list of dictionaries
-    with open(csv_file, "r") as file:
+    with open(csv_file, "r", encoding="utf-8") as file:
         csv_reader = csv.DictReader(file)
         recipes_lst = [row for row in csv_reader]
 
@@ -136,7 +136,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    file_w = open(args.output_file, "w")
+    file_w = open(args.output_file, "w", encoding="utf-8")
 
     # List of recipe files
     recipe_files = get_all_files(

--- a/tools/tutorial-cell-updater.py
+++ b/tools/tutorial-cell-updater.py
@@ -107,7 +107,7 @@ def update_notebook(fname: str):
 
     tutorial_path = fname.replace("./", "")
 
-    with open(fname) as f:
+    with open(fname, encoding="utf-8") as f:
         nb = json.load(f)
 
         cells = nb["cells"]
@@ -128,7 +128,7 @@ def update_notebook(fname: str):
 
         update_footer_cell(footer_cell)
 
-    with open(fname, "w") as wf:
+    with open(fname, "w", encoding="utf-8") as wf:
         json.dump(nb, wf, indent=1, ensure_ascii=False)
         print(file=wf)  # print final newline that jupyter adds apparently
 


### PR DESCRIPTION
## What does this PR do?

This PR makes calls to `open` use UTF-8 encoding.

The current behaviour is that the encoding depends on the local environment. Under Linux, if environment variable `LC_ALL=C.UTF-8` is set, files are read as UTF-8. However, we have found that in practice, behaviour changes from user to user or machine to machine, and transcriptions with non-ASCII characters get messed up. This PR makes the behaviour deterministic.

When opening files for `csv`, this also add `newline=""`, as required by <https://docs.python.org/3/library/csv.html#csv.reader>.

*Change after review*: the PR now also adds a check for the encoding to the pre-commit checks.

## Breaking changes

For users/machines that have `LC_ALL=C.UTF-8` set, nothing changes. For users/machines that have `LC_ALL` set differently, the behaviour changes to the correct one.

## Remarks

* I believe I have changed all relevant calls to `open` but it is possible I have missed some. This highlights that it might have been better to have all parsing, including calls to `open`, in one place instead of scattered around.
* This is a bit of a big PR that touches many files. I'd be happy to split it up into multiple changes per subdirectory or something if that's more useful.
* I have not been able to run all recipes.

cc @TParcollet for visibility.
