### PR TITLE
Fix dataset preparation save folder in `fluent-speech-commands` recipe

### DIFF
--- a/recipes/fluent-speech-commands/direct/train.py
+++ b/recipes/fluent-speech-commands/direct/train.py
@@ -266,7 +266,7 @@ if __name__ == "__main__":
         prepare_FSC,
         kwargs={
             "data_folder": hparams["data_folder"],
-            "save_folder": hparams["output_folder"],
+            "save_folder": hparams["save_folder"],
             "skip_prep": hparams["skip_prep"],
         },
     )


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

-->

Variable `save_folder` was mapped to `hparams["output_folder"]` which resulted in a file not found error. By we fix that by passing the correct parameter to `prepare_FSC`.

Did not bother opening issue since fix is trivial.

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- [X] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [X] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] ~Did you make sure to **update the documentation** with your changes? (if necessary)~
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [X] Did you list all the **breaking changes** introduced by this pull request?
- [X] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
