### PR TITLE
fix unnecessary pos_emb for RoPE

### DIFF
--- a/speechbrain/lobes/models/transformer/Conformer.py
+++ b/speechbrain/lobes/models/transformer/Conformer.py
@@ -804,7 +804,6 @@ class ConformerEncoder(nn.Module):
 
         if (
             self.attention_type == "RelPosMHAXL"
-            or self.attention_type == "RoPEMHA"
         ):
             if pos_embs is None:
                 raise ValueError(

--- a/speechbrain/lobes/models/transformer/Conformer.py
+++ b/speechbrain/lobes/models/transformer/Conformer.py
@@ -802,9 +802,7 @@ class ConformerEncoder(nn.Module):
             The attention values.
         """
 
-        if (
-            self.attention_type == "RelPosMHAXL"
-        ):
+        if self.attention_type == "RelPosMHAXL":
             if pos_embs is None:
                 raise ValueError(
                     f"The chosen attention type for the Conformer is {self.attention_type}. For this attention type, the positional embeddings are mandatory"


### PR DESCRIPTION
This PR deletes the `pos_emb` check for RoPE in `forward_streaming` of the Conformer. The rotation matrix of RoPE will not be passed as an argument so this line shouldn't be here. 