### PR TITLE
Fix "use_amp" errors in recipes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.12'
-      - uses: pre-commit/action@v4.2.0
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,5 +12,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
-      - uses: pre-commit/action@v2.0.3
+          python-version: '3.12'
+      - uses: pre-commit/action@v4.2.0

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -30,7 +30,7 @@ jobs:
               run: |
                   pip install uv
                   uv pip install --system ctc-segmentation sacrebleu # ctc-segmentation is funky with uv due to their oldest-supported-numpy dependency
-                  uv pip install --system -r requirements.txt torch==2.6.0+cpu torchaudio==2.6.0+cpu --extra-index-url https://download.pytorch.org/whl/cpu k2==1.24.4.dev20250307+cpu.torch2.6.0 --find-links https://k2-fsa.github.io/k2/cpu.html kaldilm==1.15.1 gensim==4.3.2 bitsandbytes==0.45.3 scikit-learn==1.6.1
+                  uv pip install --system -r requirements.txt torch==2.6.0+cpu torchaudio==2.6.0+cpu --extra-index-url https://download.pytorch.org/whl/cpu k2==1.24.4.dev20250307+cpu.torch2.6.0 --find-links https://k2-fsa.github.io/k2/cpu.html gensim==4.3.2 bitsandbytes==0.45.3 scikit-learn==1.6.1
                   uv pip install --system --editable . --no-deps  # already installed pinned deps from requirements.txt, we're good
             - name: Install sox
               run: |

--- a/.github/workflows/verify-docs-gen.yml
+++ b/.github/workflows/verify-docs-gen.yml
@@ -24,7 +24,7 @@ jobs:
               run: |
                   pip install uv
                   uv pip install --system sphinx>=7.4.1
-                  uv pip install --system -r requirements.txt -r docs/docs-requirements.txt torch==2.6.0+cpu torchaudio==2.6.0+cpu --extra-index-url https://download.pytorch.org/whl/cpu kaldilm==1.15.1
+                  uv pip install --system -r requirements.txt -r docs/docs-requirements.txt torch==2.6.0+cpu torchaudio==2.6.0+cpu --extra-index-url https://download.pytorch.org/whl/cpu
                   uv pip install --system --editable . --no-deps  # already installed pinned deps from requirements.txt, we're good
             - name: Generate docs
               run: |

--- a/conftest.py
+++ b/conftest.py
@@ -16,6 +16,7 @@ collect_ignore = [
     "speechbrain/lobes/models/flair",
     "speechbrain/lobes/models/spacy",
     "speechbrain/alignment/ctc_segmentation.py",
+    "speechbrain/lm/arpa.py",
 ]
 try:
     import numba  # noqa: F401

--- a/recipes/Aishell1Mix/separation/train.py
+++ b/recipes/Aishell1Mix/separation/train.py
@@ -34,7 +34,6 @@ from tqdm import tqdm
 
 import speechbrain as sb
 import speechbrain.nnet.schedulers as schedulers
-from speechbrain.core import AMPConfig
 from speechbrain.utils.distributed import run_on_main
 from speechbrain.utils.logger import get_logger
 
@@ -112,8 +111,6 @@ class Separation(sb.Brain):
 
     def fit_batch(self, batch):
         """Trains one batch"""
-        amp = AMPConfig.from_name(self.precision)
-        should_step = (self.step % self.grad_accumulation_factor) == 0
 
         # Unpacking batch list
         mixture = batch.mix_sig
@@ -126,78 +123,39 @@ class Separation(sb.Brain):
         if self.hparams.num_spks == 3:
             targets.append(batch.s3_sig)
 
-        with self.no_sync(not should_step):
-            if self.use_amp:
-                with torch.autocast(
-                    dtype=amp.dtype,
-                    device_type=torch.device(self.device).type,
-                ):
-                    predictions, targets = self.compute_forward(
-                        mixture, targets, sb.Stage.TRAIN, noise
-                    )
-                    loss = self.compute_objectives(predictions, targets)
+        with self.training_ctx:
+            predictions, targets = self.compute_forward(
+                mixture, targets, sb.Stage.TRAIN, noise
+            )
+            loss = self.compute_objectives(predictions, targets)
 
-                    # hard threshold the easy dataitems
-                    if self.hparams.threshold_byloss:
-                        th = self.hparams.threshold
-                        loss_to_keep = loss[loss > th]
-                        if loss_to_keep.nelement() > 0:
-                            loss = loss_to_keep.mean()
-                    else:
-                        loss = loss.mean()
-
-                if (
-                    loss < self.hparams.loss_upper_lim and loss.nelement() > 0
-                ):  # the fix for computational problems
-                    self.scaler.scale(loss).backward()
-                    if self.hparams.clip_grad_norm >= 0:
-                        self.scaler.unscale_(self.optimizer)
-                        torch.nn.utils.clip_grad_norm_(
-                            self.modules.parameters(),
-                            self.hparams.clip_grad_norm,
-                        )
-                    self.scaler.step(self.optimizer)
-                    self.scaler.update()
-                else:
-                    self.nonfinite_count += 1
-                    logger.info(
-                        "infinite loss or empty loss! it happened {} times so far - skipping this batch".format(
-                            self.nonfinite_count
-                        )
-                    )
-                    loss.data = torch.tensor(0.0).to(self.device)
+            # hard threshold the easy dataitems
+            if self.hparams.threshold_byloss:
+                th = self.hparams.threshold
+                loss_to_keep = loss[loss > th]
+                if loss_to_keep.nelement() > 0:
+                    loss = loss_to_keep.mean()
             else:
-                predictions, targets = self.compute_forward(
-                    mixture, targets, sb.Stage.TRAIN, noise
+                loss = loss.mean()
+
+        if loss < self.hparams.loss_upper_lim and loss.nelement() > 0:
+            self.scaler.scale(loss).backward()
+            if self.hparams.clip_grad_norm >= 0:
+                self.scaler.unscale_(self.optimizer)
+                torch.nn.utils.clip_grad_norm_(
+                    self.modules.parameters(),
+                    self.hparams.clip_grad_norm,
                 )
-                loss = self.compute_objectives(predictions, targets)
-
-                if self.hparams.threshold_byloss:
-                    th = self.hparams.threshold
-                    loss_to_keep = loss[loss > th]
-                    if loss_to_keep.nelement() > 0:
-                        loss = loss_to_keep.mean()
-                else:
-                    loss = loss.mean()
-
-                if (
-                    loss < self.hparams.loss_upper_lim and loss.nelement() > 0
-                ):  # the fix for computational problems
-                    loss.backward()
-                    if self.hparams.clip_grad_norm >= 0:
-                        torch.nn.utils.clip_grad_norm_(
-                            self.modules.parameters(),
-                            self.hparams.clip_grad_norm,
-                        )
-                    self.optimizer.step()
-                else:
-                    self.nonfinite_count += 1
-                    logger.info(
-                        "infinite loss or empty loss! it happened {} times so far - skipping this batch".format(
-                            self.nonfinite_count
-                        )
-                    )
-                    loss.data = torch.tensor(0.0).to(self.device)
+            self.scaler.step(self.optimizer)
+            self.scaler.update()
+        else:
+            self.nonfinite_count += 1
+            logger.info(
+                "infinite loss or empty loss! it happened {} times so far - skipping this batch".format(
+                    self.nonfinite_count
+                )
+            )
+            loss.data = torch.tensor(0.0).to(self.device)
         self.optimizer.zero_grad()
 
         return loss.detach().cpu()

--- a/recipes/BinauralWSJ0Mix/separation/train.py
+++ b/recipes/BinauralWSJ0Mix/separation/train.py
@@ -36,7 +36,6 @@ from tqdm import tqdm
 
 import speechbrain as sb
 import speechbrain.nnet.schedulers as schedulers
-from speechbrain.core import AMPConfig
 from speechbrain.processing.features import STFT, spectral_magnitude
 from speechbrain.utils.distributed import run_on_main
 from speechbrain.utils.logger import get_logger
@@ -200,8 +199,6 @@ class Separation(sb.Brain):
 
     def fit_batch(self, batch):
         """Trains one batch"""
-        amp = AMPConfig.from_name(self.precision)
-        should_step = (self.step % self.grad_accumulation_factor) == 0
 
         # Unpacking batch list
         mixture = batch.mix_sig
@@ -214,78 +211,39 @@ class Separation(sb.Brain):
         if "noise" in self.hparams.experiment_name:
             noise = batch.noise_sig[0]
 
-        with self.no_sync(not should_step):
-            if self.use_amp:
-                with torch.autocast(
-                    dtype=amp.dtype,
-                    device_type=torch.device(self.device).type,
-                ):
-                    predictions, targets = self.compute_forward(
-                        mixture, targets, sb.Stage.TRAIN, noise
-                    )
-                    loss = self.compute_objectives(predictions, targets)
+        with self.training_ctx:
+            predictions, targets = self.compute_forward(
+                mixture, targets, sb.Stage.TRAIN, noise
+            )
+            loss = self.compute_objectives(predictions, targets)
 
-                    # hard threshold the easy dataitems
-                    if self.hparams.threshold_byloss:
-                        th = self.hparams.threshold
-                        loss = loss[loss > th]
-                        if loss.nelement() > 0:
-                            loss = loss.mean()
-                    else:
-                        loss = loss.mean()
-
-                if (
-                    loss.nelement() > 0 and loss < self.hparams.loss_upper_lim
-                ):  # the fix for computational problems
-                    self.scaler.scale(loss).backward()
-                    if self.hparams.clip_grad_norm >= 0:
-                        self.scaler.unscale_(self.optimizer)
-                        torch.nn.utils.clip_grad_norm_(
-                            self.modules.parameters(),
-                            self.hparams.clip_grad_norm,
-                        )
-                    self.scaler.step(self.optimizer)
-                    self.scaler.update()
-                else:
-                    self.nonfinite_count += 1
-                    logger.info(
-                        "infinite loss or empty loss! it happened {} times so far - skipping this batch".format(
-                            self.nonfinite_count
-                        )
-                    )
-                    loss.data = torch.tensor(0.0).to(self.device)
-            else:
-                predictions, targets = self.compute_forward(
-                    mixture, targets, sb.Stage.TRAIN, noise
-                )
-                loss = self.compute_objectives(predictions, targets)
-
-                if self.hparams.threshold_byloss:
-                    th = self.hparams.threshold
-                    loss = loss[loss > th]
-                    if loss.nelement() > 0:
-                        loss = loss.mean()
-                else:
+            # hard threshold the easy dataitems
+            if self.hparams.threshold_byloss:
+                th = self.hparams.threshold
+                loss = loss[loss > th]
+                if loss.nelement() > 0:
                     loss = loss.mean()
+            else:
+                loss = loss.mean()
 
-                if (
-                    loss.nelement() > 0 and loss < self.hparams.loss_upper_lim
-                ):  # the fix for computational problems
-                    loss.backward()
-                    if self.hparams.clip_grad_norm >= 0:
-                        torch.nn.utils.clip_grad_norm_(
-                            self.modules.parameters(),
-                            self.hparams.clip_grad_norm,
-                        )
-                    self.optimizer.step()
-                else:
-                    self.nonfinite_count += 1
-                    logger.info(
-                        "infinite loss or empty loss! it happened {} times so far - skipping this batch".format(
-                            self.nonfinite_count
-                        )
-                    )
-                    loss.data = torch.tensor(0.0).to(self.device)
+        if loss.nelement() > 0 and loss < self.hparams.loss_upper_lim:
+            self.scaler.scale(loss).backward()
+            if self.hparams.clip_grad_norm >= 0:
+                self.scaler.unscale_(self.optimizer)
+                torch.nn.utils.clip_grad_norm_(
+                    self.modules.parameters(),
+                    self.hparams.clip_grad_norm,
+                )
+            self.scaler.step(self.optimizer)
+            self.scaler.update()
+        else:
+            self.nonfinite_count += 1
+            logger.info(
+                "infinite loss or empty loss! it happened {} times so far - skipping this batch".format(
+                    self.nonfinite_count
+                )
+            )
+            loss.data = torch.tensor(0.0).to(self.device)
         self.optimizer.zero_grad()
 
         return loss.detach().cpu()

--- a/recipes/LibriSpeech/self-supervised-learning/wav2vec2/train_sb_wav2vec2.py
+++ b/recipes/LibriSpeech/self-supervised-learning/wav2vec2/train_sb_wav2vec2.py
@@ -23,7 +23,6 @@ from torch.nn.parallel import DistributedDataParallel
 
 import speechbrain as sb
 from speechbrain import Stage
-from speechbrain.core import AMPConfig
 from speechbrain.dataio.dataloader import SaveableDataLoader
 from speechbrain.dataio.sampler import DynamicBatchSampler
 from speechbrain.lobes.models.wav2vec import (
@@ -124,21 +123,11 @@ class W2V2Brain(sb.core.Brain):
         return objectives
 
     def fit_batch(self, batch):
-        amp = AMPConfig.from_name(self.precision)
         should_step = (self.step % self.grad_accumulation_factor) == 0
 
         # Managing automatic mixed precision
         with self.no_sync(not should_step):
-            if self.use_amp:
-                with torch.autocast(
-                    dtype=amp.dtype,
-                    device_type=torch.device(self.device).type,
-                ):
-                    outputs = self.compute_forward(batch, Stage.TRAIN)
-                    objectives = self.compute_objectives(
-                        outputs, batch, Stage.TRAIN
-                    )
-            else:
+            with self.training_ctx:
                 outputs = self.compute_forward(batch, Stage.TRAIN)
                 objectives = self.compute_objectives(
                     outputs, batch, Stage.TRAIN

--- a/recipes/REAL-M/sisnr-estimation/train.py
+++ b/recipes/REAL-M/sisnr-estimation/train.py
@@ -20,7 +20,6 @@ from tqdm import tqdm
 
 import speechbrain as sb
 import speechbrain.nnet.schedulers as schedulers
-from speechbrain.core import AMPConfig
 from speechbrain.utils.distributed import run_on_main
 from speechbrain.utils.logger import get_logger
 
@@ -160,8 +159,6 @@ class Separation(sb.Brain):
 
     def fit_batch(self, batch):
         """Trains one batch"""
-        amp = AMPConfig.from_name(self.precision)
-        should_step = (self.step % self.grad_accumulation_factor) == 0
 
         if self.hparams.use_whamr_train:
             whamr_prob = torch.rand(1).item()
@@ -179,73 +176,32 @@ class Separation(sb.Brain):
         if self.hparams.num_spks == 3:
             targets.append(batch.s3_sig)
 
-        with self.no_sync(not should_step):
-            if self.use_amp:
-                with torch.autocast(
-                    dtype=amp.dtype,
-                    device_type=torch.device(self.device).type,
-                ):
-                    (
-                        predictions,
-                        snrhat,
-                        snr,
-                        snr_compressed,
-                    ) = self.compute_forward(
-                        mixture, targets, sb.Stage.TRAIN, noise
-                    )
+        with self.training_ctx:
+            predictions, snrhat, snr, snr_compressed = self.compute_forward(
+                mixture, targets, sb.Stage.TRAIN, noise
+            )
 
-                    snr = snr.reshape(-1)
-                    loss = ((snr_compressed - snrhat).abs()).mean()
+            snr = snr.reshape(-1)
+            loss = ((snr_compressed - snrhat).abs()).mean()
 
-                    if (
-                        loss.nelement() > 0
-                        and loss < self.hparams.loss_upper_lim
-                    ):  # the fix for computational problems
-                        self.scaler.scale(loss).backward()
-                        if self.hparams.clip_grad_norm >= 0:
-                            self.scaler.unscale_(self.optimizer)
-                            torch.nn.utils.clip_grad_norm_(
-                                self.modules.parameters(),
-                                self.hparams.clip_grad_norm,
-                            )
-                        self.scaler.step(self.optimizer)
-                        self.scaler.update()
-                    else:
-                        self.nonfinite_count += 1
-                        logger.info(
-                            "infinite loss or empty loss! it happened {} times so far - skipping this batch".format(
-                                self.nonfinite_count
-                            )
-                        )
-                        loss.data = torch.tensor(0.0).to(self.device)
-
-            else:
-                # get the oracle snrs, estimated snrs, and the source estimates
-                predictions, snrhat, snr, snr_compressed = self.compute_forward(
-                    mixture, targets, sb.Stage.TRAIN, noise
+        if loss.nelement() > 0 and loss < self.hparams.loss_upper_lim:
+            self.scaler.scale(loss).backward()
+            if self.hparams.clip_grad_norm >= 0:
+                self.scaler.unscale_(self.optimizer)
+                torch.nn.utils.clip_grad_norm_(
+                    self.modules.parameters(),
+                    self.hparams.clip_grad_norm,
                 )
-
-                snr = snr.reshape(-1)
-                loss = ((snr_compressed - snrhat).abs()).mean()
-
-                if (
-                    loss.nelement() > 0 and loss < self.hparams.loss_upper_lim
-                ):  # the fix for computational problems
-                    loss.backward()
-                    if self.hparams.clip_grad_norm >= 0:
-                        torch.nn.utils.clip_grad_norm_(
-                            self.modules.parameters(),
-                            self.hparams.clip_grad_norm,
-                        )
-                    self.optimizer.step()
-                else:
-                    self.nonfinite_count += 1
-                    logger.info(
-                        "infinite loss or empty loss! it happened {} times so far - skipping this batch".format(
-                            self.nonfinite_count
-                        )
-                    )
-                    loss.data = torch.tensor(0.0).to(self.device)
+            self.scaler.step(self.optimizer)
+            self.scaler.update()
+        else:
+            self.nonfinite_count += 1
+            logger.info(
+                "infinite loss or empty loss! it happened {} times so far - skipping this batch".format(
+                    self.nonfinite_count
+                )
+            )
+            loss.data = torch.tensor(0.0).to(self.device)
 
         self.optimizer.zero_grad()
 

--- a/recipes/WHAMandWHAMR/enhancement/train.py
+++ b/recipes/WHAMandWHAMR/enhancement/train.py
@@ -32,7 +32,6 @@ from tqdm import tqdm
 
 import speechbrain as sb
 import speechbrain.nnet.schedulers as schedulers
-from speechbrain.core import AMPConfig
 from speechbrain.processing.features import spectral_magnitude
 from speechbrain.utils.distributed import run_on_main
 from speechbrain.utils.logger import get_logger
@@ -153,85 +152,45 @@ class Separation(sb.Brain):
 
     def fit_batch(self, batch):
         """Trains one batch"""
-        amp = AMPConfig.from_name(self.precision)
-        should_step = (self.step % self.grad_accumulation_factor) == 0
 
         # Unpacking batch list
         mixture = batch.mix_sig
         targets = [batch.s1_sig, batch.s2_sig]
         noise = batch.noise_sig[0]
 
-        with self.no_sync(not should_step):
-            if self.use_amp:
-                with torch.autocast(
-                    dtype=amp.dtype, device_type=torch.device(self.device).type
-                ):
-                    predictions, targets = self.compute_forward(
-                        mixture, targets, sb.Stage.TRAIN, noise
-                    )
-                    loss = self.compute_objectives(predictions, targets)
+        with self.training_ctx:
+            predictions, targets = self.compute_forward(
+                mixture, targets, sb.Stage.TRAIN, noise
+            )
+            loss = self.compute_objectives(predictions, targets)
 
-                    # hard threshold the easy dataitems
-                    if self.hparams.threshold_byloss:
-                        th = self.hparams.threshold
-                        loss = loss[loss > th]
-                        if loss.nelement() > 0:
-                            loss = loss.mean()
-                    else:
-                        loss = loss.mean()
-
-                if (
-                    loss.nelement() > 0 and loss < self.hparams.loss_upper_lim
-                ):  # the fix for computational problems
-                    self.scaler.scale(loss).backward()
-                    if self.hparams.clip_grad_norm >= 0:
-                        self.scaler.unscale_(self.optimizer)
-                        torch.nn.utils.clip_grad_norm_(
-                            self.modules.parameters(),
-                            self.hparams.clip_grad_norm,
-                        )
-                    self.scaler.step(self.optimizer)
-                    self.scaler.update()
-                else:
-                    self.nonfinite_count += 1
-                    logger.info(
-                        "infinite loss or empty loss! it happened {} times so far - skipping this batch".format(
-                            self.nonfinite_count
-                        )
-                    )
-                    loss.data = torch.tensor(0.0).to(self.device)
-            else:
-                predictions, targets = self.compute_forward(
-                    mixture, targets, sb.Stage.TRAIN, noise
-                )
-                loss = self.compute_objectives(predictions, targets)
-
-                if self.hparams.threshold_byloss:
-                    th = self.hparams.threshold
-                    loss = loss[loss > th]
-                    if loss.nelement() > 0:
-                        loss = loss.mean()
-                else:
+            # hard threshold the easy dataitems
+            if self.hparams.threshold_byloss:
+                th = self.hparams.threshold
+                loss = loss[loss > th]
+                if loss.nelement() > 0:
                     loss = loss.mean()
+            else:
+                loss = loss.mean()
 
-                if (
-                    loss.nelement() > 0 and loss < self.hparams.loss_upper_lim
-                ):  # the fix for computational problems
-                    loss.backward()
-                    if self.hparams.clip_grad_norm >= 0:
-                        torch.nn.utils.clip_grad_norm_(
-                            self.modules.parameters(),
-                            self.hparams.clip_grad_norm,
-                        )
-                    self.optimizer.step()
-                else:
-                    self.nonfinite_count += 1
-                    logger.info(
-                        "infinite loss or empty loss! it happened {} times so far - skipping this batch".format(
-                            self.nonfinite_count
-                        )
-                    )
-                    loss.data = torch.tensor(0.0).to(self.device)
+        if loss.nelement() > 0 and loss < self.hparams.loss_upper_lim:
+            self.scaler.scale(loss).backward()
+            if self.hparams.clip_grad_norm >= 0:
+                self.scaler.unscale_(self.optimizer)
+                torch.nn.utils.clip_grad_norm_(
+                    self.modules.parameters(),
+                    self.hparams.clip_grad_norm,
+                )
+            self.scaler.step(self.optimizer)
+            self.scaler.update()
+        else:
+            self.nonfinite_count += 1
+            logger.info(
+                "infinite loss or empty loss! it happened {} times so far - skipping this batch".format(
+                    self.nonfinite_count
+                )
+            )
+            loss.data = torch.tensor(0.0).to(self.device)
         self.optimizer.zero_grad()
 
         return loss.detach().cpu()

--- a/recipes/WHAMandWHAMR/separation/train.py
+++ b/recipes/WHAMandWHAMR/separation/train.py
@@ -31,7 +31,6 @@ from tqdm import tqdm
 
 import speechbrain as sb
 import speechbrain.nnet.schedulers as schedulers
-from speechbrain.core import AMPConfig
 from speechbrain.utils.distributed import run_on_main
 from speechbrain.utils.logger import get_logger
 
@@ -116,85 +115,45 @@ class Separation(sb.Brain):
 
     def fit_batch(self, batch):
         """Trains one batch"""
-        amp = AMPConfig.from_name(self.precision)
-        should_step = (self.step % self.grad_accumulation_factor) == 0
 
         # Unpacking batch list
         mixture = batch.mix_sig
         targets = [batch.s1_sig, batch.s2_sig]
         noise = batch.noise_sig[0]
 
-        with self.no_sync(not should_step):
-            if self.use_amp:
-                with torch.autocast(
-                    dtype=amp.dtype, device_type=torch.device(self.device).type
-                ):
-                    predictions, targets = self.compute_forward(
-                        mixture, targets, sb.Stage.TRAIN, noise
-                    )
-                    loss = self.compute_objectives(predictions, targets)
+        with self.training_ctx:
+            predictions, targets = self.compute_forward(
+                mixture, targets, sb.Stage.TRAIN, noise
+            )
+            loss = self.compute_objectives(predictions, targets)
 
-                    # hard threshold the easy dataitems
-                    if self.hparams.threshold_byloss:
-                        th = self.hparams.threshold
-                        loss = loss[loss > th]
-                        if loss.nelement() > 0:
-                            loss = loss.mean()
-                    else:
-                        loss = loss.mean()
-
-                if (
-                    loss.nelement() > 0 and loss < self.hparams.loss_upper_lim
-                ):  # the fix for computational problems
-                    self.scaler.scale(loss).backward()
-                    if self.hparams.clip_grad_norm >= 0:
-                        self.scaler.unscale_(self.optimizer)
-                        torch.nn.utils.clip_grad_norm_(
-                            self.modules.parameters(),
-                            self.hparams.clip_grad_norm,
-                        )
-                    self.scaler.step(self.optimizer)
-                    self.scaler.update()
-                else:
-                    self.nonfinite_count += 1
-                    logger.info(
-                        "infinite loss or empty loss! it happened {} times so far - skipping this batch".format(
-                            self.nonfinite_count
-                        )
-                    )
-                    loss.data = torch.tensor(0.0).to(self.device)
-            else:
-                predictions, targets = self.compute_forward(
-                    mixture, targets, sb.Stage.TRAIN, noise
-                )
-                loss = self.compute_objectives(predictions, targets)
-
-                if self.hparams.threshold_byloss:
-                    th = self.hparams.threshold
-                    loss = loss[loss > th]
-                    if loss.nelement() > 0:
-                        loss = loss.mean()
-                else:
+            # hard threshold the easy dataitems
+            if self.hparams.threshold_byloss:
+                th = self.hparams.threshold
+                loss = loss[loss > th]
+                if loss.nelement() > 0:
                     loss = loss.mean()
+            else:
+                loss = loss.mean()
 
-                if (
-                    loss.nelement() > 0 and loss < self.hparams.loss_upper_lim
-                ):  # the fix for computational problems
-                    loss.backward()
-                    if self.hparams.clip_grad_norm >= 0:
-                        torch.nn.utils.clip_grad_norm_(
-                            self.modules.parameters(),
-                            self.hparams.clip_grad_norm,
-                        )
-                    self.optimizer.step()
-                else:
-                    self.nonfinite_count += 1
-                    logger.info(
-                        "infinite loss or empty loss! it happened {} times so far - skipping this batch".format(
-                            self.nonfinite_count
-                        )
-                    )
-                    loss.data = torch.tensor(0.0).to(self.device)
+        if loss.nelement() > 0 and loss < self.hparams.loss_upper_lim:
+            self.scaler.scale(loss).backward()
+            if self.hparams.clip_grad_norm >= 0:
+                self.scaler.unscale_(self.optimizer)
+                torch.nn.utils.clip_grad_norm_(
+                    self.modules.parameters(),
+                    self.hparams.clip_grad_norm,
+                )
+            self.scaler.step(self.optimizer)
+            self.scaler.update()
+        else:
+            self.nonfinite_count += 1
+            logger.info(
+                "infinite loss or empty loss! it happened {} times so far - skipping this batch".format(
+                    self.nonfinite_count
+                )
+            )
+            loss.data = torch.tensor(0.0).to(self.device)
         self.optimizer.zero_grad()
 
         return loss.detach().cpu()

--- a/recipes/WSJ0Mix/separation/train.py
+++ b/recipes/WSJ0Mix/separation/train.py
@@ -34,7 +34,6 @@ from tqdm import tqdm
 
 import speechbrain as sb
 import speechbrain.nnet.schedulers as schedulers
-from speechbrain.core import AMPConfig
 from speechbrain.utils.distributed import run_on_main
 from speechbrain.utils.logger import get_logger
 
@@ -100,8 +99,6 @@ class Separation(sb.Brain):
 
     def fit_batch(self, batch):
         """Trains one batch"""
-        amp = AMPConfig.from_name(self.precision)
-        should_step = (self.step % self.grad_accumulation_factor) == 0
 
         # Unpacking batch list
         mixture = batch.mix_sig
@@ -110,77 +107,39 @@ class Separation(sb.Brain):
         if self.hparams.num_spks == 3:
             targets.append(batch.s3_sig)
 
-        with self.no_sync(not should_step):
-            if self.use_amp:
-                with torch.autocast(
-                    dtype=amp.dtype, device_type=torch.device(self.device).type
-                ):
-                    predictions, targets = self.compute_forward(
-                        mixture, targets, sb.Stage.TRAIN
-                    )
-                    loss = self.compute_objectives(predictions, targets)
+        with self.training_ctx:
+            predictions, targets = self.compute_forward(
+                mixture, targets, sb.Stage.TRAIN
+            )
+            loss = self.compute_objectives(predictions, targets)
 
-                    # hard threshold the easy dataitems
-                    if self.hparams.threshold_byloss:
-                        th = self.hparams.threshold
-                        loss = loss[loss > th]
-                        if loss.nelement() > 0:
-                            loss = loss.mean()
-                    else:
-                        loss = loss.mean()
-
-                if (
-                    loss.nelement() > 0 and loss < self.hparams.loss_upper_lim
-                ):  # the fix for computational problems
-                    self.scaler.scale(loss).backward()
-                    if self.hparams.clip_grad_norm >= 0:
-                        self.scaler.unscale_(self.optimizer)
-                        torch.nn.utils.clip_grad_norm_(
-                            self.modules.parameters(),
-                            self.hparams.clip_grad_norm,
-                        )
-                    self.scaler.step(self.optimizer)
-                    self.scaler.update()
-                else:
-                    self.nonfinite_count += 1
-                    logger.info(
-                        "infinite loss or empty loss! it happened {} times so far - skipping this batch".format(
-                            self.nonfinite_count
-                        )
-                    )
-                    loss.data = torch.tensor(0.0).to(self.device)
-            else:
-                predictions, targets = self.compute_forward(
-                    mixture, targets, sb.Stage.TRAIN
-                )
-                loss = self.compute_objectives(predictions, targets)
-
-                if self.hparams.threshold_byloss:
-                    th = self.hparams.threshold
-                    loss = loss[loss > th]
-                    if loss.nelement() > 0:
-                        loss = loss.mean()
-                else:
+            # hard threshold the easy dataitems
+            if self.hparams.threshold_byloss:
+                th = self.hparams.threshold
+                loss = loss[loss > th]
+                if loss.nelement() > 0:
                     loss = loss.mean()
+            else:
+                loss = loss.mean()
 
-                if (
-                    loss.nelement() > 0 and loss < self.hparams.loss_upper_lim
-                ):  # the fix for computational problems
-                    loss.backward()
-                    if self.hparams.clip_grad_norm >= 0:
-                        torch.nn.utils.clip_grad_norm_(
-                            self.modules.parameters(),
-                            self.hparams.clip_grad_norm,
-                        )
-                    self.optimizer.step()
-                else:
-                    self.nonfinite_count += 1
-                    logger.info(
-                        "infinite loss or empty loss! it happened {} times so far - skipping this batch".format(
-                            self.nonfinite_count
-                        )
-                    )
-                    loss.data = torch.tensor(0.0).to(self.device)
+        if loss.nelement() > 0 and loss < self.hparams.loss_upper_lim:
+            self.scaler.scale(loss).backward()
+            if self.hparams.clip_grad_norm >= 0:
+                self.scaler.unscale_(self.optimizer)
+                torch.nn.utils.clip_grad_norm_(
+                    self.modules.parameters(),
+                    self.hparams.clip_grad_norm,
+                )
+            self.scaler.step(self.optimizer)
+            self.scaler.update()
+        else:
+            self.nonfinite_count += 1
+            logger.info(
+                "infinite loss or empty loss! it happened {} times so far - skipping this batch".format(
+                    self.nonfinite_count
+                )
+            )
+            loss.data = torch.tensor(0.0).to(self.device)
         self.optimizer.zero_grad()
 
         return loss.detach().cpu()

--- a/tests/utils/recipe_tests.py
+++ b/tests/utils/recipe_tests.py
@@ -16,7 +16,7 @@ from time import time
 from hyperpyyaml import load_hyperpyyaml
 
 from speechbrain.utils.data_utils import download_file  # noqa: F401
-from speechbrain.utils.logger import get_logger
+from speechbrain.utils.logger import get_logger, setup_logging
 
 __skip_list = ["README.md", "setup"]
 
@@ -476,6 +476,8 @@ def run_recipe_tests(
     -------
     python -c 'from speechbrain.utils.recipe_tests import run_recipe_tests; print("TEST FAILED!") if not(run_recipe_tests(filters_fields=["Dataset", "Task"], filters=[["AISHELL-1", "CommonVoice"], "SSL"])) else print("TEST PASSED")'
     """
+    setup_logging()
+
     # Create the output folder (where the tests results will be saved)
     os.makedirs(output_folder, exist_ok=True)
     logger.info("Test outputs will be put in %s", output_folder)


### PR DESCRIPTION
Found via the recipe tests, see #2869 

"Brain" class no longer has the "use_amp" attribute due to changes to the mixed precision handling (from #2827 ? )

But this should make recipes a little cleaner as we don't need to repeat the optimizer update code twice.