### PR TITLE
Make RelPosEncXL able to encode the sign of the relative position

### DIFF
--- a/speechbrain/nnet/attention.py
+++ b/speechbrain/nnet/attention.py
@@ -342,9 +342,23 @@ class RelPosEncXL(nn.Module):
         If unspecified, defaults to `torch.float32`. Controls the data type of
         the output embedding (but does not affect the precision of the
         computations, which remain `torch.float32`).
+    use_legacy_symmetric : bool, optional
+        If True (the default), the embedding of a negative relative position
+        is made equal to that of the matching positive one, which leaves the
+        encoding unable to tell apart a key that is `d` steps ahead from one
+        that is `d` steps behind. If False, the sine terms are negated for the
+        negative positions, as in Transformer-XL.
+        Every SpeechBrain checkpoint released so far was trained with True, so
+        the default is kept for compatibility. See
+        https://github.com/speechbrain/speechbrain/issues/3070
     """
 
-    def __init__(self, emb_dim: int, dtype: torch.dtype = torch.float32):
+    def __init__(
+        self,
+        emb_dim: int,
+        dtype: torch.dtype = torch.float32,
+        use_legacy_symmetric: bool = True,
+    ):
         super().__init__()
         self.emb_dim = emb_dim
 
@@ -355,6 +369,7 @@ class RelPosEncXL(nn.Module):
         self.register_buffer("inv_freq", inv_freq)
 
         self.emb_dtype = dtype
+        self.use_legacy_symmetric = use_legacy_symmetric
 
     @torch.no_grad()
     def make_pe(self, seq_len: int):
@@ -369,7 +384,10 @@ class RelPosEncXL(nn.Module):
         Returns
         -------
         torch.Tensor
-            Positional embedding tensor of shape `[1, 2*seq_len-1, embed_dim]`
+            Positional embedding tensor of shape `[1, 2*seq_len-1, embed_dim]`.
+            Row `i` corresponds to the signed relative position
+            `seq_len - 1 - i`, which is the order expected by
+            :meth:`~RelPosMHAXL.rel_shift`.
         """
 
         emb_dtype = self.emb_dtype
@@ -395,10 +413,16 @@ class RelPosEncXL(nn.Module):
             ).unsqueeze(-1)
 
             sinusoids = torch.sin(positions * self.inv_freq)
+            cosinusoids = torch.cos(positions * self.inv_freq)
             pe_past[:, 0::2] = sinusoids
-            pe_past[:, 1::2] = torch.cos(positions * self.inv_freq)
-            pe_future[:, 0::2] = sinusoids  # same for past and future
-            pe_future[:, 1::2] = torch.cos(-positions * self.inv_freq)
+            pe_past[:, 1::2] = cosinusoids
+            # `cos` is even, so only the sine terms differ between the positive
+            # and the negative relative positions.
+            if self.use_legacy_symmetric:
+                pe_future[:, 0::2] = sinusoids
+            else:
+                pe_future[:, 0::2] = -sinusoids
+            pe_future[:, 1::2] = cosinusoids
 
             pe_past = torch.flip(pe_past, (0,)).unsqueeze(0)
             pe_future = pe_future[1:].unsqueeze(0)

--- a/tests/unittests/test_attention.py
+++ b/tests/unittests/test_attention.py
@@ -32,6 +32,57 @@ def test_rel_pos_MHA(device):
                     relpos(q, k, k, pos_embs=pos_embs)
 
 
+def rel_pos_enc_xl_slow(seq_len: int, emb_dim: int) -> np.ndarray:
+    """
+    Slow implementation of RelPosEncXL.make_pe.
+    """
+    result = np.zeros((2 * seq_len - 1, emb_dim))
+
+    for index in range(2 * seq_len - 1):
+        # rows run from the largest positive relative position down to the
+        # largest negative one, as expected by `RelPosMHAXL.rel_shift`.
+        position = seq_len - 1 - index
+
+        # Implement (1) from https://arxiv.org/pdf/1706.03762 for a signed
+        # position, as https://arxiv.org/pdf/1901.02860 does.
+        for dimension_pair_index in range(emb_dim // 2):
+            angle = position * 10000 ** (-2 * dimension_pair_index / emb_dim)
+            result[index][dimension_pair_index * 2] = math.sin(angle)
+            result[index][dimension_pair_index * 2 + 1] = math.cos(angle)
+
+    return result
+
+
+@pytest.mark.parametrize(
+    "seq_len, emb_dim", [(1, 4), (2, 4), (7, 16), (16, 2), (33, 64)]
+)
+def test_rel_pos_enc_xl(device, seq_len, emb_dim):
+    from speechbrain.nnet.attention import RelPosEncXL
+
+    reference = rel_pos_enc_xl_slow(seq_len, emb_dim)
+
+    # If opposite relative positions shared an embedding, the encoding could
+    # not tell a key `d` steps ahead from one `d` steps behind, and this test
+    # would be much weaker.
+    centre = seq_len - 1
+    assert seq_len == 1 or not np.allclose(
+        reference[:centre], np.flip(reference[centre + 1 :], axis=0)
+    )
+
+    encoder = RelPosEncXL(emb_dim, use_legacy_symmetric=False).to(device=device)
+    result = encoder.make_pe(seq_len)
+    assert result.shape == (1, 2 * seq_len - 1, emb_dim)
+
+    assert np.allclose(result[0].cpu().numpy(), reference, atol=1e-5)
+
+    # the default stays symmetric, so that checkpoints trained before this was
+    # made configurable keep behaving the same way
+    legacy = RelPosEncXL(emb_dim).to(device=device).make_pe(seq_len)
+    assert torch.equal(
+        legacy[0, :centre], torch.flip(legacy[0, centre + 1 :], (0,))
+    )
+
+
 memoised_calls = []
 
 


### PR DESCRIPTION
## What does this PR do?

`RelPosEncXL.make_pe()` fills the negative half of the relative positional embedding with `sin(+p)` instead of `sin(-p)`. `cos` is even so the cosine terms were already right, but `sin` is odd, so the rows for relative distance `-d` come out bit-identical to the rows for `+d`.

Both halves are read. `rel_shift` maps row `p` of `pos_embs` onto the (query, key) pairs at relative distance `d = (klen - 1) - p`, so rows past the centre are the keys sitting to the right of the query. Probing it with a one-hot matrix, `klen = 5`:

```
row 3 (d=+1) -> i=1:j=0, i=2:j=1, i=3:j=2, i=4:j=3
row 4 (d= 0) -> i=0:j=0, i=1:j=1, i=2:j=2, i=3:j=3, i=4:j=4
row 5 (d=-1) -> i=0:j=1, i=1:j=2, i=2:j=3, i=3:j=4
```

Rows 3 and 5 are equal on `develop`, so a non-causal `RelPosMHAXL` adds the same positional bias to a key one step ahead as to a key one step behind. Running a constant sequence through it, so that the content term is flat and only the positional term shapes the map, gives an attention row that is exactly symmetric about the query:

```
[0.179007, 0.191125, 0.158071, 0.1226, 0.158071, 0.191125]
```

ESPnet's `RelPositionalEncoding` negates the position for both terms, and Transformer-XL's `PositionalEmbedding` takes a signed `pos_seq`, so both are odd in the sine terms.

Refs #3070, reported and diagnosed by @coollip.

## Why the default is unchanged

Every checkpoint SpeechBrain has released was trained against the symmetric embedding, so switching it silently would degrade all of them. The corrected formulation is behind `use_legacy_symmetric=False` and the default output is bit-identical to `develop`:

```
>>> torch.equal(develop_pe, patched_pe)   # emb_dim=64, seq_len=50, default args
True
```

To put a number on what flipping the default would cost, `speechbrain/asr-streaming-conformer-librispeech` decoded in full-context greedy mode over the first 500 utterances of LibriSpeech test-clean, on CPU:

```
use_legacy_symmetric=True    WER 2.12   224 edits / 10561 words
use_legacy_symmetric=False   WER 2.90   306 edits / 10561 words
```

That is a compatibility cost and not evidence that the symmetric encoding is better, since the checkpoint was trained with it. I have no way to train a Conformer from scratch to compare the two properly, so this PR makes no claim that the corrected encoding trains better, only that it is the one Transformer-XL and ESPnet define.

Models on the hub built with `attention_type: RelPosMHAXL` and `causal: False`, which is what would need retraining or pinning if the default were flipped:

```
speechbrain/asr-branchformer-large-tedlium2
speechbrain/asr-conformer-loquacious
speechbrain/asr-conformer-transformerlm-ksponspeech
speechbrain/asr-conformer-transformerlm-librispeech
speechbrain/asr-conformersmall-transformerlm-librispeech
speechbrain/asr-streaming-conformer-gigaspeech
speechbrain/asr-streaming-conformer-librispeech
```

plus 27 recipe hparams using `RelPosMHAXL`, none of which set `causal: True`. Causal encoders are unaffected either way, the negative rows are masked out and the module output is bit-identical.

## Verification

The new test compares `make_pe()` against a scalar reference written from the definition, in the same shape as the existing `test_rope_rotate`. On `develop`:

```
$ pytest tests/unittests/test_attention.py -q
E   TypeError: RelPosEncXL.__init__() got an unexpected keyword argument 'use_legacy_symmetric'
5 failed, 17 passed in 1.55s
```

With the patch, and with the surrounding modules:

```
$ pytest tests/unittests/test_attention.py tests/unittests/test_conformer.py \
    tests/unittests/test_streaming.py tests/unittests/test_transformer_src_tgt_masks.py -q
28 passed in 1.19s

$ pytest tests/unittests -q
4 failed, 743 passed, 6 skipped in 208.93s

$ pytest --doctest-modules speechbrain/nnet/attention.py speechbrain/lobes/models/transformer/ -q
31 passed in 3.29s
```

The 4 unittest failures are `test_RNN`, `test_SpectrogramDrop`, `test_fallback_when_all_fail` and `test_run_shell`. They fail identically on an unpatched checkout here (torch 2.13, python 3.12, macOS), so they are unrelated.

## Open question

The flag is only reachable by constructing `RelPosEncXL` directly. Making it settable from a recipe needs a pass-through in `TransformerInterface` and `TransformerASR`, and flipping the default instead would need the affected hyperparams pinned the way #2604 was handled. I kept this PR to the one module so the choice stays with you, and I am happy to follow up with either.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing [tests](https://github.com/speechbrain/speechbrain/tree/develop/tests) pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>
