### PR TITLE
Use torch.accelerator in infer_device so non-CUDA accelerators are detected

### DIFF
--- a/speechbrain/utils/distributed.py
+++ b/speechbrain/utils/distributed.py
@@ -79,8 +79,8 @@ def get_local_rank() -> Optional[int]:
 def infer_device() -> str:
     """Make a basic guess about intended running device based on
     availability and distributed environment variable 'LOCAL_RANK'"""
-    if torch.cuda.is_available():
-        device = "cuda"
+    if torch.accelerator.is_available():
+        device = str(torch.accelerator.current_accelerator())
         local_rank = get_local_rank()
         if local_rank is not None:
             device += f":{local_rank}"

--- a/tests/unittests/test_distributed.py
+++ b/tests/unittests/test_distributed.py
@@ -91,3 +91,24 @@ def test_run_on_main(tmpdir):
         world_size,
         join=True,
     )
+
+
+# Test infer_device.
+
+
+def test_infer_device():
+    device = distributed.infer_device()
+    if torch.accelerator.is_available():
+        assert device.startswith(torch.accelerator.current_accelerator())
+    else:
+        assert device == "cpu"
+
+
+def test_infer_device_local_rank(monkeypatch):
+    monkeypatch.setenv("LOCAL_RANK", "1")
+    device = distributed.infer_device()
+    if torch.accelerator.is_available():
+        assert device == f"{torch.accelerator.current_accelerator()}:1"
+    else:
+        assert device == "cpu"
+


### PR DESCRIPTION
## Problem

`speechbrain.utils.distributed.infer_device()` guesses the running device with `torch.cuda.is_available()`, falling back to `"cpu"` on any other accelerator. On machines with a non-CUDA accelerator (e.g. Ascend NPU via `torch_npu`, or any backend registered through the `torch.accelerator` API), this forces `Brain` and the pretrained interfaces (`speechbrain.inference.interfaces`) onto the CPU even though an accelerator is present, and multi-process runs all pile onto the CPU instead of using one accelerator per rank.

## Root cause

```python
def infer_device() -> str:
    if torch.cuda.is_available():
        device = "cuda"
        ...
    else:
        device = "cpu"
    return device
```

Only CUDA is considered; every other accelerator is invisible to the guess.

## Fix

Use the device-agnostic PyTorch accelerator API, which returns `"cuda"` on CUDA machines (identical behavior) and the actual accelerator type (e.g. `"npu"`, `"mps"`) where available:

```python
if torch.accelerator.is_available():
    device = str(torch.accelerator.current_accelerator())
    local_rank = get_local_rank()
    if local_rank is not None:
        device += f":{local_rank}"
else:
    device = "cpu"
```

`current_accelerator()` returns a `torch.device` on newer versions, so the result is stringified before appending the rank suffix (the function's return type stays `str`).

Adds unit tests for both the plain and `LOCAL_RANK` paths.

Note: `torch.accelerator` is available since PyTorch 2.4, while SpeechBrain pins `torch>=2.1.0` — happy to guard this with a `getattr` fallback if you prefer keeping 2.1–2.3 compatibility.

## Verification

Verified on Ascend 910B (aarch64, torch 2.14.0a0 + torch_npu 2.14.0):

- old code returns `"cpu"` while an NPU is available (the bug)
- new code returns `"npu"`; `torch.nn.Linear(2, 2).to("npu")` plus a forward pass run correctly
- with `LOCAL_RANK=1` the returned device is `"npu:1"`
- on CUDA machines the returned value is unchanged (`"cuda"` / `"cuda:<rank>"`)
