### PR TITLE
fix(inference): make DiffWaveVocoder.forward and PIQAudioInterpreter.forward callable

### DIFF
--- a/speechbrain/inference/interpretability.py
+++ b/speechbrain/inference/interpretability.py
@@ -177,6 +177,6 @@ class PIQAudioInterpreter(Pretrained):
         x_int_sound_domain, text_lab = self.interpret_batch(batch)
         return x_int_sound_domain, text_lab, fs_model
 
-    def forward(self, wavs, wav_lens=None):
+    def forward(self, wavs):
         """Runs the classification"""
-        return self.interpret_batch(wavs, wav_lens)
+        return self.interpret_batch(wavs)

--- a/speechbrain/inference/vocoders.py
+++ b/speechbrain/inference/vocoders.py
@@ -290,9 +290,9 @@ class DiffWaveVocoder(Pretrained):
             )
         return waveform.squeeze(0)
 
-    def forward(self, spectrogram):
+    def forward(self, spectrogram, hop_len):
         """Decodes the input spectrograms"""
-        return self.decode_batch(spectrogram)
+        return self.decode_batch(spectrogram, hop_len)
 
 
 class UnitHIFIGAN(Pretrained):


### PR DESCRIPTION
## What does this PR do?

Two `Pretrained` wrappers in `speechbrain/inference/` call their own delegate
with an argument list the delegate cannot accept, so `module(...)` raises
`TypeError` before any inference happens. Both are one-line call-site
mismatches; I kept them in one PR because it is the same defect, but happy to
split if you prefer.

**1. `DiffWaveVocoder.forward` (`speechbrain/inference/vocoders.py`)**

```python
def forward(self, spectrogram):
    return self.decode_batch(spectrogram)      # TypeError: missing a required argument: 'hop_len'
```

`DiffWaveVocoder.decode_batch(self, mel, hop_len, mel_lens=None, ...)` makes
`hop_len` required — it is passed to `self.infer(scale=hop_len, ...)` and to
`mask_noise`. The two sibling vocoders in the same file bind fine, which is
what makes this one stand out: `HIFIGAN.decode_batch(self, spectrogram,
mel_lens=None, hop_len=None)` has `hop_len` optional, and
`UnitHIFIGAN.forward` forwards `spk` explicitly. The DiffWave wrapper looks
copied from `HIFIGAN.forward` without noticing that its `decode_batch` has a
second required parameter.

Fix: take `hop_len` in `forward` and pass it through.

**2. `PIQAudioInterpreter.forward` (`speechbrain/inference/interpretability.py`)**

```python
def forward(self, wavs, wav_lens=None):
    return self.interpret_batch(wavs, wav_lens)   # TypeError: too many positional arguments
```

`interpret_batch(self, wavs)` takes no lengths, and the class's own
`interpret_file` already calls it as `self.interpret_batch(batch)`. The
`wav_lens` parameter has therefore never reached anything — passing it (or
leaving it at its default) fails identically, because it is forwarded
positionally either way.

Fix: drop the argument that has no receiver, so `forward` matches
`interpret_batch` and `interpret_file`. I deliberately did **not** add
`wav_lens` support to `interpret_batch` instead: the method does no
length-based masking anywhere, so adding an ignored parameter would just move
the silent-drop one level down.

Neither class is referenced anywhere else in the repo (`recipes/`, `tests/`,
`templates/`, `docs/` are all clean), and the docstring example in
`interpretability.py` uses `interpret_file`, so nothing that currently works
changes behaviour.

Fixes #<no issue — found by an arity sweep over `self.<method>(...)` call sites>

<!-- Breaking changes: both `forward` signatures change, but every call to
either one raised TypeError before this patch, so no working caller exists. -->

## Verification

No model download or GPU needed. I replayed each `forward -> delegate` call
site against signatures parsed out of the real source with
`inspect.Signature.bind`, running the same harness over `git show HEAD:<file>`
and over the patched tree, and including the two sibling vocoders as a control:

```
===== BEFORE (git HEAD) =====
  FAIL  DiffWaveVocoder.forward(self, spectrogram) -> self.decode_batch(<spectrogram>)
          TypeError: missing a required argument: 'hop_len'
  OK    HIFIGAN.forward(self, spectrogram) -> self.decode_batch(<spectrogram>)
  OK    UnitHIFIGAN.forward(self, units, spk=None) -> self.decode_batch(<units>, spk=...)
  FAIL  PIQAudioInterpreter.forward(self, wavs, wav_lens=None) -> self.interpret_batch(<wavs>, <wav_lens>)
          TypeError: too many positional arguments

===== AFTER (patched working tree) =====
  OK    DiffWaveVocoder.forward(self, spectrogram, hop_len) -> self.decode_batch(<spectrogram>, <hop_len>)
  OK    HIFIGAN.forward(self, spectrogram) -> self.decode_batch(<spectrogram>)
  OK    UnitHIFIGAN.forward(self, units, spk=None) -> self.decode_batch(<units>, spk=...)
  OK    PIQAudioInterpreter.forward(self, wavs) -> self.interpret_batch(<wavs>)
```

Lint/format with the `ruff` version pinned in `.pre-commit-config.yaml`
(`v0.12.4`), run at the repo root:

```
ruff check speechbrain/inference/vocoders.py speechbrain/inference/interpretability.py   # All checks passed!
ruff format --check ...                                                                  # 2 files already formatted
```

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the [contributor guideline](https://speechbrain.readthedocs.io/en/latest/contributing.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (docstrings unchanged; no public docs describe these two `forward` signatures)
- [ ] Did you write any **new necessary tests**? — neither class has an existing unit test and both need a pretrained checkpoint to instantiate; happy to add one if you can point me at the right fixture.
- [x] Did you verify new and **existing tests pass** locally with your changes? (`ruff` + the signature replay above; the affected classes have no tests)
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Does your code adhere to project-specific code style and conventions?

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
