### PR TITLE
Fix DNS composite_eval.py always raising TypeError (eval_composite missing sample_rate)

### DIFF
--- a/recipes/DNS/enhancement/composite_eval.py
+++ b/recipes/DNS/enhancement/composite_eval.py
@@ -454,9 +454,9 @@ if __name__ == "__main__":
             enhanced_path_f = os.path.join(
                 enhanced_path, _file[:-4] + "_enhanced.wav"
             )
-            clean_sig = librosa.load(clean_path_f, sr=None)[0]
+            clean_sig, sample_rate = librosa.load(clean_path_f, sr=None)
             enhanced_sig = librosa.load(enhanced_path_f, sr=None)[0]
-            res = eval_composite(clean_sig, enhanced_sig)
+            res = eval_composite(clean_sig, enhanced_sig, sample_rate)
             csig += res["csig"]
             cbak += res["cbak"]
             covl += res["covl"]


### PR DESCRIPTION
Running `recipes/DNS/enhancement/composite_eval.py` as a script fails
immediately with `TypeError: eval_composite() missing 1 required positional
argument: 'sample_rate'`.

The DNS copy of `eval_composite` takes three arguments (`composite_eval.py:19`):

```python
def eval_composite(ref_wav, deg_wav, sample_rate):
```

`sample_rate` is genuinely required — it is forwarded to `wss()`, `llr()` and
`SSNR()` inside the function body. But the `__main__` block at
`composite_eval.py:459` still calls it with two:

```python
clean_sig = librosa.load(clean_path_f, sr=None)[0]
enhanced_sig = librosa.load(enhanced_path_f, sr=None)[0]
res = eval_composite(clean_sig, enhanced_sig)
```

### Why the intended fix is unambiguous

The same recipe already contains a correct call —
`recipes/DNS/enhancement/train.py:462`:

```python
composite_metrics = eval_composite(
    clean.squeeze().cpu().numpy(),
    predictions[0].squeeze().cpu().numpy(),
    self.hparams.sample_rate,
)
```

And `recipes/Voicebank/MTL/ASR_enhance/composite_eval.py` still carries the
pre-change shape this file was copied from — a two-parameter
`def eval_composite(ref_wav, deg_wav)` with a matching two-argument call at
`:435`. So the DNS copy gained the `sample_rate` parameter, `train.py` was
updated, and this script's `__main__` block was not.

| Call site | Args | Callee params | Status |
|---|---|---|---|
| `recipes/DNS/enhancement/train.py:462` | 3 | 3 | ✅ |
| `recipes/DNS/enhancement/composite_eval.py:459` | 2 | 3 | ❌ |
| `recipes/Voicebank/MTL/ASR_enhance/composite_eval.py:435` | 2 | 2 | ✅ (separate copy) |

### The change

`librosa.load(..., sr=None)` already loads at the file's native sample rate and
returns it as the second element — the script was discarding it with `[0]`.
This PR keeps that value and passes it through, so the metrics are computed at
the rate the audio is actually stored at rather than at a hardcoded guess:

```python
clean_sig, sample_rate = librosa.load(clean_path_f, sr=None)
enhanced_sig = librosa.load(enhanced_path_f, sr=None)[0]
res = eval_composite(clean_sig, enhanced_sig, sample_rate)
```

Checked with the pinned `ruff` v0.12.4 from `.pre-commit-config.yaml`, run from
the repository root: `ruff format --check` reports *1 file already formatted*
and `ruff check` reports *All checks passed!*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
