### PR TITLE
Use safeloader to load checkpoint meta files

### DIFF
--- a/recipes/ESC50/interpret/interpreter_brain.py
+++ b/recipes/ESC50/interpret/interpreter_brain.py
@@ -366,13 +366,13 @@ class InterpreterBrain(sb.core.Brain):
         comp_tensor = torch.Tensor(self.comp.scores)
         comp_tensor = comp_tensor[~torch.isnan(comp_tensor)]
         tmp = {
-            "SPS": torch.Tensor(self.sps.scores).mean().item(),
-            "COMP": comp_tensor.mean().item(),
+            "SPS": torch.Tensor(self.sps.scores).mean(),
+            "COMP": comp_tensor.mean(),
         }
         quantus_metrics = {}
         for m in tmp:
             if not tmp[m].isnan():
-                quantus_metrics[m] = tmp[m]
+                quantus_metrics[m] = tmp[m].item()
 
         if stage == sb.Stage.VALID:
             current_fid = torch.Tensor(self.inp_fid.scores).mean()
@@ -387,9 +387,9 @@ class InterpreterBrain(sb.core.Brain):
                 "AI": torch.Tensor(self.AI.scores).mean().item(),
                 "AD": torch.Tensor(self.AD.scores).mean().item(),
                 "AG": torch.Tensor(self.AG.scores).mean().item(),
-                "faithfulness_mean": torch.Tensor(
-                    self.faithfulness.scores
-                ).mean().item(),
+                "faithfulness_mean": torch.Tensor(self.faithfulness.scores)
+                .mean()
+                .item(),
             }
             valid_stats.update(extra_m)
             valid_stats.update(quantus_metrics)
@@ -415,9 +415,9 @@ class InterpreterBrain(sb.core.Brain):
                 "AI": torch.Tensor(self.AI.scores).mean().item(),
                 "AD": torch.Tensor(self.AD.scores).mean().item(),
                 "AG": torch.Tensor(self.AG.scores).mean().item(),
-                "faithfulness_mean": torch.Tensor(
-                    self.faithfulness.scores
-                ).mean().item(),
+                "faithfulness_mean": torch.Tensor(self.faithfulness.scores)
+                .mean()
+                .item(),
             }
             test_stats.update(extra_m)
             test_stats.update(quantus_metrics)

--- a/recipes/ESC50/interpret/interpreter_brain.py
+++ b/recipes/ESC50/interpret/interpreter_brain.py
@@ -358,7 +358,7 @@ class InterpreterBrain(sb.core.Brain):
             }
 
         extra_m = {
-            k: torch.Tensor(getattr(self, k).scores).mean()
+            k: torch.Tensor(getattr(self, k).scores).mean().item()
             for k in self.extra_metrics().keys()
         }
 
@@ -366,8 +366,8 @@ class InterpreterBrain(sb.core.Brain):
         comp_tensor = torch.Tensor(self.comp.scores)
         comp_tensor = comp_tensor[~torch.isnan(comp_tensor)]
         tmp = {
-            "SPS": torch.Tensor(self.sps.scores).mean(),
-            "COMP": comp_tensor.mean(),
+            "SPS": torch.Tensor(self.sps.scores).mean().item(),
+            "COMP": comp_tensor.mean().item(),
         }
         quantus_metrics = {}
         for m in tmp:
@@ -383,13 +383,13 @@ class InterpreterBrain(sb.core.Brain):
             valid_stats = {
                 "loss": stage_loss,
                 "acc": self.acc_metric.summarize("average"),
-                "input_fidelity": current_fid,
-                "AI": torch.Tensor(self.AI.scores).mean(),
-                "AD": torch.Tensor(self.AD.scores).mean(),
-                "AG": torch.Tensor(self.AG.scores).mean(),
+                "input_fidelity": current_fid.item(),
+                "AI": torch.Tensor(self.AI.scores).mean().item(),
+                "AD": torch.Tensor(self.AD.scores).mean().item(),
+                "AG": torch.Tensor(self.AG.scores).mean().item(),
                 "faithfulness_mean": torch.Tensor(
                     self.faithfulness.scores
-                ).mean(),
+                ).mean().item(),
             }
             valid_stats.update(extra_m)
             valid_stats.update(quantus_metrics)
@@ -407,17 +407,17 @@ class InterpreterBrain(sb.core.Brain):
             )
 
         if stage == sb.Stage.TEST:
-            current_fid = torch.Tensor(self.inp_fid.scores).mean()
+            current_fid = torch.Tensor(self.inp_fid.scores).mean().item()
             test_stats = {
                 "loss": stage_loss,
                 "acc": self.acc_metric.summarize("average"),
                 "input_fidelity": current_fid,
-                "AI": torch.Tensor(self.AI.scores).mean(),
-                "AD": torch.Tensor(self.AD.scores).mean(),
-                "AG": torch.Tensor(self.AG.scores).mean(),
+                "AI": torch.Tensor(self.AI.scores).mean().item(),
+                "AD": torch.Tensor(self.AD.scores).mean().item(),
+                "AG": torch.Tensor(self.AG.scores).mean().item(),
                 "faithfulness_mean": torch.Tensor(
                     self.faithfulness.scores
-                ).mean(),
+                ).mean().item(),
             }
             test_stats.update(extra_m)
             test_stats.update(quantus_metrics)

--- a/speechbrain/utils/checkpoints.py
+++ b/speechbrain/utils/checkpoints.py
@@ -1219,7 +1219,7 @@ class Checkpointer:
         checkpoints = []
         for ckpt_dir in checkpoint_dirs:
             with open(ckpt_dir / METAFNAME, encoding="utf-8") as fi:
-                meta = yaml.load(fi, Loader=yaml.Loader)
+                meta = yaml.load(fi, Loader=yaml.SafeLoader)
             paramfiles = {}
             for ckptfile in ckpt_dir.iterdir():
                 if ckptfile.suffix == PARAMFILE_EXT:

--- a/tests/unittests/test_checkpoints.py
+++ b/tests/unittests/test_checkpoints.py
@@ -312,11 +312,9 @@ def test_torch_meta(tmpdir, device):
     recoverable = Recoverable(1.0)
     recoverables = {"recoverable": recoverable}
     recoverer = Checkpointer(tmpdir, recoverables)
-    saved = recoverer.save_checkpoint(
-        meta={"loss": torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device=device)}
-    )
+    saved = recoverer.save_checkpoint(meta={"loss": 3.7})
     loaded = recoverer.recover_if_possible()
-    assert saved.meta["loss"].allclose(loaded.meta["loss"])
+    assert saved.meta["loss"] == loaded.meta["loss"]
 
 
 def test_checkpoint_hook_register(tmpdir):


### PR DESCRIPTION
While loading checkpoints is known to be unsafe (see issue #1930), a related potential security issue is loading checkpoint meta files (usually `CKPT.yaml`) which is currently also unsafe, and has the potential to be slightly more surprising as all meta files in the save directory can be loaded for sorting etc., not just the target checkpoint. This adjusts the behavior so that meta files are loaded with SafeLoader, reducing the chance that a malicious meta file could be loaded without knowing.

Adopting this PR would mean that the old supported behavior of storing objects (e.g. Tensors) in the meta would be no longer supported, so we should run recipe tests and make sure no recipes depend on this. Also, this would merit a warning in the release notes and potentially a minor version marker rather than patch (i.e. 1.2 rather than 1.1.1).