### PR TITLE
Skip hpopt reporting when no result was provided

### DIFF
--- a/speechbrain/utils/hpopt.py
+++ b/speechbrain/utils/hpopt.py
@@ -331,7 +331,7 @@ class HyperparameterOptimizationContext:
         self.reporter_kwargs = reporter_kwargs or {}
         self.reporter = None
         self.enabled = False
-        self.result = {"objective": 0.0}
+        self.result = None
 
     def parse_arguments(
         self, arg_list, pass_hpopt_args=None, pass_trial_id=True

--- a/tests/unittests/test_hpopt.py
+++ b/tests/unittests/test_hpopt.py
@@ -65,3 +65,41 @@ def test_hpopt_context():
     output.seek(0)
     output_result = json.load(output)
     assert output_result["per"] == 3
+    assert hp.get_trial_id() == hp.DEFAULT_TRIAL_ID
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+@pytest.mark.parametrize("objective_key", ["error", "objective"])
+def test_hpopt_context_without_report(enabled, objective_key):
+    from io import StringIO
+
+    from speechbrain.utils import hpopt as hp
+
+    output = StringIO()
+    with hp.hyperparameter_optimization(
+        objective_key=objective_key, output=output
+    ) as hp_ctx:
+        args = ["hparams.yaml"] + (["--hpopt", "True"] if enabled else [])
+        hp_ctx.parse_arguments(args)
+
+    assert output.getvalue() == ""
+    assert hp.get_trial_id() == hp.DEFAULT_TRIAL_ID
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_hpopt_context_reports_zero(enabled):
+    import json
+    from io import StringIO
+
+    from speechbrain.utils import hpopt as hp
+
+    output = StringIO()
+    with hp.hyperparameter_optimization(
+        objective_key="error", output=output
+    ) as hp_ctx:
+        args = ["hparams.yaml"] + (["--hpopt", "True"] if enabled else [])
+        hp_ctx.parse_arguments(args)
+        hp.report_result({"error": 0.0})
+
+    assert json.loads(output.getvalue()) == {"error": 0.0, "objective": 0.0}
+    assert hp.get_trial_id() == hp.DEFAULT_TRIAL_ID


### PR DESCRIPTION
## What does this PR do?

Fixes #2358.

Exiting a hyperparameter-optimization context without calling `report_result()` reports the initial `{"objective": 0.0}` placeholder. This raises `KeyError` with a custom objective key, including evaluation-only runs, or emits a result that was never measured with the default key.

Initialize the pending result to `None`, which the existing exit guard already handles. Explicitly reported results, including zero, still go through the selected reporter or generic fallback.

Validation:
- New regression cases cover no result with custom/default objective keys and hpopt enabled/disabled. Before the fix: 4 failed, 5 passed (2 `KeyError`s and 2 unwanted zero reports).
- `pytest tests/unittests/test_hpopt.py --doctest-modules speechbrain/utils/hpopt.py -q`: 18 passed. This also checks explicit zero results, last-result selection and context cleanup using the real generic reporter.
- `pre-commit run -a` and `git diff --check` passed.

No model downloads or training runs were needed. The full suite and a live Oríon experiment were not run. No new dependencies or API changes.

Implemented and tested with OpenAI Codex, with independent read-only review by another Codex agent.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Read the contributor guideline.
- [x] This PR does one thing.
- [x] Documentation checked; the existing API/docstrings remain applicable.
- [x] Added necessary regression tests.
- [x] Verified new and related existing tests locally (scope above).
- [x] Listed breaking changes: none.
- [x] Followed project code style and conventions.

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review?
- [ ] Check that all items from **Before submitting** are resolved.
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR.
- [ ] Add labels and milestones (and optionally projects) to classify the PR.
- [ ] Confirm compatibility requirements.
- [ ] Review the self-review checklist.

</details>
