### PR TITLE
Fix BEST RQ norm error and efficiency changes

### DIFF
--- a/recipes/LibriSpeech/ASR/CTC/hparams/train_sb_BEST-RQ.yaml
+++ b/recipes/LibriSpeech/ASR/CTC/hparams/train_sb_BEST-RQ.yaml
@@ -276,7 +276,7 @@ pretrainer: !new:speechbrain.utils.parameter_transfer.Pretrainer
 
    paths:
       pt_model: !ref <pt_model_path>/model.ckpt
-      normalize: !ref <pt_model_path>/normalizer.ckpt
+      normalize: !ref <pt_model_path>/normalize.ckpt
 
 train_logger: !new:speechbrain.utils.train_logger.FileTrainLogger
    save_file: !ref <train_log>

--- a/recipes/LibriSpeech/self-supervised-learning/BEST-RQ/README.md
+++ b/recipes/LibriSpeech/self-supervised-learning/BEST-RQ/README.md
@@ -10,7 +10,7 @@ Simply type:
 # single GPU example
 python train.py hparams/BEST-RQ.yaml --data_folder /path/to/LibriSpeech/
 
-# multi GPU example
+# single node multi GPU example
 torchrun --rdzv-backend=c10d --rdzv-endpoint=localhost:0 --nnodes=1 --nproc-per-node=2 train.py hparams/BEST-RQ.yaml --data_folder /path/to/LibriSpeech/
 ```
 

--- a/recipes/LibriSpeech/self-supervised-learning/BEST-RQ/README.md
+++ b/recipes/LibriSpeech/self-supervised-learning/BEST-RQ/README.md
@@ -7,7 +7,11 @@ More information on the architecture can be found in [the original paper](https:
 # Go !
 Simply type:
 ```shell
-python train.py hparams/BEST-RQ.yaml --find_unused_parameters
+# single GPU example
+python train.py hparams/BEST-RQ.yaml --data_folder /path/to/LibriSpeech/
+
+# multi GPU example
+torchrun --rdzv-backend=c10d --rdzv-endpoint=localhost:0 --nnodes=1 --nproc-per-node=2 train.py hparams/BEST-RQ.yaml --data_folder /path/to/LibriSpeech/
 ```
 
 Do not forget to replace the `!PLACEHOLDER` variables in the yaml corresponding to your local configuration.

--- a/recipes/LibriSpeech/self-supervised-learning/BEST-RQ/hparams/BEST-RQ.yaml
+++ b/recipes/LibriSpeech/self-supervised-learning/BEST-RQ/hparams/BEST-RQ.yaml
@@ -146,7 +146,8 @@ compute_features: !new:speechbrain.lobes.features.Fbank
     n_mels: !ref <n_mels>
 
 normalize: !new:speechbrain.processing.features.InputNormalization
-    norm_type: sentence
+   norm_type: global
+   update_until_epoch: 4
 
 ############################## running ################################
 
@@ -169,7 +170,7 @@ checkpointer: !new:speechbrain.utils.checkpoints.Checkpointer
     recoverables:
         model: !ref <model>
         noam_scheduler: !ref <noam_annealing>
-        normalizer: !ref <normalize>
+        normalize: !ref <normalize>
         counter: !ref <epoch_counter>
         quantizer: !ref <Quantizer>
         linear: !ref <linear>

--- a/recipes/LibriSpeech/self-supervised-learning/BEST-RQ/train.py
+++ b/recipes/LibriSpeech/self-supervised-learning/BEST-RQ/train.py
@@ -53,9 +53,10 @@ class BestRQBrain(sb.core.Brain):
         feats = pad_feats(feats, divis_by)
 
         # get targets from quantizer and stack the frames!
+        mask_idx = mask[::4] // 4
         B, T, C = feats.shape
         targets = self.modules.Quantizer(
-            feats.view(B, feats.shape[1] // divis_by, -1)
+            feats.view(B, feats.shape[1] // divis_by, -1)[:,mask_idx,:]
         )
 
         # generate random noise
@@ -78,9 +79,7 @@ class BestRQBrain(sb.core.Brain):
         logits = self.modules.linear(enc_out)
 
         ##### get masked region for loss computation only over these.
-        mask_idx = mask[::divis_by] // divis_by
         logits = logits[:, mask_idx, :]
-        targets = targets[:, mask_idx]
 
         B, T, C = logits.shape
         return logits.view(B * T, C), targets.view(B * T)

--- a/speechbrain/nnet/quantisers.py
+++ b/speechbrain/nnet/quantisers.py
@@ -168,7 +168,7 @@ class RandomProjectionQuantizer(nn.Module):
     def forward(self, x):
         """Forward the latent vector to obtain a quantised output"""
 
-        x = F.normalize(x @ self.P)
+        x = F.normalize(x @ self.P, dim=2)
         return vector_norm(
             (self.CB.unsqueeze(1) - x.unsqueeze(1)), dim=-1
         ).argmin(dim=1)


### PR DESCRIPTION
## What does this PR do?

This PR overall fixes and improve the BEST-RQ recipe. More specifically it does the following:
- fixes issue with normalizing on the wrong dimension in the ```RandomProjectionQuantizer```
- fixes inconsistency with normalizer in pre-training and fine-tuning scripts
- makes ```compute_forward``` function more efficient by only computing pseudo-targets on masked area