### PR TITLE
Use epoch loop loader for transfer to correctly handle end_of_epoch

### DIFF
--- a/speechbrain/utils/epoch_loop.py
+++ b/speechbrain/utils/epoch_loop.py
@@ -12,6 +12,7 @@ from speechbrain.utils.logger import get_logger
 from .checkpoints import (
     mark_as_loader,
     mark_as_saver,
+    mark_as_transfer,
     register_checkpoint_hooks,
 )
 
@@ -65,6 +66,7 @@ class EpochCounter:
             fo.write(str(self.current))
 
     @mark_as_loader
+    @mark_as_transfer
     def _recover(self, path, end_of_epoch=True):
         # NOTE: end_of_epoch = True by default so that when
         #  loaded in parameter transfer, this starts a new epoch.
@@ -183,6 +185,7 @@ class EpochCounterWithStopper(EpochCounter):
             )
 
     @mark_as_loader
+    @mark_as_transfer
     def _recover(self, path, end_of_epoch=True, device=None):
         del device  # Not used.
         with open(path, encoding="utf-8") as fi:


### PR DESCRIPTION
Fixes #2964 

I used this code to test:

```python
import speechbrain as sb

counter = sb.utils.epoch_loop.EpochCounter(10)
checkpoints = sb.utils.checkpoints.Checkpointer("tmpdir", {"epoch": counter})

for epoch in counter:
    print(epoch)
    ckpt = checkpoints.save_checkpoint()

print("Epoch at end", counter.current)

# Load via parameter transfer
transfer = sb.utils.parameter_transfer.Pretrainer(loadables={"epoch": counter})
transfer.collect_files(ckpt.path)
transfer.load_collected()

# Load via checkpoint
#checkpoints.load_checkpoint(ckpt)

# Test
counter.limit = 20
for epoch in counter:
    print(epoch)
```