### PR TITLE
Fix BinaryMetricStats DER denominator

### DIFF
--- a/speechbrain/utils/metric_stats.py
+++ b/speechbrain/utils/metric_stats.py
@@ -785,7 +785,7 @@ class BinaryMetricStats(MetricStats):
 
         self.summary["FAR"] = FP / (FP + TN + eps)
         self.summary["FRR"] = FN / (TP + FN + eps)
-        self.summary["DER"] = (FP + FN) / (TP + TN + eps)
+        self.summary["DER"] = (FP + FN) / (TP + TN + FP + FN + eps)
         self.summary["threshold"] = threshold
 
         self.summary["precision"] = TP / (TP + FP + eps)

--- a/tests/unittests/test_metrics.py
+++ b/tests/unittests/test_metrics.py
@@ -119,7 +119,7 @@ def test_embedding_error_rate_stats(device):
 
 
 def test_binary_metrics(device):
-    from speechbrain.utils.metric_stats import BinaryMetricStats
+    from speechbrain.utils.metric_stats import EER, BinaryMetricStats
 
     binary_stats = BinaryMetricStats()
     binary_stats.append(
@@ -132,9 +132,17 @@ def test_binary_metrics(device):
     assert summary["TN"] == 2
     assert summary["FP"] == 1
     assert summary["FN"] == 2
+    assert math.isclose(summary["DER"], 3 / 6, abs_tol=1e-6)
 
     summary = binary_stats.summarize(threshold=None)
     assert summary["threshold"] >= 0.3 and summary["threshold"] < 0.4
+
+    # at the EER threshold the detection error rate is the EER
+    eer, _ = EER(
+        torch.tensor([0.1, 0.8, 0.3], device=device),
+        torch.tensor([0.4, 0.2, 0.6], device=device),
+    )
+    assert math.isclose(summary["DER"], eer, abs_tol=1e-6)
 
     summary = binary_stats.summarize(threshold=None, max_samples=1)
     assert summary["threshold"] >= 0.1 and summary["threshold"] < 0.2


### PR DESCRIPTION
## What does this PR do?

`BinaryMetricStats.summarize` divided the detection errors by the number of correct decisions instead of by the number of decisions:

```python
self.summary["DER"] = (FP + FN) / (TP + TN + eps)
```

The docstring says `DER - Detection Error Rate (EER if no threshold passed)`, but the two did not agree. On the data already in `tests/unittests/test_metrics.py` the automatic threshold gives FAR = FRR = 0.667, so the EER is 0.667, while `summary["DER"]` came back as 2.0. With a fixed threshold and no correct decisions at all, the old expression divided by `eps` and returned 4e+08.

The denominator is now `TP + TN + FP + FN`, which makes DER equal the EER at the automatic threshold. Every other field of the summary is unchanged.

A 2021 commit (f3f9b38, "Correct FAR and FRR") fixed the same denominator for FAR and FRR and left DER alone.

The regression test covers both the fixed-threshold value and the equality with the EER.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the contributor guideline?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (the existing docstring already describes the corrected behavior)
- [x] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests** pass locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request? (none; `DER` was previously unusable and is asserted nowhere)
- [x] Does your code adhere to project-specific code style and conventions?

</details>