### PR TITLE
Fix argument to rec_loss in (Variational)AutoencoderLoss (from Samsung AI Center Cambridge)

### DIFF
--- a/speechbrain/nnet/losses.py
+++ b/speechbrain/nnet/losses.py
@@ -1712,7 +1712,7 @@ class VariationalAutoencoderLoss(nn.Module):
     def _compute_components(self, predictions, targets):
         rec, _, mean, log_var, _, _ = predictions
         rec_loss = self._align_length_axis(
-            self.rec_loss(targets, rec, reduction=None)
+            self.rec_loss(targets, rec, reduction="none")
         )
         dist_loss = self._align_length_axis(
             -0.5 * (1 + log_var - mean**2 - log_var.exp())
@@ -1785,7 +1785,7 @@ class AutoencoderLoss(nn.Module):
         The computed loss.
         """
         rec_loss = self._align_length_axis(
-            self.rec_loss(targets, predictions.rec, reduction=None)
+            self.rec_loss(targets, predictions.rec, reduction="none")
         )
         return _reduce_autoencoder_loss(rec_loss, length, reduction)
 


### PR DESCRIPTION
## What does this PR do?

This fixes what is seemingly a bug. This was flagged by Pyright (see #2901).

The protocol for `rec_loss` is not specified, but its default value for `rec_loss` is `mseloss`, which has a parameter `reduction="mean"`. So I assume the value for `reduction` should be `"none"` instead of `None`.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
