### PR TITLE
Avoid running tests on draft PRs

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,7 @@ on: # yamllint disable-line rule:truthy
 
 jobs:
   pre-commit:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -10,6 +10,7 @@ on:    # yamllint disable-line rule:truthy
 
 jobs:
     tests:
+        if: github.event.pull_request.draft == false
         name: Tests
         runs-on: ubuntu-latest
         strategy:

--- a/.github/workflows/verify-docs-gen.yml
+++ b/.github/workflows/verify-docs-gen.yml
@@ -8,6 +8,7 @@ on:    # yamllint disable-line rule:truthy
 
 jobs:
     docs:
+        if: github.event.pull_request.draft == false
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
For efficiency, skip running tests on draft PRs until they're ready for review. Creating this as a draft to verify no tests are run.
