### PR TITLE
Fix incorrect documented defaults for HF wrapper freeze/output_norm (#3060)

### DIFF
--- a/speechbrain/integrations/huggingface/hubert.py
+++ b/speechbrain/integrations/huggingface/hubert.py
@@ -38,10 +38,10 @@ class HuBERT(Wav2Vec2):
         HuggingFace hub name: e.g "facebook/hubert-base-ls960"
     save_path : str
         Path (dir) of the downloaded model.
-    output_norm : bool (default: True)
+    output_norm : bool (default: False)
         If True, a layer_norm (affine) will be applied to the output obtained
         from the HuBERT model.
-    freeze : bool (default: True)
+    freeze : bool (default: False)
         If True, the model is frozen. If False, the model will be trained
         alongside with the rest of the pipeline.
     freeze_feature_extractor :  bool (default: False)

--- a/speechbrain/integrations/huggingface/huggingface.py
+++ b/speechbrain/integrations/huggingface/huggingface.py
@@ -75,7 +75,7 @@ class HFTransformersInterface(nn.Module):
         If True, build a sequence-to-sequence model with lm_head
     quantization_config : dict (default: None)
         Quantization config, extremely useful for deadling with LLM
-    freeze : bool (default: True)
+    freeze : bool (default: False)
         If True, the model is frozen. If False, the model will be trained
         alongside with the rest of the pipeline.
     cache_dir : str or Path (default: None)

--- a/speechbrain/integrations/huggingface/mert.py
+++ b/speechbrain/integrations/huggingface/mert.py
@@ -34,10 +34,10 @@ class MERT(Wav2Vec2):
         HuggingFace hub name: e.g "m-a-p/MERT-v1-330M"
     save_path : str
         Path (dir) of the downloaded model.
-    output_norm : bool (default: True)
+    output_norm : bool (default: False)
         If True, a layer_norm (affine) will be applied to the output obtained
         from the mert model.
-    freeze : bool (default: True)
+    freeze : bool (default: False)
         If True, the model is frozen. If False, the model will be trained
         alongside with the rest of the pipeline.
     freeze_feature_extractor :  bool (default: False)

--- a/speechbrain/integrations/huggingface/wav2vec2.py
+++ b/speechbrain/integrations/huggingface/wav2vec2.py
@@ -45,10 +45,10 @@ class Wav2Vec2(HFTransformersInterface):
         HuggingFace hub name: e.g "facebook/wav2vec2-large-lv60"
     save_path : str
         Path (dir) of the downloaded model.
-    output_norm : bool (default: True)
+    output_norm : bool (default: False)
         If True, a layer_norm (affine) will be applied to the output obtained
         from the wav2vec model.
-    freeze : bool (default: True)
+    freeze : bool (default: False)
         If True, the model is frozen. If False, the model will be trained
         alongside with the rest of the pipeline.
     freeze_feature_extractor :  bool (default: False)

--- a/speechbrain/integrations/huggingface/wavlm.py
+++ b/speechbrain/integrations/huggingface/wavlm.py
@@ -38,10 +38,10 @@ class WavLM(Wav2Vec2):
         HuggingFace hub name: e.g "microsoft/wavlm-large"
     save_path : str
         Path (dir) of the downloaded model.
-    output_norm : bool (default: True)
+    output_norm : bool (default: False)
         If True, a layer_norm (affine) will be applied to the output obtained
         from the wavlm model.
-    freeze : bool (default: True)
+    freeze : bool (default: False)
         If True, the model is frozen. If False, the model will be trained
         alongside with the rest of the pipeline.
     freeze_feature_extractor :  bool (default: False)

--- a/speechbrain/integrations/huggingface/weighted_ssl.py
+++ b/speechbrain/integrations/huggingface/weighted_ssl.py
@@ -39,7 +39,7 @@ class WeightedSSLModel(HFTransformersInterface):
         Path (dir) of the downloaded model.
     layernorm: bool, (default: False)
         Whether layer representations should be layernormed before sum
-    freeze : bool (default: True)
+    freeze : bool (default: False)
         If True, the model is frozen. If False, the model will be trained
         alongside with the rest of the pipeline.
     **kwargs : dict


### PR DESCRIPTION
## Summary

Fixes #3060.

Several HuggingFace integration wrappers document `freeze` (and, for the SSL feature-extractor wrappers, `output_norm`) as defaulting to `True`, but their `__init__` signatures actually default to `False`. The reported case is `Wav2Vec2.freeze` (docstring says `default: True`, code is `freeze=False`).

This is a copy-paste error: the more recently added `W2VBert` wrapper documents these arguments correctly (`output_norm` → `False`, `freeze` → `True` matching its own signature), which confirms the intended fix is to correct the docstrings rather than change any runtime defaults.

This PR is **documentation only** — no behavior changes.

## Changes

Corrected the documented defaults to match the actual `__init__` defaults:

| File | Argument(s) corrected (`True` → `False`) |
| --- | --- |
| `huggingface/wav2vec2.py` (reported) | `output_norm`, `freeze` |
| `huggingface/wavlm.py` | `output_norm`, `freeze` |
| `huggingface/hubert.py` | `output_norm`, `freeze` |
| `huggingface/mert.py` | `output_norm`, `freeze` |
| `huggingface/weighted_ssl.py` | `freeze` |
| `huggingface/huggingface.py` (base `HFTransformersInterface`) | `freeze` |

Wrappers that were already consistent (`w2v_bert`, `whisper`, `gpt`, `nllb`, `mbart`, `textencoder`, `labse`, `llama`) were left untouched.

## Verification

- Confirmed each corrected default against the corresponding `__init__` signature.
- `ruff check` and `ruff format --check` pass on all changed files.
- The change is docstring-only, so existing behavior and the `tests/utils/check_docstrings.py` presence check are unaffected.
