### PR TITLE
docs: fix incorrect parameter description in load_data_json

### DIFF
--- a/speechbrain/dataio/dataio.py
+++ b/speechbrain/dataio/dataio.py
@@ -43,7 +43,7 @@ def load_data_json(json_path, replacements=None):
     Arguments
     ---------
     json_path : str
-        Path to CSV file.
+        Path to the JSON file.
     replacements : dict
         (Optional dict), e.g., {"data_folder": "/home/speechbrain/data"}.
         This is used to recursively format all string values in the data.


### PR DESCRIPTION
## Summary

Fixes a small docstring typo in `load_data_json`.

The `json_path` parameter description incorrectly referred to a CSV file instead of a JSON file.

## Changes

* Updated:

  * `Path to CSV file.`
  * → `Path to the JSON file.`

## Notes

* Documentation-only change
* No runtime behavior modified
* No unrelated files changed
