### PR TITLE
Fix LengthsCapable containers dropping lengths for wav_lens-named layers (fixes #2986)

### DIFF
--- a/speechbrain/nnet/containers.py
+++ b/speechbrain/nnet/containers.py
@@ -11,7 +11,7 @@ import operator
 import torch
 
 from speechbrain.nnet.linear import Linear
-from speechbrain.utils.callchains import lengths_arg_exists
+from speechbrain.utils.callchains import lengths_arg_name
 from speechbrain.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -168,6 +168,10 @@ class LengthsCapableSequential(Sequential):
     This is useful for Sequential models that include RNNs where it is
     important to avoid padding, or for some feature normalization layers.
 
+    The lengths are forwarded under the name each layer expects: both the
+    ``lengths`` and ``wav_lens`` argument names are recognized (the latter
+    is used by e.g. the HuggingFace integration lobes).
+
     Unfortunately, this module is not jit-able because the compiler doesn't
     know ahead of time if the length will be passed, and some layers don't
     accept the length parameter.
@@ -175,6 +179,7 @@ class LengthsCapableSequential(Sequential):
 
     def __init__(self, *args, **kwargs):
         self.takes_lengths = []
+        self.lengths_arg_names = []
         super().__init__(*args, **kwargs)
 
     def append(self, *args, **kwargs):
@@ -182,13 +187,16 @@ class LengthsCapableSequential(Sequential):
         # Add lengths arg inference here.
         super().append(*args, **kwargs)
         latest_forward_method = list(self.values())[-1].forward
-        self.takes_lengths.append(lengths_arg_exists(latest_forward_method))
+        lengths_arg = lengths_arg_name(latest_forward_method)
+        self.lengths_arg_names.append(lengths_arg)
+        self.takes_lengths.append(lengths_arg is not None)
 
     def forward(self, x, lengths=None):
         """Applies layers in sequence, passing only the first element of tuples.
 
         In addition, forward the ``lengths`` argument to all layers that accept
-        a ``lengths`` argument in their ``forward()`` method (e.g. RNNs).
+        a ``lengths`` (or ``wav_lens``) argument in their ``forward()`` method
+        (e.g. RNNs, the HuggingFace integration lobes).
 
         Arguments
         ---------
@@ -202,9 +210,9 @@ class LengthsCapableSequential(Sequential):
         x : torch.Tensor
             The outputs after all layers are applied.
         """
-        for layer, give_lengths in zip(self.values(), self.takes_lengths):
-            if give_lengths:
-                x = layer(x, lengths=lengths)
+        for layer, lengths_arg in zip(self.values(), self.lengths_arg_names):
+            if lengths_arg is not None:
+                x = layer(x, **{lengths_arg: lengths})
             else:
                 x = layer(x)
             if isinstance(x, tuple):

--- a/speechbrain/utils/callchains.py
+++ b/speechbrain/utils/callchains.py
@@ -19,6 +19,34 @@ def lengths_arg_exists(func):
     return "lengths" in spec.args + spec.kwonlyargs
 
 
+LENGTHS_ARG_NAMES = ("lengths", "wav_lens")
+
+
+def lengths_arg_name(func):
+    """Return the name of the relative-lengths argument of ``func``, if any.
+
+    Both ``lengths`` (the general SpeechBrain convention) and ``wav_lens``
+    (the name used by e.g. the HuggingFace integration lobes) are recognized.
+
+    Arguments
+    ---------
+    func : callable
+        The function, method, or other callable to search for a lengths arg.
+
+    Returns
+    -------
+    str or None
+        The name of the lengths argument, or None if ``func`` does not take
+        one.
+    """
+    spec = inspect.getfullargspec(func)
+    candidates = spec.args + spec.kwonlyargs
+    for name in LENGTHS_ARG_NAMES:
+        if name in candidates:
+            return name
+    return None
+
+
 class LengthsCapableChain:
     """Chain together callables. Can handle relative lengths.
 
@@ -35,6 +63,7 @@ class LengthsCapableChain:
     def __init__(self, *funcs):
         self.funcs = []
         self.takes_lengths = []
+        self.lengths_arg_names = []
         for func in funcs:
             self.append(func)
 
@@ -47,8 +76,9 @@ class LengthsCapableChain:
             The main input
         lengths : Any
             The lengths argument which will be conditionally passed to
-            any functions in the chain that take a 'lengths' argument.
-            In SpeechBrain the convention is to use relative lengths.
+            any functions in the chain that take a 'lengths' (or
+            'wav_lens') argument. In SpeechBrain the convention is to
+            use relative lengths.
 
         Returns
         -------
@@ -63,9 +93,9 @@ class LengthsCapableChain:
         """
         if not self.funcs:
             return x
-        for func, give_lengths in zip(self.funcs, self.takes_lengths):
-            if give_lengths:
-                x = func(x, lengths)
+        for func, lengths_arg in zip(self.funcs, self.lengths_arg_names):
+            if lengths_arg is not None:
+                x = func(x, **{lengths_arg: lengths})
             else:
                 x = func(x)
             if isinstance(x, tuple):
@@ -75,7 +105,9 @@ class LengthsCapableChain:
     def append(self, func):
         """Add a function to the chain"""
         self.funcs.append(func)
-        self.takes_lengths.append(lengths_arg_exists(func))
+        lengths_arg = lengths_arg_name(func)
+        self.lengths_arg_names.append(lengths_arg)
+        self.takes_lengths.append(lengths_arg is not None)
 
     def __str__(self):
         clsname = self.__class__.__name__

--- a/tests/unittests/test_callchains.py
+++ b/tests/unittests/test_callchains.py
@@ -11,6 +11,23 @@ def test_lengths_arg_exists():
     assert lengths_arg_exists(len_func)
 
 
+def test_lengths_arg_name():
+    from speechbrain.utils.callchains import lengths_arg_name
+
+    def non_len_func(x):
+        return x + 1
+
+    def len_func(x, lengths):
+        return x + lengths
+
+    def wav_lens_func(x, wav_lens=None):
+        return x + wav_lens
+
+    assert lengths_arg_name(non_len_func) is None
+    assert lengths_arg_name(len_func) == "lengths"
+    assert lengths_arg_name(wav_lens_func) == "wav_lens"
+
+
 def test_lengths_capable_chain():
     from speechbrain.utils.callchains import LengthsCapableChain
 
@@ -30,3 +47,14 @@ def test_lengths_capable_chain():
     assert chain(1, 2) == 5
     chain.append(tuple_func)
     assert chain(1, 2) == 5
+
+
+def test_lengths_capable_chain_wav_lens():
+    from speechbrain.utils.callchains import LengthsCapableChain
+
+    def wav_lens_func(x, wav_lens=None):
+        assert wav_lens is not None
+        return x + wav_lens
+
+    chain = LengthsCapableChain(wav_lens_func)
+    assert chain(1, 2) == 3

--- a/tests/unittests/test_containers.py
+++ b/tests/unittests/test_containers.py
@@ -1,0 +1,40 @@
+import torch
+
+
+def test_lengths_capable_sequential_lengths_dispatch():
+    from speechbrain.nnet.containers import LengthsCapableSequential
+
+    class LengthsModule(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.received = None
+
+        def forward(self, x, lengths=None):
+            self.received = lengths
+            return x
+
+    class WavLensModule(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.received = None
+
+        def forward(self, x, wav_lens=None):
+            self.received = wav_lens
+            return x
+
+    class PlainModule(torch.nn.Module):
+        def forward(self, x):
+            return x
+
+    lengths_layer = LengthsModule()
+    wav_lens_layer = WavLensModule()
+    model = LengthsCapableSequential(
+        lengths_layer, PlainModule(), wav_lens_layer
+    )
+
+    x = torch.randn(2, 4)
+    lengths = torch.tensor([0.5, 1.0])
+    model(x, lengths=lengths)
+
+    assert lengths_layer.received is lengths
+    assert wav_lens_layer.received is lengths


### PR DESCRIPTION
## Motivation

Reported in #2986: batched inference through `EncoderASR` produces different transcripts than per-utterance inference, with divergences appearing *early* in the shorter (padded) utterances — not just in the tail.

Root cause: `LengthsCapableSequential` (and the lighter `LengthsCapableChain`) only forward `lengths` to layers whose `forward()` declares a parameter literally named `lengths` (`speechbrain/utils/callchains.py::lengths_arg_exists`). The HuggingFace integration lobes all name it `wav_lens` (`forward(self, wav, wav_lens=None)`), so in the standard `encoder: !new:speechbrain.nnet.containers.LengthsCapableSequential` inference setup, the wav2vec2/HuBERT/WavLM module is silently called **without** lengths → `make_padding_masks(src, wav_len=None)` returns `None` → the HF model runs with `attention_mask=None`, and self-attention attends over the zero-padding, shifting every frame of the shorter items in the batch.

Note this is also a train/inference mismatch: training recipes typically call the lobe directly (`self.modules.wav2vec2(wavs, wav_lens)`), so the attention mask is applied during training but silently dropped at batched inference time.

## Changes

- New `speechbrain.utils.callchains.lengths_arg_name(func)`: returns the name of the relative-lengths argument (`lengths` or `wav_lens`), or `None` if there is none.
- `LengthsCapableSequential.forward` and `LengthsCapableChain.__call__` now pass the lengths under the layer's **actual** parameter name.
- `lengths_arg_exists` is untouched, so the augmenter and enhancement call sites keep their exact behavior. The `takes_lengths` attributes are kept in sync (and now also report `wav_lens`-style layers).

## Backward compatibility

- Layers with a `lengths` parameter: identical call as before.
- Layers with neither name: called without lengths, as before.
- Layers with a `wav_lens` parameter (the HF lobes): now actually receive the lengths — the intended fix. This deliberately changes batched-inference outputs for affected pipelines, aligning them with the mask-aware training-time behavior.

The issue reporter validated the equivalent fix end-to-end via a user-side wrapper: the WER delta between per-utterance and batched inference dropped to ~1e-3 over 300 samples (the residual is the convolutional front-end seeing the padding, inherent to padded batching). This PR makes that wrapper unnecessary.

## Test Plan

- `pytest tests/unittests/test_callchains.py tests/unittests/test_containers.py` — 5 passed, including the new `test_lengths_arg_name`, `test_lengths_capable_chain_wav_lens`, and `test_lengths_capable_sequential_lengths_dispatch` (a `wav_lens`-named module actually receives the lengths through the container).
- `pytest --doctest-modules speechbrain/nnet/containers.py speechbrain/utils/callchains.py tests/unittests/test_augment.py` — 17 passed (augmenter unaffected).
- `ruff check` and `ruff format --check` clean on all changed files.

Fixes #2986.

---

*Co-written by a human (@oliver0006) and Claude AI (Fable 5) working together.*
