### PR TITLE
Use correct signature for torch.tensor.type() (from Samsung, AI Center, Cambridge)

### DIFF
--- a/speechbrain/alignment/aligner.py
+++ b/speechbrain/alignment/aligner.py
@@ -739,7 +739,7 @@ class HMMAligner(torch.nn.Module):
             )
             v_matrix[:, :, t] = x + emiss_pred_useful[:, :, t]
 
-            backpointers[:, :, t] = argmax.type(torch.FloatTensor)
+            backpointers[:, :, t] = argmax.type(dtype=torch.float32)
 
         z_stars = []
         z_stars_loc = []


### PR DESCRIPTION
## What does this PR do?

This fixes a call `.type(torch.FloatTensor)` which according to the signature of `.type` should pass a `dtype`.

This was flagged by Pyright (see https://github.com/speechbrain/speechbrain/pull/2901).

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
