### PR TITLE
Make arpa_to_fst work when arguments are str (from Samsung, AI Center, Cambridge)

### DIFF
--- a/speechbrain/lm/arpa.py
+++ b/speechbrain/lm/arpa.py
@@ -325,6 +325,11 @@ def arpa_to_fst(
             "Install using `pip install kaldilm`."
         )
 
+    if isinstance(out_fst, str):
+        out_fst = Path(out_fst)
+    if isinstance(in_arpa, str):
+        in_arpa = Path(in_arpa)
+
     if cache and out_fst.exists():
         return
     if not in_arpa.exists():


### PR DESCRIPTION
## What does this PR do?

`arpa_to_fst` calls `out_fst.exists()` and `in_arpa.exists()`, but `out_fst` and `in_arpa` can be not only `Path` (when this works) but also `str` (when this'll fail).

This therefore explicitly converts to Path where necessary.

This was flagged by Pyright (see https://github.com/speechbrain/speechbrain/pull/2901).

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
