### PR TITLE
Clarify positional encoding length limit errors

### DIFF
--- a/speechbrain/lobes/models/transformer/Transformer.py
+++ b/speechbrain/lobes/models/transformer/Transformer.py
@@ -299,7 +299,16 @@ class PositionalEncoding(nn.Module):
         Returns
         -------
         The positional encoding.
+
+        Raises
+        ------
+        ValueError
+            If the input sequence is longer than ``max_len``.
         """
+        if x.size(1) > self.max_len:
+            raise ValueError(
+                f"Input sequence length {x.size(1)} exceeds the maximum positional encoding length {self.max_len}."
+            )
         return self.pe[:, : x.size(1)].clone().detach()
 
 

--- a/tests/unittests/test_positional_encoding.py
+++ b/tests/unittests/test_positional_encoding.py
@@ -1,0 +1,84 @@
+import pytest
+import torch
+
+
+@pytest.mark.parametrize("length", [0, 1, 3, 4])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_positional_encoding_within_limit(device, length, dtype):
+    from speechbrain.lobes.models.transformer.Transformer import (
+        PositionalEncoding,
+    )
+
+    encoding = PositionalEncoding(input_size=2, max_len=4).to(
+        device=device, dtype=dtype
+    )
+    inputs = torch.zeros(2, length, 2, device=device, dtype=dtype)
+
+    result = encoding(inputs)
+
+    positions = torch.arange(length, device=device, dtype=torch.float32)
+    expected = torch.stack((positions.sin(), positions.cos()), dim=-1)
+    torch.testing.assert_close(result, expected.unsqueeze(0).to(dtype))
+    assert not result.requires_grad
+
+
+@pytest.mark.parametrize("max_len", [4, 2500])
+def test_positional_encoding_exceeds_limit(device, max_len):
+    from speechbrain.lobes.models.transformer.Transformer import (
+        PositionalEncoding,
+    )
+
+    encoding = PositionalEncoding(input_size=2, max_len=max_len).to(device)
+    inputs = torch.zeros(1, max_len + 1, 2, device=device)
+
+    with pytest.raises(
+        ValueError,
+        match=rf"Input sequence length {max_len + 1} exceeds the maximum positional encoding length {max_len}",
+    ):
+        encoding(inputs)
+
+
+@pytest.mark.parametrize("path", ["encode", "source", "target"])
+def test_transformer_asr_exceeds_positional_encoding_limit(device, path):
+    from speechbrain.lobes.models.transformer.TransformerASR import (
+        TransformerASR,
+    )
+
+    model = (
+        TransformerASR(
+            tgt_vocab=8,
+            input_size=4,
+            d_model=4,
+            nhead=2,
+            num_encoder_layers=1,
+            num_decoder_layers=1,
+            d_ffn=8,
+            dropout=0,
+            max_length=4,
+            causal=False,
+        )
+        .to(device)
+        .eval()
+    )
+    source = torch.zeros(1, 4, 4, device=device)
+    target = torch.ones(1, 4, device=device, dtype=torch.long)
+
+    with torch.no_grad():
+        encoder_out, decoder_out = model(source, target)
+        assert encoder_out.shape == decoder_out.shape == (1, 4, 4)
+        assert torch.isfinite(encoder_out).all()
+        assert torch.isfinite(decoder_out).all()
+
+        if path == "target":
+            target = torch.ones(1, 5, device=device, dtype=torch.long)
+        else:
+            source = torch.zeros(1, 5, 4, device=device)
+
+        with pytest.raises(
+            ValueError,
+            match="Input sequence length 5 exceeds the maximum positional encoding length 4",
+        ):
+            if path == "encode":
+                model.encode(source)
+            else:
+                model(source, target)


### PR DESCRIPTION
## What does this PR do?

Related to #2071, specifically the requested diagnostic for inputs exceeding the positional encoding limit.

`PositionalEncoding` silently returns only `max_len` positions for a longer input. ASR callers then fail with a tensor-size mismatch that does not identify the configured limit. Raise `ValueError` in the shared module with both the input length and the maximum length, before returning an incomplete encoding.

The configured capacity and sinusoidal values stay unchanged. Inputs at the limit remain valid. This does not add support for transcribing arbitrarily long recordings.

Validation on CPU, Python 3.11.15 / PyTorch 2.6.0:

- New tests cover empty/short/exact-limit sequences, float32/float64 module conversion, custom/default limits, and real small `TransformerASR` encode/source/target paths. Before the fix: 5 failed, 8 passed. Afterward: 13 passed.
- New and related attention, conformer, streaming and mask tests, plus all Transformer doctests: **59 passed**.
- Separate baseline comparisons give identical normal ASR outputs, input gradients and checkpoint metadata. TorchScript retains valid-boundary behavior and reports the new error for over-limit inputs.
- Full-repository and changed-file pre-commit checks and `git diff --check` pass.

The tests use synthetic features and a locally initialized small model. No pretrained models, datasets, GPU execution or full repository test suite were used. Existing mask-type deprecation and attention-test overflow warnings remain.

Implemented and tested autonomously with OpenAI Codex, with independent read-only review by another Codex agent.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Read the contributor guideline.
- [x] This PR does one thing.
- [x] Documented the new exception.
- [x] Added necessary regression tests.
- [x] Ran the new and related existing tests listed above.
- [x] Described the intentional change for over-limit input.
- [x] Code style checks pass.

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Ready for review.
- [ ] Confirm the contributor checklist.
- [ ] Review the title and description.
- [ ] Add appropriate labels and milestones.
- [ ] Confirm compatibility requirements.
- [ ] Review the changes.

</details>
