### PR TITLE
Readthedocs now requires a `sphinx.configuration` key

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,3 +13,8 @@ python:
 
 # Don't build any extra formats
 formats: []
+
+# Path to sphinx config file, as per the change outlined in
+# https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
Docs builds are failing due to a new requirement from Read the Docs -- a certain `sphinx.configuration` key, as outlined in this blog post:

https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

This change should add the required key.