### PR TITLE
Attempt fix for input_norm test

### DIFF
--- a/tests/unittests/test_input_norm.py
+++ b/tests/unittests/test_input_norm.py
@@ -188,7 +188,6 @@ def initialise_process_group(rank: int, world_size: int, tmpdir):
     os.environ["RANK"] = str(rank)
     os.environ["LOCAL_RANK"] = str(rank)
     sync_file = f"file://{tmpdir}/sync"
-    #sync_file = 'tcp://10.1.1.20:23456'
     torch.distributed.init_process_group(
         "gloo", rank=rank, world_size=world_size, init_method=sync_file
     )

--- a/tests/unittests/test_input_norm.py
+++ b/tests/unittests/test_input_norm.py
@@ -40,7 +40,11 @@ def random_mask_numpy(
         for d in range(len(data_shape))
     )
 
-    return generator.integers(0, 2, size=mask_shape, dtype=bool)
+    mask = generator.integers(0, 2, size=mask_shape, dtype=bool)
+
+    if np.count_nonzero(mask) == 0:
+        return None
+    return mask
 
 
 def reference_gaussian_statistics(
@@ -184,6 +188,7 @@ def initialise_process_group(rank: int, world_size: int, tmpdir):
     os.environ["RANK"] = str(rank)
     os.environ["LOCAL_RANK"] = str(rank)
     sync_file = f"file://{tmpdir}/sync"
+    #sync_file = 'tcp://10.1.1.20:23456'
     torch.distributed.init_process_group(
         "gloo", rank=rank, world_size=world_size, init_method=sync_file
     )
@@ -272,12 +277,15 @@ def parallel_mean_var_update(rank, world_size, tmpdir, random_seed):
         if float(torch.rand(size=(), generator=generator)) < 0.3:
             return None
         else:
-            return torch.randint(
+            mask = torch.randint(
                 high=2,
                 size=main_shape + (1,),
                 generator=generator,
                 dtype=torch.bool,
             )
+            if mask.count_nonzero() == 0:
+                return None
+            return mask
 
     inputs = [
         [random_input(generator) for _ in range(num_rounds)]


### PR DESCRIPTION
Input norm test is failing on some inputs on the CI server, but not locally.

This first attempt just addresses the divide by zero warning, in case that's the issue.