### PR TITLE
Make f_max integer (from Samsung, AI Center, Cambridge)

### DIFF
--- a/speechbrain/lobes/features.py
+++ b/speechbrain/lobes/features.py
@@ -119,7 +119,7 @@ class Fbank(torch.nn.Module):
         self.requires_grad = requires_grad
 
         if f_max is None:
-            f_max = sample_rate / 2
+            f_max = sample_rate // 2
 
         self.compute_STFT = STFT(
             sample_rate=sample_rate,
@@ -260,7 +260,7 @@ class MFCC(torch.nn.Module):
         self.requires_grad = requires_grad
 
         if f_max is None:
-            f_max = sample_rate / 2
+            f_max = sample_rate // 2
 
         self.compute_STFT = STFT(
             sample_rate=sample_rate,


### PR DESCRIPTION
## What does this PR do?

In the `FBank` class, if `f_max is None`, it is set to the Nyquist frequency, but the division by 2 should be an integer division (`//`).

This was flagged by Pyright (see https://github.com/speechbrain/speechbrain/pull/2901).

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
