### PR TITLE
Convert data download methods to run on main process only

### DIFF
--- a/speechbrain/augment/preparation.py
+++ b/speechbrain/augment/preparation.py
@@ -12,12 +12,14 @@ import os
 import torchaudio
 
 from speechbrain.utils.data_utils import download_file, get_all_files
+from speechbrain.utils.distributed import main_process_only
 from speechbrain.utils.logger import get_logger
 
 # Logger init
 logger = get_logger(__name__)
 
 
+@main_process_only
 def prepare_dataset_from_URL(URL, dest_folder, ext, csv_file, max_length=None):
     """Downloads a dataset containing recordings (e.g., noise sequences)
     from the provided URL and prepares the necessary CSV files for use by the noise augmenter.
@@ -51,6 +53,7 @@ def prepare_dataset_from_URL(URL, dest_folder, ext, csv_file, max_length=None):
         prepare_csv(filelist, csv_file, max_length)
 
 
+@main_process_only
 def prepare_csv(filelist, csv_file, max_length=None):
     """Iterate a set of wavs and write the corresponding csv file.
 
@@ -75,6 +78,7 @@ def prepare_csv(filelist, csv_file, max_length=None):
             os.remove(csv_file)
 
 
+@main_process_only
 def write_csv(filelist, csv_file, max_length=None):
     """
     Iterate through a list of audio files and write the corresponding CSV file.


### PR DESCRIPTION
Currently recipes with noise/rir augmentations have to add lines to the `train.py` and cannot rely solely on the yaml due to the multiprocessing requirement. This fix allows us to download the noise/rir directly in the `yaml` using something like:

```yaml
# Download and prepare the dataset of noisy sequences for augmentation
prepare_noise_data: !apply:speechbrain.augment.preparation.prepare_dataset_from_URL
    URL: !ref <NOISE_DATASET_URL>
    dest_folder: !ref <data_folder_noise>
    ext: wav
    csv_file: !ref <noise_annotation>
```