### PR TITLE
Move sentencepiece to extra_requirements.txt

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -138,7 +138,6 @@ our tests cover one PyTorch version only, _the latest_.
        "numpy",
        "packaging",
        "scipy",
-       "sentencepiece",
        "torch>=1.9",
        "torchaudio",
        "tqdm",

--- a/recipes/AISHELL-1/ASR/seq2seq/extra_requirements.txt
+++ b/recipes/AISHELL-1/ASR/seq2seq/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/AISHELL-1/ASR/transformer/extra_requirements.txt
+++ b/recipes/AISHELL-1/ASR/transformer/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/AISHELL-1/Tokenizer/extra_requirements.txt
+++ b/recipes/AISHELL-1/Tokenizer/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/Fisher-Callhome-Spanish/ST/transformer/extra_requirements.txt
+++ b/recipes/Fisher-Callhome-Spanish/ST/transformer/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/Fisher-Callhome-Spanish/Tokenizer/extra_requirements.txt
+++ b/recipes/Fisher-Callhome-Spanish/Tokenizer/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/KsponSpeech/ASR/transformer/extra_requirements.txt
+++ b/recipes/KsponSpeech/ASR/transformer/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/KsponSpeech/LM/extra_requirements.txt
+++ b/recipes/KsponSpeech/LM/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/KsponSpeech/Tokenizer/extra_requirements.txt
+++ b/recipes/KsponSpeech/Tokenizer/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/LibriSpeech/ASR/CTC/extra_requirements.txt
+++ b/recipes/LibriSpeech/ASR/CTC/extra_requirements.txt
@@ -1,3 +1,4 @@
 https://github.com/kpu/kenlm/archive/master.zip
 # k2 # It is better to install k2 with the procedure listed here: https://k2-fsa.github.io/k2/installation/from_wheels.html
 kaldilm==1.15.1
+sentencepiece>=0.1.91

--- a/recipes/LibriSpeech/ASR/seq2seq/extra_requirements.txt
+++ b/recipes/LibriSpeech/ASR/seq2seq/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/LibriSpeech/ASR/transducer/extra_requirements.txt
+++ b/recipes/LibriSpeech/ASR/transducer/extra_requirements.txt
@@ -3,3 +3,4 @@
 # You might need to install numba with conda
 # You might also need to install other packages such as cudatoolkit
 numba
+sentencepiece>=0.1.91

--- a/recipes/LibriSpeech/ASR/transformer/extra_requirements.txt
+++ b/recipes/LibriSpeech/ASR/transformer/extra_requirements.txt
@@ -1,1 +1,2 @@
 bayestorch>=0.0.3 # For Bayes ASR recipe
+sentencepiece>=0.1.91

--- a/recipes/SLURP/NLU/extra_requirements.txt
+++ b/recipes/SLURP/NLU/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/SLURP/direct/extra_requirements.txt
+++ b/recipes/SLURP/direct/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/Switchboard/ASR/seq2seq/extra_requirements.txt
+++ b/recipes/Switchboard/ASR/seq2seq/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/Switchboard/ASR/transformer/extra_requirements.txt
+++ b/recipes/Switchboard/ASR/transformer/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/Switchboard/LM/extra_requirements.txt
+++ b/recipes/Switchboard/LM/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/Switchboard/Tokenizer/extra_requirements.txt
+++ b/recipes/Switchboard/Tokenizer/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/Tedlium2/ASR/transformer/extra_requirements.txt
+++ b/recipes/Tedlium2/ASR/transformer/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/Tedlium2/Tokenizer/extra_requirements.txt
+++ b/recipes/Tedlium2/Tokenizer/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/VoxPopuli/ASR/transducer/extra_requirements.txt
+++ b/recipes/VoxPopuli/ASR/transducer/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/VoxPopuli/Tokenizer/extra_requirements.txt
+++ b/recipes/VoxPopuli/Tokenizer/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/fluent-speech-commands/Tokenizer/extra_requirements.txt
+++ b/recipes/fluent-speech-commands/Tokenizer/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/fluent-speech-commands/direct/extra_requirements.txt
+++ b/recipes/fluent-speech-commands/direct/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/timers-and-such/LM/extra_requirements.txt
+++ b/recipes/timers-and-such/LM/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/timers-and-such/Tokenizer/extra_requirements.txt
+++ b/recipes/timers-and-such/Tokenizer/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/timers-and-such/decoupled/extra_requirements.txt
+++ b/recipes/timers-and-such/decoupled/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/recipes/timers-and-such/direct/extra_requirements.txt
+++ b/recipes/timers-and-such/direct/extra_requirements.txt
@@ -1,4 +1,1 @@
-librosa
-pesq
-pystoi
 sentencepiece>=0.1.91

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ packaging
 pandas>=1.0.1
 pre-commit>=2.3.0
 scipy>=1.4.1
-sentencepiece>=0.1.91
 SoundFile; sys_platform == 'win32'
 torch>=2.1.0
 torchaudio>=2.1.0


### PR DESCRIPTION
Fixes #2944 

We will work on new recipes using different a different tokenizer (e.g. HF `tokenizers` or `torchtext`) but for now we just remove the requirement from the main library and put it in `extra_requirements.txt` for every recipe that uses it.