### PR TITLE
Keep optional modules lazy during IPython autoreload

### DIFF
--- a/speechbrain/utils/importutils.py
+++ b/speechbrain/utils/importutils.py
@@ -18,6 +18,9 @@ class LazyModule(ModuleType):
     """Defines a module type that lazily imports the target module, thus
     exposing contents without importing the target module needlessly.
 
+    The ``__file__`` attribute is available only after the target is loaded,
+    so inspecting its filename does not force an import.
+
     Arguments
     ---------
     name : str
@@ -109,6 +112,9 @@ class LazyModule(ModuleType):
         return f"LazyModule(package={self.package}, target={self.target}, loaded={self.lazy_module is not None})"
 
     def __getattr__(self, attr):
+        # Introspection (e.g. IPython autoreload) must not load optional modules.
+        if attr == "__file__" and self.lazy_module is None:
+            raise AttributeError(attr)
         # NOTE: exceptions here get eaten and not displayed
         return getattr(self.ensure_module(1), attr)
 

--- a/tests/unittests/test_importutils.py
+++ b/tests/unittests/test_importutils.py
@@ -1,0 +1,61 @@
+import sys
+
+import pytest
+
+
+@pytest.fixture(params=["absolute", "relative", "deprecated"])
+def lazy_module(request, tmp_path, monkeypatch):
+    from speechbrain.utils.importutils import (
+        DeprecatedModuleRedirect,
+        LazyModule,
+    )
+
+    package_name = "lazy_test_package"
+    package_dir = tmp_path / package_name
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text("", encoding="utf-8")
+    (package_dir / "target.py").write_text("value = 42\n", encoding="utf-8")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    target_name = f"{package_name}.target"
+
+    if request.param == "relative":
+        module = LazyModule("target", "target", package_name)
+    elif request.param == "deprecated":
+        module = DeprecatedModuleRedirect("old_target", target_name)
+    else:
+        module = LazyModule("target", target_name, None)
+
+    yield module, package_dir
+
+    sys.modules.pop(target_name, None)
+    sys.modules.pop(package_name, None)
+
+
+def test_lazy_module_file_inspection(lazy_module):
+    module, package_dir = lazy_module
+
+    assert not hasattr(module, "__file__")
+    assert "lazy_test_package.target" not in sys.modules
+
+    if module.__name__ == "old_target":
+        with pytest.warns(UserWarning, match="was deprecated"):
+            assert module.value == 42
+    else:
+        assert module.value == 42
+
+    assert module.__file__ == str(package_dir / "target.py")
+    assert module.lazy_module is sys.modules["lazy_test_package.target"]
+
+
+def test_lazy_module_file_inspection_without_optional_dependency(lazy_module):
+    module, package_dir = lazy_module
+    (package_dir / "target.py").write_text(
+        "import missing_optional_dependency_for_lazy_test\n", encoding="utf-8"
+    )
+
+    assert not hasattr(module, "__file__")
+    assert "lazy_test_package.target" not in sys.modules
+
+    with pytest.raises(ImportError, match="Lazy import") as exc:
+        _ = module.value
+    assert isinstance(exc.value.__cause__, ModuleNotFoundError)


### PR DESCRIPTION
## What does this PR do?

Fixes #2995.

With `%autoreload 2`, IPython inspects `__file__` on modules in `sys.modules`. For SpeechBrain's lazy redirects, this forces optional imports: `import speechbrain` produces a post-execution callback error when Flair is not installed.

Keep `__file__` absent until the lazy target has actually loaded. Ordinary attribute access still loads the target, after which its real filename is available. This applies to absolute/relative lazy imports and deprecated redirects without adding an IPython-specific caller check or a dependency.

This intentionally changes an explicit `__file__` lookup on an unloaded proxy to raise `AttributeError`; the class documentation now describes that behavior.

Validation on Python 3.11.15 / PyTorch 2.6.0 / IPython 9.17.1:

- Six new regression cases fail before the fix and pass afterward, covering available modules, missing optional dependencies, relative imports and deprecated redirects. New and related existing tests: **16 passed**, including the HyperPyYAML deprecated-import test.
- Reproduced the original error in a real IPython shell. After the fix, `%autoreload 2; import speechbrain` succeeds without loading NLP/Flair. Editing a temporary module updates both its lazy export and an already-referenced function through IPython autoreload.
- Baseline/current comparisons preserve inspect, importlib reload and exported-function pickle behavior. `pre-commit run -a`, changed-file hooks and `git diff --check` pass.

No models or datasets were downloaded. The full repository suite, GPU execution and pretrained inference were not run.

Implemented and tested autonomously with OpenAI Codex, with independent read-only review by another Codex agent.
