### PR TITLE
Account for all combinations of arguments in IterativeCSVWriter.write (from Samsung, AI Center, Cambridge)

### DIFF
--- a/speechbrain/dataio/dataio.py
+++ b/speechbrain/dataio/dataio.py
@@ -694,20 +694,28 @@ class IterativeCSVWriter:
             Supply certain fields by key. The ID field is mandatory for all
             lines, but others can be left empty.
         """
-        if args and kwargs:
-            raise ValueError(
-                "Use either positional fields or named fields, but not both."
-            )
         if args:
             if len(args) != len(self.fields):
                 raise ValueError("Need consistent fields")
             to_write = [str(arg) for arg in args]
-        if kwargs:
-            if "ID" not in kwargs:
-                raise ValueError("I'll need to see some ID")
-            full_vals = self.defaults.copy()
-            full_vals.update(kwargs)
-            to_write = [str(full_vals.get(field, "")) for field in self.fields]
+            if kwargs:
+                raise ValueError(
+                    "Use either positional fields or named fields, "
+                    "but not both."
+                )
+        else:
+            if kwargs:
+                if "ID" not in kwargs:
+                    raise ValueError("I'll need to see some ID")
+                full_vals = self.defaults.copy()
+                full_vals.update(kwargs)
+                to_write = [
+                    str(full_vals.get(field, "")) for field in self.fields
+                ]
+            else:
+                raise ValueError(
+                    "Use either positional fields or named fields."
+                )
         self._outstream.write("\n")
         self._outstream.write(",".join(to_write))
 


### PR DESCRIPTION
## What does this PR do?

This ensures that `IterativeCSVWriter.write` raises `ValueError` not only when both types of arguments are given, but also when none is given. The current behaviour would be an error about `to_write` being undefined.

This was flagged by Pyright (see https://github.com/speechbrain/speechbrain/pull/2901):
```speechbrain/dataio/dataio.py:712:40 - error: "to_write" is possibly unbound (reportPossiblyUnboundVariable)```

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
