### PR TITLE
[URGENT] Fix DDP broadcasting

### DIFF
--- a/recipes/LibriSpeech/self-supervised-learning/BEST-RQ/hparams/BEST-RQ.yaml
+++ b/recipes/LibriSpeech/self-supervised-learning/BEST-RQ/hparams/BEST-RQ.yaml
@@ -69,7 +69,7 @@ d_ffn: 2048
 transformer_dropout: 0.1
 activation: !name:torch.nn.GELU
 output_neurons: 5000
-encoder_layerdrop: 0.05
+encoder_layerdrop: 0.0
 
 # Masking parameters
 mask_length: 4

--- a/recipes/LibriSpeech/self-supervised-learning/BEST-RQ/hparams/BEST-RQ.yaml
+++ b/recipes/LibriSpeech/self-supervised-learning/BEST-RQ/hparams/BEST-RQ.yaml
@@ -35,7 +35,7 @@ number_of_epochs: 3000
 optimizer_step_limit: 300000
 
 # This setup is for 8 V100.
-seconds_per_batch: 400
+max_batch_len: 400 # In second and per gpu
 train_num_buckets: 150
 grad_accumulation_factor: 2
 

--- a/recipes/LibriSpeech/self-supervised-learning/BEST-RQ/train.py
+++ b/recipes/LibriSpeech/self-supervised-learning/BEST-RQ/train.py
@@ -250,7 +250,7 @@ def dataio_prepare(hparams):
     # We create the DynamicBatch Sampler
     train_sampler = DynamicBatchSampler(
         train_data,
-        hparams["seconds_per_batch"],
+        hparams["max_batch_len"],
         num_buckets=hparams["train_num_buckets"],
         length_func=lambda x: x["duration"],
         batch_ordering="random",

--- a/recipes/LibriSpeech/self-supervised-learning/wav2vec2/train_sb_wav2vec2.py
+++ b/recipes/LibriSpeech/self-supervised-learning/wav2vec2/train_sb_wav2vec2.py
@@ -371,7 +371,6 @@ def main():
         train_dataset,
         valid_loader,
         train_loader_kwargs=train_loader_kwargs,
-        progressbar=False,
     )
 
 

--- a/recipes/LibriSpeech/self-supervised-learning/wav2vec2/train_sb_wav2vec2.py
+++ b/recipes/LibriSpeech/self-supervised-learning/wav2vec2/train_sb_wav2vec2.py
@@ -365,8 +365,6 @@ def main():
         checkpointer=hparams["checkpointer"],
     )
 
-    print(brain.modules)
-
     brain.fit(
         brain.hparams.epoch_counter,
         train_dataset,

--- a/recipes/LibriSpeech/self-supervised-learning/wav2vec2/train_sb_wav2vec2.py
+++ b/recipes/LibriSpeech/self-supervised-learning/wav2vec2/train_sb_wav2vec2.py
@@ -211,7 +211,6 @@ class W2V2Brain(sb.core.Brain):
             self.train_stats = stage_stats
 
         if stage == sb.Stage.VALID:
-            print(self.acc_metric)
             stage_stats["accuracy"] = sum(self.acc_metric) / len(
                 self.acc_metric
             )
@@ -365,6 +364,8 @@ def main():
         run_opts=run_opts,
         checkpointer=hparams["checkpointer"],
     )
+
+    print(brain.modules)
 
     brain.fit(
         brain.hparams.epoch_counter,

--- a/speechbrain/core.py
+++ b/speechbrain/core.py
@@ -1715,20 +1715,21 @@ class Brain:
         if not self.distributed_launch and not self.data_parallel_backend:
             return
         elif self.distributed_launch:
-            self.modules = SyncBatchNorm.convert_sync_batchnorm(self.modules)
-            if self.distributed_backend == "gloo":
-                self.modules = DDP(
-                    self.modules,
-                    device_ids=None,
-                    find_unused_parameters=self.find_unused_parameters,
-                )
-            else:
-                self.modules = DDP(
-                    self.modules,
-                    device_ids=[self.device],
-                    find_unused_parameters=self.find_unused_parameters,
-                )
-            self.modules = self.modules.module
+            for name, module in self.modules.items():
+                module = SyncBatchNorm.convert_sync_batchnorm(module)
+                if self.distributed_backend == "gloo":
+                    module = DDP(
+                        module,
+                        device_ids=None,
+                        find_unused_parameters=self.find_unused_parameters,
+                    )
+                else:
+                    module = DDP(
+                        module,
+                        device_ids=[self.device],
+                        find_unused_parameters=self.find_unused_parameters,
+                    )
+                self.modules[name] = module
         else:
             # data_parallel_backend
             for name, module in self.modules.items():

--- a/speechbrain/utils/distributed.py
+++ b/speechbrain/utils/distributed.py
@@ -228,6 +228,34 @@ def ddp_broadcast(communication_object, src=0):
     return communication_list[0]
 
 
+def ddp_all_reduce(communication_object, reduce_op):
+    r"""In DDP mode, this function will perform an all_reduce operation with the
+    specified torch operator.
+
+    See: https://pytorch.org/docs/stable/distributed.html#torch.distributed.all_reduce
+
+    Arguments
+    ---------
+    communication_object: Any
+        The object to be reduced across processes.
+    reduce_op: torch.distributed.ReduceOp
+        The operation to perform. E.g. include torch.distributed.ReduceOp.AVG or
+        torch.distributed.ReduceOp.SUM. See the Torch documentation for more.
+
+    Returns
+    -------
+    The communication_object once reduced (or itself if DDP not initialised)
+    """
+
+    # If DDP not initialised or executed with a main process barrier
+    if MAIN_PROC_ONLY >= 1 or not is_distributed_initialized():
+        return communication_object
+
+    torch.distributed.all_reduce(communication_object, op=reduce_op)
+
+    return communication_object
+
+
 def ddp_init_group(run_opts):
     r"""This function will initialize the ddp group if
     distributed_launch bool is given in the python command line.

--- a/speechbrain/utils/seed.py
+++ b/speechbrain/utils/seed.py
@@ -42,6 +42,12 @@ def seed_everything(
         The seed that was set.
     """
 
+    if not (min_seed_value <= seed <= max_seed_value):
+        logger.info(
+            f"{seed} is not in bounds, numpy accepts from {min_seed_value} to {max_seed_value}",
+        )
+        seed = min_seed_value
+
     if verbose:
         logger.info(f"Setting seed to {seed}")
 

--- a/speechbrain/utils/seed.py
+++ b/speechbrain/utils/seed.py
@@ -9,7 +9,6 @@ import random
 
 import torch
 
-from speechbrain.utils.distributed import get_rank, rank_prefixed_message
 from speechbrain.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -21,7 +20,12 @@ min_seed_value = 0
 def seed_everything(
     seed: int = 0, verbose: bool = True, deterministic: bool = False
 ) -> int:
-    r"""Function that sets the seed for pseudo-random number generators in: torch, numpy, and Python's random module.
+    r"""Function that sets the seed for pseudo-random number generators in: torch, numpy, and Python's random module. Important note on DDP: all DDP
+    process have the same seed. This is important to ensure that parameters
+    without a require_grad set to True are the same across processes. This
+    must be taken into account if one wants to build a custom data sampler as
+    the processes would pick the same samples... SpeechBrain takes care of that
+    internally.
 
     Arguments
     ---------
@@ -38,23 +42,8 @@ def seed_everything(
         The seed that was set.
     """
 
-    # if DDP, we need to offset the seed by the rank
-    # to avoid having the same seed on all processes
-    seed_offset = 0 if get_rank() is None else get_rank()
-
-    if not (min_seed_value <= seed <= max_seed_value):
-        logger.info(
-            f"{seed} is not in bounds, numpy accepts from {min_seed_value} to {max_seed_value}",
-        )
-        seed = seed_offset
-    else:
-        seed += seed_offset
-
     if verbose:
-        logger.info(
-            rank_prefixed_message(f"Setting seed to {seed}"),
-            main_process_only=False,
-        )
+        logger.info(f"Setting seed to {seed}")
 
     os.environ["SB_GLOBAL_SEED"] = str(seed)
     random.seed(seed)


### PR DESCRIPTION
This is a serious issue. @peter842323 @Adel-Moumen  and @mravanelli - anyone technically sound should have an eye on it and review. **Our DDP, under some circumstances, is broken.** Basically, any module that does not contain trainable parameters but contains non trainable ones, will not be broadcasted properly. For BEST-RQ, for instance, it means that if you train with 4 GPUs, each GPU will get a different Quantizer. This is also true for input normalization! Up until now, if we use global as an input normalisation, the running mean and var will be calculated per GPU ... 

This PR addresses this by removing the offset to the seed of the processes. This makes sure that all processes initialise with the same seed i.e. same parameters. 

The module solution did not work as it's breaking most of the code base.

TODO:
- [x] Adel Check if it breaks stuff to redirect self.modules.module to self.modules (not good)
- [x] Adapt the input normalisation to use all_reduce operation to average the statistics.