### PR TITLE
Replace axis= by dim= for calls to Torch (from Samsung, AI Center, Cambridge)

### DIFF
--- a/speechbrain/lobes/models/L2I.py
+++ b/speechbrain/lobes/models/L2I.py
@@ -99,7 +99,7 @@ class Psi(nn.Module):
         # for compatibility with cnn14 fixed frequency dimension
         x1 = F.pad(x1, (0, 1, 0, 0))
         x2 = F.pad(x2, (0, 1, 0, 0))
-        x = torch.cat((x1, x2, x3), axis=1)
+        x = torch.cat((x1, x2, x3), dim=1)
 
         # upsample time axis and collapse freq
         x = self.upsamp_time(x)

--- a/speechbrain/lobes/models/discrete/speechtokenizer.py
+++ b/speechbrain/lobes/models/discrete/speechtokenizer.py
@@ -151,7 +151,7 @@ class SpeechTokenizer(nn.Module):
         ]  # Contain timbre info, complete info lost by the first quantizer
 
         # Concatenating semantic tokens (RVQ_1) and supplementary timbre tokens and then decoding
-        wav = self.model.decode(torch.cat([RVQ_1, RVQ_supplement], axis=0))
+        wav = self.model.decode(torch.cat([RVQ_1, RVQ_supplement], dim=0))
 
         # Decoding from RVQ-i:j tokens from the ith quantizers to the jth quantizers
         # wav = self.model.decode(codes[i: (j + 1)], st=i)

--- a/speechbrain/lobes/models/segan_model.py
+++ b/speechbrain/lobes/models/segan_model.py
@@ -240,7 +240,7 @@ def g3_loss(
             ZERO, torch.exp(ZERO) ** (1 / 2)
         )
         kl = torch.distributions.kl.kl_divergence(distq, distp)
-        kl = kl.sum(axis=1).sum(axis=1).mean()
+        kl = kl.sum(dim=1).sum(dim=1).mean()
     else:
         kl = 0
     if reduction == "mean":

--- a/speechbrain/nnet/loss/stoi_loss.py
+++ b/speechbrain/nnet/loss/stoi_loss.py
@@ -118,7 +118,7 @@ def removeSilentFrames(x, y, dyn_range=40, N=256, K=128):
             (x_sil[0:K, 1:] + x_sil[K:, 0:-1]).T.flatten(),
             x_sil[K:N, -1],
         ),
-        axis=0,
+        dim=0,
     )
     y_sil = torch.cat(
         (
@@ -126,7 +126,7 @@ def removeSilentFrames(x, y, dyn_range=40, N=256, K=128):
             (y_sil[0:K, 1:] + y_sil[K:, 0:-1]).T.flatten(),
             y_sil[K:N, -1],
         ),
-        axis=0,
+        dim=0,
     )
 
     return [x_sil, y_sil]

--- a/speechbrain/nnet/unet.py
+++ b/speechbrain/nnet/unet.py
@@ -1341,7 +1341,7 @@ class EncoderUNetModel(nn.Module):
         h = self.middle_block(h, emb)
         if self.spatial_pooling:
             results.append(h.type(x.dtype).mean(dim=(2, 3)))
-            h = torch.cat(results, axis=-1)
+            h = torch.cat(results, dim=-1)
             return self.out(h)
         else:
             h = h.type(x.dtype)

--- a/speechbrain/processing/multi_mic.py
+++ b/speechbrain/processing/multi_mic.py
@@ -1552,9 +1552,9 @@ def sphere(levels_count=4):
         subtrs[3 * trs_count + torch.arange(0, trs_count), 5] = trs[:, 0]
 
         subtrs_flatten = torch.cat(
-            (subtrs[:, [0, 1]], subtrs[:, [2, 3]], subtrs[:, [4, 5]]), axis=0
+            (subtrs[:, [0, 1]], subtrs[:, [2, 3]], subtrs[:, [4, 5]]), dim=0
         )
-        subtrs_sorted, _ = torch.sort(subtrs_flatten, axis=1)
+        subtrs_sorted, _ = torch.sort(subtrs_flatten, dim=1)
 
         index_max = torch.max(subtrs_sorted)
 
@@ -1581,7 +1581,7 @@ def sphere(levels_count=4):
 
         pts = pts[unique_values[:, 0], :] + pts[unique_values[:, 1], :]
         pts /= torch.repeat_interleave(
-            torch.unsqueeze(torch.sum(pts**2, axis=1) ** 0.5, 1), 3, 1
+            torch.unsqueeze(torch.sum(pts**2, dim=1) ** 0.5, 1), 3, 1
         )
 
     return pts


### PR DESCRIPTION
This fixes calls to Torch functions that use `axis=` (Numpy-style, I suspect) instead of `dim=`.

These problems were flagged by Pyright (see https://github.com/speechbrain/speechbrain/pull/2901).

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
