### PR TITLE
Fix LoRA adapter support for convolutional layers (fixes #3056)

### DIFF
--- a/speechbrain/nnet/adapters.py
+++ b/speechbrain/nnet/adapters.py
@@ -332,7 +332,7 @@ class LoRA(nn.Module):
     ---------
     target_module: nn.Module
         Module corresponding to the pretrained layer that will be wrapped with
-        this adapter. Works with nn.Linear and nn.Conv
+        this adapter. Works with nn.Linear and nn.Conv1d/2d/3d
     rank: int
         Size of the projection layer or rank (usually smaller).
     alpha : float
@@ -347,13 +347,16 @@ class LoRA(nn.Module):
     >>> output = adapt(x)
     >>> output.shape
     torch.Size([8, 60, 64])
+
+    >>> x = torch.rand((8, 16, 100))
+    >>> base_conv = nn.Conv1d(16, 32, kernel_size=3, stride=2)
+    >>> adapt = LoRA(base_conv, rank=4)
+    >>> adapt(x).shape == base_conv(x).shape
+    True
     """
 
     def __init__(self, target_module, rank=16, alpha=1.0):
         super().__init__()
-
-        input_size = target_module.weight.data.shape[1]
-        output_size = target_module.weight.data.shape[0]
 
         # Disable gradient for pretrained module
         self.pretrained_module = target_module
@@ -361,12 +364,46 @@ class LoRA(nn.Module):
             param.requires_grad = False
         device = target_module.weight.device
 
-        self.adapter_down_proj = nn.Linear(
-            input_size, rank, bias=False, device=device
-        )
-        self.adapter_up_proj = nn.Linear(
-            rank, output_size, bias=False, device=device
-        )
+        if isinstance(target_module, (nn.Conv1d, nn.Conv2d, nn.Conv3d)):
+            if target_module.groups != 1:
+                raise ValueError(
+                    "LoRA does not support convolutions with groups != 1, "
+                    f"got groups={target_module.groups} for {target_module}."
+                )
+            conv_cls = type(target_module)
+            # Follows the approach of HF peft: the down projection mirrors
+            # the geometry of the pretrained convolution so that both
+            # branches produce outputs of identical shape, while the up
+            # projection is a pointwise convolution.
+            self.adapter_down_proj = conv_cls(
+                target_module.in_channels,
+                rank,
+                kernel_size=target_module.kernel_size,
+                stride=target_module.stride,
+                padding=target_module.padding,
+                dilation=target_module.dilation,
+                padding_mode=target_module.padding_mode,
+                bias=False,
+                device=device,
+            )
+            self.adapter_up_proj = conv_cls(
+                rank,
+                target_module.out_channels,
+                kernel_size=1,
+                bias=False,
+                device=device,
+            )
+        else:
+            input_size = target_module.weight.data.shape[1]
+            output_size = target_module.weight.data.shape[0]
+
+            self.adapter_down_proj = nn.Linear(
+                input_size, rank, bias=False, device=device
+            )
+            self.adapter_up_proj = nn.Linear(
+                rank, output_size, bias=False, device=device
+            )
+
         self.adapter_up_proj.weight.data.fill_(0.0)
 
         self.scaling = alpha / rank

--- a/tests/unittests/test_adapters.py
+++ b/tests/unittests/test_adapters.py
@@ -1,0 +1,152 @@
+import pytest
+import torch
+import torch.nn as nn
+
+
+def test_lora_linear_identity_at_init(device):
+    from speechbrain.nnet.adapters import LoRA
+
+    base = nn.Linear(16, 24).to(device)
+    adapter = LoRA(base, rank=4)
+    x = torch.rand(8, 10, 16, device=device)
+
+    # LoRA property: the up projection starts at zero, so the adapted
+    # layer must behave exactly like the pretrained layer at init.
+    assert torch.allclose(adapter(x), base(x))
+
+
+def test_lora_conv1d_identity_at_init(device):
+    from speechbrain.nnet.adapters import LoRA
+
+    base = nn.Conv1d(16, 32, kernel_size=3, stride=2).to(device)
+    adapter = LoRA(base, rank=4)
+    x = torch.rand(8, 16, 100, device=device)
+    out = adapter(x)
+
+    assert out.shape == base(x).shape
+    assert torch.allclose(out, base(x))
+
+
+def test_lora_conv_geometries(device):
+    from speechbrain.nnet.adapters import LoRA
+
+    for conv_kwargs in (
+        {"kernel_size": 10, "stride": 5},
+        {"kernel_size": 3, "padding": "same"},
+        {"kernel_size": 5, "padding": 2, "dilation": 2},
+    ):
+        base = nn.Conv1d(4, 8, **conv_kwargs).to(device)
+        adapter = LoRA(base, rank=2)
+        x = torch.rand(2, 4, 50, device=device)
+        assert adapter(x).shape == base(x).shape
+
+
+def test_lora_conv2d_and_conv3d(device):
+    from speechbrain.nnet.adapters import LoRA
+
+    base_2d = nn.Conv2d(3, 8, kernel_size=3, stride=2).to(device)
+    adapter_2d = LoRA(base_2d, rank=2)
+    x_2d = torch.rand(2, 3, 32, 32, device=device)
+    assert torch.allclose(adapter_2d(x_2d), base_2d(x_2d))
+
+    base_3d = nn.Conv3d(2, 4, kernel_size=3).to(device)
+    adapter_3d = LoRA(base_3d, rank=2)
+    x_3d = torch.rand(2, 2, 8, 8, 8, device=device)
+    assert torch.allclose(adapter_3d(x_3d), base_3d(x_3d))
+
+
+def test_lora_conv_matches_manual_formula(device):
+    from speechbrain.nnet.adapters import LoRA
+
+    rank, alpha = 2, 8.0
+    base = nn.Conv1d(3, 6, kernel_size=3).to(device)
+    adapter = LoRA(base, rank=rank, alpha=alpha)
+    nn.init.normal_(adapter.adapter_up_proj.weight)
+
+    x = torch.rand(2, 3, 20, device=device)
+    expected = base(x) + adapter.adapter_up_proj(
+        adapter.adapter_down_proj(x)
+    ) * (alpha / rank)
+
+    assert torch.allclose(adapter(x), expected)
+
+
+def test_lora_conv_freezes_pretrained_and_trains_adapters(device):
+    from speechbrain.nnet.adapters import LoRA
+
+    base = nn.Conv1d(4, 8, kernel_size=3).to(device)
+    adapter = LoRA(base, rank=2)
+    nn.init.normal_(adapter.adapter_up_proj.weight)
+
+    x = torch.rand(2, 4, 30, device=device)
+    adapter(x).sum().backward()
+
+    assert adapter.pretrained_module.weight.grad is None
+    assert adapter.adapter_down_proj.weight.grad is not None
+    assert adapter.adapter_up_proj.weight.grad is not None
+
+
+def test_lora_conv_learns(device):
+    from speechbrain.nnet.adapters import LoRA
+
+    base = nn.Conv1d(4, 8, kernel_size=3).to(device)
+    adapter = LoRA(base, rank=2)
+    x = torch.rand(2, 4, 30, device=device)
+    out_before = adapter(x).detach().clone()
+
+    optimizer = torch.optim.SGD(
+        [p for p in adapter.parameters() if p.requires_grad], lr=1.0
+    )
+    adapter(x).sum().backward()
+    optimizer.step()
+
+    assert not torch.allclose(adapter(x), out_before)
+    # The pretrained weights must not have moved
+    assert torch.allclose(adapter.pretrained_module(x), base(x))
+
+
+def test_lora_conv_groups_not_supported(device):
+    from speechbrain.nnet.adapters import LoRA
+
+    base = nn.Conv1d(4, 8, kernel_size=3, groups=2).to(device)
+    with pytest.raises(ValueError, match="groups"):
+        LoRA(base, rank=2)
+
+
+def test_adapted_model_all_conv(device):
+    # Reproduces the exact scenario reported in issue #3056
+    from speechbrain.nnet.adapters import AdaptedModel, LoRA
+
+    class SimpleConv(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv1 = nn.Conv1d(1, 32, kernel_size=10, stride=5)
+            self.conv2 = nn.Conv1d(32, 32, kernel_size=3, stride=2)
+
+        def forward(self, x):
+            return self.conv2(self.conv1(x))
+
+    model = SimpleConv()
+    reference = SimpleConv()
+    reference.load_state_dict(model.state_dict())
+    reference = reference.to(device)
+
+    adapted = AdaptedModel(
+        model_to_adapt=model,
+        adapter_class=LoRA,
+        all_conv=True,
+        adapter_kwargs={"rank": 4},
+    ).to(device)
+
+    x = torch.rand(2, 1, 1600, device=device)
+    out = adapted(x)
+
+    assert out.shape == reference(x).shape
+    assert torch.allclose(out, reference(x))
+    out.sum().backward()
+
+    trainable = [
+        name for name, p in adapted.named_parameters() if p.requires_grad
+    ]
+    assert trainable, "The adapters should be trainable"
+    assert all("adapter" in name for name in trainable)


### PR DESCRIPTION
## What this does

Fixes #3056

The `LoRA` adapter class claimed to support `nn.Conv` layers but assumed `nn.Linear` semantics, crashing with `RuntimeError: mat1 and mat2 shapes cannot be multiplied` on any convolutional layer (e.g. the wav2vec2-style repro in the issue).

This PR implements real convolutional support instead of removing the claim, following the approach used by HF `peft`:

- **Down projection**: a conv of the same type mirroring the pretrained layer's geometry (`kernel_size`, `stride`, `padding`, `dilation`, `padding_mode`), mapping onto `rank` channels — so both branches produce outputs of identical shape
- **Up projection**: a pointwise (1×1) conv from `rank` to `out_channels`, zero-initialized (standard LoRA init)
- **Grouped convolutions** (`groups != 1`): clear `ValueError` instead of a cryptic crash
- **No behavior change** for `nn.Linear` (and other weight-matrix modules); checkpoint attribute names (`adapter_down_proj`/`adapter_up_proj`) are preserved so existing checkpoints keep loading

## Testing

New `tests/unittests/test_adapters.py` with 9 tests verifying the core LoRA properties:

- Identity at init (zero up-projection ⇒ adapted output == pretrained output), for Linear, Conv1d, Conv2d and Conv3d
- Exact match with the manual formula `base(x) + up(down(x)) * alpha/rank`
- Pretrained weights frozen (no grads) while adapter weights receive gradients and actually learn (one SGD step changes the output, pretrained output unchanged)
- Shape equality across geometries (`stride=5`, `padding='same'`, `dilation=2`)
- `groups != 1` raises `ValueError`
- The exact `AdaptedModel(all_conv=True)` repro from the issue, forward + backward, with only adapter params trainable

Also added a Conv1d doctest to the `LoRA` docstring. All 9 tests + 3 doctests pass; `ruff check`, `ruff format` and `codespell` pass on the changed files.

---

*Co-written by a human (@oliver0006) and Claude AI (Fable 5) working together.*
