### PR TITLE
Fix #2784 by handling 1-D case for BCE loss

### DIFF
--- a/speechbrain/nnet/losses.py
+++ b/speechbrain/nnet/losses.py
@@ -540,8 +540,10 @@ def bce_loss(
         # In 1-dimensional case, add singleton dimension for time
         # so that we don't run into errors with the time-masked loss
         inputs, targets = inputs.unsqueeze(-1), targets.unsqueeze(-1)
-        if weight is not None and weight.dim() == 1:
-            weight = weight.unsqueeze(-1)
+
+    # input / target cannot be 1D so bump weight up to match
+    if weight is not None and weight.dim() == 1:
+        weight = weight.unsqueeze(-1)
 
     # Pass the loss function but apply reduction="none" first
     loss = functools.partial(

--- a/speechbrain/nnet/losses.py
+++ b/speechbrain/nnet/losses.py
@@ -536,6 +536,10 @@ def bce_loss(
         inputs, targets = truncate(inputs, targets, allowed_len_diff)
     elif length is not None:
         raise ValueError("length can be passed only for >= 2D inputs.")
+    else:
+        # In 1-dimensional case, add singleton dimension for time
+        # so that we don't run into errors with the time-masked loss
+        inputs, targets = inputs.unsqueeze(-1), targets.unsqueeze(-1)
 
     # Pass the loss function but apply reduction="none" first
     loss = functools.partial(

--- a/speechbrain/nnet/losses.py
+++ b/speechbrain/nnet/losses.py
@@ -540,6 +540,8 @@ def bce_loss(
         # In 1-dimensional case, add singleton dimension for time
         # so that we don't run into errors with the time-masked loss
         inputs, targets = inputs.unsqueeze(-1), targets.unsqueeze(-1)
+        if weight is not None and weight.dim() == 1:
+            weight = weight.unsqueeze(-1)
 
     # Pass the loss function but apply reduction="none" first
     loss = functools.partial(

--- a/tests/unittests/test_losses.py
+++ b/tests/unittests/test_losses.py
@@ -63,6 +63,19 @@ def test_bce_loss(device):
     with pytest.raises(ValueError):
         bce_loss(predictions, targets, length=torch.ones(5, device=device))
 
+    # Try with weight
+    weight = torch.full((5,), 0.5)
+    out_cost = bce_loss(predictions, targets, weight=weight)
+    assert torch.allclose(
+        torch.exp(out_cost), torch.tensor(2.0, device=device).sqrt()
+    )
+
+    # Try with smoothing
+    out_cost = bce_loss(predictions, targets, label_smoothing=0.5)
+    assert torch.allclose(
+        torch.exp(out_cost), torch.tensor(2.0, device=device).sqrt()
+    )
+
 
 def test_classification_error(device):
     from speechbrain.nnet.losses import classification_error


### PR DESCRIPTION
Fixes #2784 

One can check by simply running this code on develop and on this branch:

```python
>>> import torch, speechbrain
>>> a, b = torch.tensor([2.4, -3.5]), torch.tensor([1.0, 0.0])
>>> speechbrain.nnet.losses.bce_loss(a, b, label_smoothing=0.1)
```