### PR TITLE
Fix attentive statistics pooling dtype mismatch with FP16 and BF16

### DIFF
--- a/speechbrain/lobes/models/ECAPA_TDNN.py
+++ b/speechbrain/lobes/models/ECAPA_TDNN.py
@@ -285,7 +285,7 @@ class AttentiveStatisticsPooling(nn.Module):
             mean, std = _compute_statistics(x, mask / total)
             mean = mean.unsqueeze(2).repeat(1, 1, L)
             std = std.unsqueeze(2).repeat(1, 1, L)
-            attn = torch.cat([x, mean, std], dim=1)
+            attn = torch.cat([x, mean, std], dim=1).to(x.dtype)
         else:
             attn = x
 

--- a/tests/unittests/test_ECAPA_TDNN.py
+++ b/tests/unittests/test_ECAPA_TDNN.py
@@ -1,0 +1,39 @@
+import pytest
+import torch
+
+
+@pytest.mark.parametrize(
+    "dtype", [torch.float16, torch.bfloat16, torch.float32]
+)
+@pytest.mark.parametrize("global_context", [True, False])
+@pytest.mark.parametrize("use_lengths", [True, False])
+def test_attentive_statistics_pooling_dtype(
+    device, dtype, global_context, use_lengths
+):
+    from speechbrain.lobes.models.ECAPA_TDNN import AttentiveStatisticsPooling
+
+    pool = AttentiveStatisticsPooling(
+        channels=2, attention_channels=2, global_context=global_context
+    ).to(device=device, dtype=dtype)
+    # Uniform attention gives the mean and standard deviation of valid frames.
+    with torch.no_grad():
+        pool.conv.conv.weight.zero_()
+        pool.conv.conv.bias.zero_()
+    x = torch.tensor(
+        [[[1, 3, 1, 3], [2, 4, 2, 4]], [[1, 3, 5, 7], [2, 4, 6, 8]]],
+        device=device,
+        dtype=dtype,
+        requires_grad=True,
+    )
+    lengths = torch.tensor([1.0, 0.5], device=device) if use_lengths else None
+
+    output = pool(x, lengths)
+
+    expected = [[2, 3, 1, 1], [2, 3, 1, 1]]
+    if not use_lengths:
+        expected[1] = [4, 5, 2.2360679775, 2.2360679775]
+    expected = torch.tensor(expected, device=device, dtype=dtype).unsqueeze(2)
+    torch.testing.assert_close(output, expected)
+    output.sum().backward()
+    assert torch.isfinite(x.grad).all()
+    assert all(torch.isfinite(param.grad).all() for param in pool.parameters())


### PR DESCRIPTION
## What does this PR do?

Fixes #2544.

With FP16/BF16 inputs and weights, `AttentiveStatisticsPooling` computes its global statistics in FP32. Concatenating these statistics with the input promotes the attention input to FP32, so the following half-precision convolution raises a dtype mismatch.

Cast the concatenated attention input back to `x.dtype`. The global statistics still accumulate at their original precision, and the path without global context is unchanged. No new dependencies or API changes.

Validation (CPU, PyTorch 2.6.0):
- New parameterized forward/backward test covers FP16, BF16 and FP32, with/without global context and supplied lengths. It checks known masked statistics, output dtype and finite gradients. Before the fix: 4 failed, 8 passed.
- After the fix, the new test, existing pooling/CNN/normalization tests and ECAPA-TDNN doctests: 31 passed.
- Independent local checks with nonzero attention gradients and 70,000 frames passed for all three dtypes.
- `pre-commit run -a`, changed-file pre-commit and `git diff --check` passed.

The full test suite, GPU execution and pretrained-model/training recipes were not run. This fixes the pooling layer's reported mismatch; it does not claim to validate full ECAPA training in half precision.

Implemented and tested with OpenAI Codex, with independent read-only review by another Codex agent.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Read the contributor guideline.
- [x] This PR does one thing.
- [x] Documentation checked; the existing API/docstrings remain applicable.
- [x] Added necessary regression tests.
- [x] Verified new and related existing tests locally (scope above).
- [x] Listed breaking changes: none.
- [x] Followed project code style and conventions.

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review?
- [ ] Check that all items from **Before submitting** are resolved.
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR.
- [ ] Add labels and milestones (and optionally projects) to classify the PR.
- [ ] Confirm compatibility requirements.
- [ ] Review the self-review checklist.

</details>
