### PR TITLE
Fix Mimi Bug

### DIFF
--- a/speechbrain/lobes/models/discrete/speechtokenizer.py
+++ b/speechbrain/lobes/models/discrete/speechtokenizer.py
@@ -37,6 +37,8 @@ class SpeechTokenizer(nn.Module):
         HuggingFace hub name: e.g "fnlp/SpeechTokenizer"
     save_path : str
         Path (dir) of the downloaded model.
+    sample_rate : int (default: 16000)
+        The audio sampling rate
 
     Example
     -------
@@ -57,6 +59,7 @@ class SpeechTokenizer(nn.Module):
         self,
         source,
         save_path,
+        sample_rate=16000,
     ):
 
         # Lazy import to avoid circular dependency issues
@@ -84,6 +87,7 @@ class SpeechTokenizer(nn.Module):
             config_path, ckpt_path
         )
         self.model.eval()
+        self.sample_rate = sample_rate
 
     def forward(self, wav, wav_lens=None):
         """Takes an input waveform and return its corresponding wav2vec encoding.

--- a/speechbrain/lobes/models/discrete/wavtokenizer.py
+++ b/speechbrain/lobes/models/discrete/wavtokenizer.py
@@ -91,6 +91,7 @@ class WavTokenizer(nn.Module):
             config_path, checkpoint_path
         )
         self.embeddings = self._compute_embedding()
+        self.sample_rate = sample_rate
 
     def forward(self, inputs):
         """Encodes the input audio as tokens and embeddings and  decodes audio from tokens

--- a/speechbrain/lobes/models/huggingface_transformers/mimi.py
+++ b/speechbrain/lobes/models/huggingface_transformers/mimi.py
@@ -78,8 +78,8 @@ class Mimi(HFTransformersInterface):
 
         super().__init__(source=source, save_path=save_path, freeze=freeze)
         self.num_codebooks = num_codebooks
-        self.sampling_rate = sample_rate
-        self.embeddings = self._compute_embedding()
+        self.sample_rate = sample_rate
+        self.embeddings = None
 
     @torch.no_grad()
     def _compute_embedding(self):
@@ -115,6 +115,9 @@ class Mimi(HFTransformersInterface):
         audio : torch.Tensor
             the reconstructed audio
         """
+        if self.embeddings is None:
+            self.embeddings = self._compute_embedding()
+
         tokens, embedding = self.encode(inputs, length)
         audio = self.decode(tokens, length)
 
@@ -139,6 +142,9 @@ class Mimi(HFTransformersInterface):
             Raw vector embeddings from the model's
             quantizers
         """
+        if self.embeddings is None:
+            self.embeddings = self._compute_embedding()
+
         if inputs.dim() == 2:
             inputs = inputs.unsqueeze(1)
         max_len = inputs.size(-1)
@@ -178,6 +184,9 @@ class Mimi(HFTransformersInterface):
         audio : torch.Tensor
             the reconstructed audio
         """
+        if self.embeddings is None:
+            self.embeddings = self._compute_embedding()
+
         result = self.model.decode(tokens)
         audio = result.audio_values
         if length is not None:

--- a/speechbrain/lobes/models/huggingface_transformers/mimi.py
+++ b/speechbrain/lobes/models/huggingface_transformers/mimi.py
@@ -70,7 +70,7 @@ class Mimi(HFTransformersInterface):
     def __init__(
         self,
         source,
-        save_path=None,
+        save_path,
         sample_rate=24000,
         freeze=True,
         num_codebooks=8,
@@ -115,8 +115,6 @@ class Mimi(HFTransformersInterface):
         audio : torch.Tensor
             the reconstructed audio
         """
-        if self.embeddings is None:
-            self.embeddings = self._compute_embedding()
 
         tokens, embedding = self.encode(inputs, length)
         audio = self.decode(tokens, length)


### PR DESCRIPTION
## What does this PR do?

- Mimi does not function correctly on CUDA because the embeddings are always loaded onto the CPU (in the __init__ function) and are never transferred to CUDA. To address this, I followed the approach in the original code by calling _compute_embedding within the forward or encode function on the first call to ensure the embeddings are loaded onto the correct device.

- Added a sampling_rate attribute for both WavTokenizer and SpeechTokenizer.

-->

Fixes #<issue_number>

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
