### PR TITLE
Fix typo in literature reference

### DIFF
--- a/docs/tutorials/nn/conformer-streaming-asr.ipynb
+++ b/docs/tutorials/nn/conformer-streaming-asr.ipynb
@@ -556,7 +556,7 @@
     "The easiest way to train a streaming Conformer model is currently using the RNN-T loss (and optionally CTC as an auxiliary loss to improve training). For a refresher, see [Speech Recognition From Scratch](https://speechbrain.readthedocs.io/en/latest/tutorials/tasks/speech-recognition-from-scratch.html) and its linked resources.\n",
     "\n",
     "It may be possible to also add encoder-decoder cross-entropy as either an auxiliary loss (to improve model accuracy even if using the RNN-T path for inference), or used for streaming, but this was not tested and is currently unsupported.  \n",
-    "To implement this, you may want to explore the litterature and the approach taken by competitive models."
+    "To implement this, you may want to explore the literature and the approach taken by competitive models."
    ]
   },
   {


### PR DESCRIPTION
## What does this PR do?

This pull request makes a minor correction in the documentation for the streaming Conformer ASR tutorial, fixing a typo in the word "literature."