### PR TITLE
Replace deprecated torch.cuda.amp.custom_fwd with torch.amp.custom_fw

### DIFF
--- a/speechbrain/utils/autocast.py
+++ b/speechbrain/utils/autocast.py
@@ -137,7 +137,7 @@ def fwd_default_precision(
 ):
     """Decorator for forward methods which, by default, *disables* autocast
     and casts any floating-point tensor parameters into the specified dtype
-    (much like `torch.cuda.amp.custom_fwd`).
+    (much like `torch.amp.custom_fwd`).
 
     The *wrapped forward* will gain an additional `force_allow_autocast` keyword
     parameter.
@@ -180,12 +180,13 @@ def fwd_default_precision(
     if fwd is None:
         return functools.partial(fwd_default_precision, cast_inputs=cast_inputs)
 
-    # NOTE: torch.cuda.amp.custom_fwd is written with the assumption of CUDA
-    # autocast. There does not seem to be a generic equivalent.
-    # Detecting CUDA AMP specifically also seems difficult or impossible, so we
-    # cannot even reliably warn about the issue. For now, we just document the
-    # problem.
-    wrapped_fwd = torch.cuda.amp.custom_fwd(fwd, cast_inputs=cast_inputs)
+    # NOTE: Previously used torch.cuda.amp.custom_fwd, which assumed CUDA autocast.
+    # Now updated to torch.amp.custom_fwd with explicit device_type='cuda'.
+    # There does not seem to be a generic equivalent for non-CUDA devices.
+    # Detecting active AMP device automatically is non-trivial, so for now,
+    # we assume CUDA context explicitly as before.
+
+    wrapped_fwd = torch.amp.custom_fwd(fwd, cast_inputs=cast_inputs, device_type='cuda')
 
     @functools.wraps(fwd)
     def wrapper(*args, force_allow_autocast: bool = False, **kwargs):
@@ -211,3 +212,4 @@ def fwd_default_precision(
             return wrapped_fwd(*args, **kwargs)
 
     return wrapper
+


### PR DESCRIPTION
## What does this PR do?

This pull request updates the `fwd_default_precision` decorator in `autocast.py` to replace the deprecated `torch.cuda.amp.custom_fwd` with the recommended `torch.amp.custom_fwd`, including the required argument `device_type='cuda'`.

This change prevents future compatibility issues and suppresses deprecation warnings introduced in recent versions of PyTorch (>= 2.1). The update is strictly scoped to maintain backward compatibility while aligning with PyTorch's AMP API changes.

No new dependencies are introduced.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

