### PR TITLE
Ensure that x is not unbound in WordEmbeddingEncoder (from Samsung, AI Center, Cambridge)

### DIFF
--- a/speechbrain/lobes/models/g2p/model.py
+++ b/speechbrain/lobes/models/g2p/model.py
@@ -193,8 +193,7 @@ class WordEmbeddingEncoder(nn.Module):
         emb_enc: torch.Tensor
             encoded word embeddings
         """
-        if self.norm is not None:
-            x = self.norm(emb)
+        x = emb if self.norm is None else self.norm(emb)
         x = self.lin(x)
         x = self.activation(x)
         return x


### PR DESCRIPTION
## What does this PR do?

I believe that this fixes a bug in `WordEmbeddingEncoder.forward` when `self.norm is None`. I believe `x` would have been unbound.

I found this with Pyright (see https://github.com/speechbrain/speechbrain/pull/2901).

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
