### PR TITLE
Fix time-domain convolution kernel orientation

### DIFF
--- a/speechbrain/processing/signal_processing.py
+++ b/speechbrain/processing/signal_processing.py
@@ -295,9 +295,10 @@ def convolve1d(
 
     # Use the implementation given by torch, which should be efficient on GPU
     else:
+        # conv1d performs cross-correlation, so reverse the kernel for convolution.
         convolved = torch.nn.functional.conv1d(
             input=waveform,
-            weight=kernel,
+            weight=kernel.flip(-1),
             stride=stride,
             groups=groups,
             padding=padding if not isinstance(padding, tuple) else 0,

--- a/tests/unittests/test_convolve1d.py
+++ b/tests/unittests/test_convolve1d.py
@@ -1,0 +1,86 @@
+import pytest
+import torch
+
+
+@pytest.mark.parametrize("padding", [0, 1, (2, 2), (2, 0), (0, 2)])
+@pytest.mark.parametrize("stride", [1, 2])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_convolve1d_time_domain(device, padding, stride, dtype):
+    import numpy as np
+
+    from speechbrain.processing.signal_processing import convolve1d
+
+    waveform = torch.tensor([1, 2, 3, 4], device=device, dtype=dtype)
+    kernel = torch.tensor([1, 2, 4], device=device, dtype=dtype)
+    pad_width = padding if isinstance(padding, tuple) else (padding, padding)
+    expected = np.convolve(
+        np.pad(waveform.cpu().numpy(), pad_width),
+        kernel.cpu().numpy(),
+        mode="valid",
+    )[::stride]
+
+    result = convolve1d(
+        waveform.view(1, -1, 1),
+        kernel.view(1, -1, 1),
+        padding=padding,
+        stride=stride,
+    )
+
+    assert result.dtype == dtype
+    np.testing.assert_allclose(result[0, :, 0].cpu().numpy(), expected)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_convolve1d_time_domain_matches_fft(device, dtype):
+    from speechbrain.processing.signal_processing import convolve1d
+
+    waveform = torch.tensor([1, 2, 3, 4], device=device, dtype=dtype).view(
+        1, -1, 1
+    )
+    kernel = torch.tensor([1, 2, 4], device=device, dtype=dtype).view(1, -1, 1)
+    time_result = convolve1d(waveform, kernel, padding=(2, 2))
+    fft_result = convolve1d(waveform, kernel, padding=(0, 2), use_fft=True)
+    expected = torch.tensor(
+        [1, 4, 11, 18, 20, 16], device=device, dtype=dtype
+    ).view(1, -1, 1)
+
+    torch.testing.assert_close(time_result, expected)
+    torch.testing.assert_close(time_result, fft_result)
+
+
+@pytest.mark.parametrize("stride", [1, 2])
+def test_convolve1d_grouped(device, stride):
+    import numpy as np
+
+    from speechbrain.processing.signal_processing import convolve1d
+
+    waveform = torch.arange(24, device=device, dtype=torch.float64).view(
+        2, 6, 2
+    )
+    kernel = torch.arange(1, 13, device=device, dtype=torch.float64).view(
+        4, 3, 1
+    )
+    result = convolve1d(waveform, kernel, groups=2, stride=stride)
+
+    for batch in range(2):
+        for channel in range(4):
+            expected = np.convolve(
+                waveform[batch, :, channel // 2].cpu().numpy(),
+                kernel[channel, :, 0].cpu().numpy(),
+                mode="valid",
+            )[::stride]
+            np.testing.assert_allclose(
+                result[batch, :, channel].cpu().numpy(), expected
+            )
+
+
+def test_convolve1d_gradients(device):
+    from speechbrain.processing.signal_processing import convolve1d
+
+    waveform = torch.randn(
+        1, 4, 1, device=device, dtype=torch.float64, requires_grad=True
+    )
+    kernel = torch.randn(
+        1, 3, 1, device=device, dtype=torch.float64, requires_grad=True
+    )
+    assert torch.autograd.gradcheck(convolve1d, (waveform, kernel))


### PR DESCRIPTION
## What does this PR do?

Fixes #1527.

`convolve1d(..., use_fft=False)` currently performs cross-correlation because it passes the kernel directly to PyTorch's `conv1d`. For a waveform `[1, 2, 3, 4]` and kernel `[1, 2, 4]`, it returns `[17, 24]` instead of the valid convolution `[11, 18]`. Reverse the kernel along its time axis before calling PyTorch.

This intentionally changes time-domain results for asymmetric kernels. `DropFreq` uses this path both to build and apply its filter; its existing frequency-rejection tests pass, and old/new waveform comparisons agree within floating-point tolerance (bitwise reproducibility is not promised). The FFT path, including the default `reverberate` implementation, is unchanged.

Validation on CPU with PyTorch 2.6.0:
- New tests compare against NumPy convolution across padding, stride, dtype, batch and grouped-channel cases, check FFT agreement with linear-convolution padding, and run autograd gradcheck. Before the fix: 24 failed, 1 passed.
- After the fix: the new tests, existing signal-processing and augmentation tests, and signal-processing doctests all pass: **46 passed**.
- `pre-commit run -a` and `git diff --check` pass. No model or dataset downloads were needed. The full repository test suite and GPU execution were not run.

Implemented and tested autonomously with OpenAI Codex, with a separate agent reviewing the code, callers, and compatibility checks.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Read the contributor guideline.
- [x] This PR does one thing.
- [x] Documentation checked; the existing convolution API description remains applicable.
- [x] Added necessary regression tests.
- [x] Verified new and related existing tests locally (scope above).
- [x] Listed behavior changes for asymmetric time-domain kernels above.
- [x] Followed project code style and conventions.

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review?
- [ ] Check that all items from **Before submitting** are resolved.
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR.
- [ ] Add labels and milestones (and optionally projects) to classify the PR.
- [ ] Confirm compatibility requirements.
- [ ] Review the self-review checklist.

</details>
