### PR TITLE
Turn huggingface updates off by default to fix #2817

### DIFF
--- a/speechbrain/utils/fetching.py
+++ b/speechbrain/utils/fetching.py
@@ -218,7 +218,7 @@ def fetch(
     source: Union[str, FetchSource],
     savedir: Optional[Union[str, pathlib.Path]] = None,
     overwrite: bool = False,
-    allow_updates: bool = True,
+    allow_updates: bool = False,
     allow_network: bool = True,
     save_filename: Optional[str] = None,
     use_auth_token: bool = False,


### PR DESCRIPTION
Fixes #2817 

When the files exist locally, we don't want to hit the network unless specifically requested to. When this option is `True`, then `fetch` still downloads the model to the cache, even if it exists in the target directory, in case there's some update to the model.

This option is not yet made available through `Pretrained.from_hparams` but would be accessible if and when we merge #2828.