### PR TITLE
Allow importing model params with `convs_intermedite` typo in `PostNet`

### DIFF
--- a/speechbrain/utils/checkpoints.py
+++ b/speechbrain/utils/checkpoints.py
@@ -81,6 +81,7 @@ PARAMFILE_EXT = ".ckpt"  # ...because these files will be
 # some keys have been renamed in the new version of the code
 KEYS_MAPPING: Dict[str, str] = {
     ".mutihead_attn": ".multihead_attn",  # see PR #2489
+    ".convs_intermedite": ".convs_intermediate",  # fix for PostNet blame #2463
 }
 
 


### PR DESCRIPTION
## What does this PR do?

This fixes importing some (older?) models that were failing to import otherwise.  
Putting it as a PR to make it easier to find but not bothering with review since this is a very minor fix that shouldn't be functionally different (`convs_intermedite` no longer has any reference in codebase)