### PR TITLE
fix speed perturb inversion

### DIFF
--- a/speechbrain/augment/time_domain.py
+++ b/speechbrain/augment/time_domain.py
@@ -8,6 +8,7 @@ All classes are implemented as `torch.nn.Module`, enabling end-to-end differenti
 Authors:
 - Peter Plantinga (2020)
 - Mirco Ravanelli (2023)
+- Gianfranco Dumoulin Bertucci (2025)
 """
 
 # Importing libraries
@@ -477,7 +478,7 @@ class SpeedPerturb(torch.nn.Module):
     >>> clean.shape
     torch.Size([1, 52173])
     >>> perturbed.shape
-    torch.Size([1, 46956])
+    torch.Size([1, 57971])
     """
 
     def __init__(self, orig_freq, speeds=[90, 100, 110], device="cpu"):
@@ -493,7 +494,7 @@ class SpeedPerturb(torch.nn.Module):
         for speed in self.speeds:
             config = {
                 "orig_freq": self.orig_freq,
-                "new_freq": self.orig_freq * speed // 100,
+                "new_freq": round(self.orig_freq * 100 / speed),
             }
             self.resamplers.append(Resample(**config))
 

--- a/tests/integration/augmentation/hyperparams.yaml
+++ b/tests/integration/augmentation/hyperparams.yaml
@@ -48,4 +48,4 @@ do_clip: !new:speechbrain.augment.time_domain.DoClip
 
 speed_perturb: !new:speechbrain.augment.time_domain.SpeedPerturb
     orig_freq: !ref <sample_rate>
-    speeds: [90]
+    speeds: [111.11]

--- a/tests/unittests/test_augment.py
+++ b/tests/unittests/test_augment.py
@@ -104,7 +104,10 @@ def test_speed_perturb(device):
 
     # Half speed
     half_speed = SpeedPerturb(16000, speeds=[50]).to(device)
-    assert half_speed(test_waveform).allclose(test_waveform[:, ::2], atol=3e-1)
+    slowed_wav = half_speed(test_waveform)
+
+    assert slowed_wav.shape[-1] > test_waveform.shape[-1]
+    assert slowed_wav.shape[-1] == test_waveform.shape[-1] * 2
 
 
 def test_drop_freq(device):


### PR DESCRIPTION
## What does this PR do?
This PR fixes the inverted speed perturb logic, updates the unit tests, and replaces the incorrect "expected" output for the integration tests.

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #2993

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Does your code adhere to project-specific code style and conventions?

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- [ ] Confirm that the changes adhere to compatibility requirements (e.g., Python version, platform)
- [ ] Review the self-review checklist to ensure the code is ready for review

</details>

<!--

🎩 Magic happens when you code. Keep the spells flowing!

-->
