### PR TITLE
Fix missing defaults in run options

### DIFF
--- a/speechbrain/utils/run_opts.py
+++ b/speechbrain/utils/run_opts.py
@@ -316,6 +316,7 @@ class RunOptions:
                 kwargs["action"] = "store_true"
             elif default is not None:
                 kwargs["type"] = type(default)
+                kwargs["default"] = default
 
             # Any options with "precision" in the name can only take these values
             if "precision" in option:


### PR DESCRIPTION
Fixes #2950 

String-based defaults were mistakenly missing from the run opts command line interface